### PR TITLE
Separate ansible lint workflows for some roles 

### DIFF
--- a/.github/workflows/ansible-lint sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_general_preconfigure.yml
@@ -3,10 +3,10 @@ name: Ansible Lint for sap_general_preconfigure
 on: 
   push: 
     paths: 
-      - './roles/sap_general_preconfigure/*'
+      - './roles/sap_general_preconfigure/**'
   pull_request:
     paths: 
-      - './roles/sap_general_preconfigure/*'
+      - './roles/sap_general_preconfigure/**'
 jobs:
   ansible-lint:
 

--- a/.github/workflows/ansible-lint sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_general_preconfigure.yml
@@ -3,10 +3,10 @@ name: Ansible Lint for sap_general_preconfigure
 on: 
   push: 
     paths: 
-      - './roles/sap_general_preconfigure/**'
+      - 'roles/sap_general_preconfigure/**'
   pull_request:
     paths: 
-      - './roles/sap_general_preconfigure/**'
+      - 'roles/sap_general_preconfigure/**'
 jobs:
   ansible-lint:
 

--- a/.github/workflows/ansible-lint sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_general_preconfigure.yml
@@ -3,10 +3,10 @@ name: Ansible Lint for sap_general_preconfigure
 on: 
   push: 
     paths: 
-      - './roles/sap_general_preconfigure'
+      - './roles/sap_general_preconfigure/*'
   pull_request:
     paths: 
-      - './roles/sap_general_preconfigure'
+      - './roles/sap_general_preconfigure/*'
 jobs:
   ansible-lint:
 

--- a/.github/workflows/ansible-lint sap_hana_install.yml
+++ b/.github/workflows/ansible-lint sap_hana_install.yml
@@ -1,12 +1,12 @@
-name: Ansible Lint for sap_netweaver_preconfigure
+name: Ansible Lint for sap_hana_install
 
 on: 
   push: 
     paths: 
-      - 'roles/sap_netweaver_preconfigure/**'
+      - 'roles/sap_hana_install/**'
   pull_request:
     paths: 
-      - 'roles/sap_netweaver_preconfigure/**'
+      - 'roles/sap_hana_install/**'
 jobs:
   ansible-lint:
 
@@ -19,7 +19,7 @@ jobs:
       uses: ansible/ansible-lint-action@master
       with:
         targets: |
-          ./roles/sap_netweaver_preconfigure
+          ./roles/sap_hana_install
         override-deps: |
           ansible-core==2.12.1
           ansible-lint==5.3.2

--- a/.github/workflows/ansible-lint sap_hana_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_hana_preconfigure.yml
@@ -1,12 +1,12 @@
-name: Ansible Lint for sap_netweaver_preconfigure
+name: Ansible Lint for sap_hana_preconfigure
 
 on: 
   push: 
     paths: 
-      - 'roles/sap_netweaver_preconfigure/**'
+      - 'roles/sap_hana_preconfigure/**'
   pull_request:
     paths: 
-      - 'roles/sap_netweaver_preconfigure/**'
+      - 'roles/sap_hana_preconfigure/**'
 jobs:
   ansible-lint:
 
@@ -19,7 +19,7 @@ jobs:
       uses: ansible/ansible-lint-action@master
       with:
         targets: |
-          ./roles/sap_netweaver_preconfigure
+          ./roles/sap_hana_preconfigure
         override-deps: |
           ansible-core==2.12.1
           ansible-lint==5.3.2

--- a/.github/workflows/ansible-lint sap_netweaver_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_netweaver_preconfigure.yml
@@ -1,0 +1,27 @@
+name: Ansible Lint for sap_netweaver_preconfigure
+
+on: 
+  push: 
+    paths: 
+      - './roles/sap_netweaver_preconfigure'
+  pull_request:
+    paths: 
+      - './roles/sap_netweaver_preconfigure'
+jobs:
+  ansible-lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: |
+          ./roles/sap_netweaver_preconfigure
+        override-deps: |
+          ansible-core==2.12.1
+          ansible-lint==5.3.2
+
+# Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -15,14 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with: 
-          path: ~/ansible_collections/community/sap_install
-      
-      - name: Install necessary python requirements
-        working-directory: ~/ansible_collections/community/sap_install
-        run: pip install -r requirements-dev.txt
-        
-      - name: Execute ansible-test sanity checks
-        working-directory: ~/ansible_collections/community/sap_install
-        run: ansible-test sanity
+      - name: Perform sanity testing with ansible-test
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: stable-2.11
+          testing-type: sanity

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -1,0 +1,27 @@
+# Worflow for ansible-test sanity tests
+
+name: ansible-test sanity
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          path: ~/ansible_collections/community/sap_install
+      
+      - name: Install necessary python requirements
+        run: pip install -r requirements-dev.txt
+        
+      - name: Execute ansible-test sanity checks
+        working-directory: ~/ansible_collections/community/sap_install
+        run: ansible-test sanity

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -20,6 +20,7 @@ jobs:
           path: ~/ansible_collections/community/sap_install
       
       - name: Install necessary python requirements
+        working-directory: ~/ansible_collections/community/sap_install
         run: pip install -r requirements-dev.txt
         
       - name: Execute ansible-test sanity checks

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Within this Ansible Collection, there are various Ansible Roles and no custom An
 | [sap_hostagent](/roles/sap_hostagent) | install SAP Host Agent |
 | [sap_storage](/roles/sap_storage) | configure storage for SAP HANA, with LVM partitions and XFS filesystem |
 
+#### Ansible Roles Lint Status
+| Role Name  | Ansible Lint Status|
+| :-- | :-- |
+| [sap_general_preconfigure](/roles/sap_general_preconfigure) | [![Ansible Lint for sap_general_preconfigure](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_general_preconfigure.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_general_preconfigure.yml) |
+
+| [sap_netweaver_preconfigure](/roles/sap_netweaver_preconfigure) | [![Ansible Lint for sap_netweaver_preconfigure](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_netweaver_preconfigure.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_netweaver_preconfigure.yml) |
+
+| [sap_hana_preconfigure](/roles/sap_hana_preconfigure) | [![Ansible Lint for sap_hana_preconfigure](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_preconfigure.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_preconfigure.yml) |
+
+| [sap_hana_install](/roles/sap_hana_install) | [![Ansible Lint for sap_hana_install](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_install.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_install.yml) |
+
+
 ***Notes:***
 - Ansible Playbook localhost executions may have limitations on SAP Software installations
 - Ansible Roles for HA/DR are all designed for execution with Terraform

--- a/README.md
+++ b/README.md
@@ -69,11 +69,8 @@ Within this Ansible Collection, there are various Ansible Roles and no custom An
 | Role Name  | Ansible Lint Status|
 | :-- | :-- |
 | [sap_general_preconfigure](/roles/sap_general_preconfigure) | [![Ansible Lint for sap_general_preconfigure](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_general_preconfigure.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_general_preconfigure.yml) |
-
 | [sap_netweaver_preconfigure](/roles/sap_netweaver_preconfigure) | [![Ansible Lint for sap_netweaver_preconfigure](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_netweaver_preconfigure.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_netweaver_preconfigure.yml) |
-
 | [sap_hana_preconfigure](/roles/sap_hana_preconfigure) | [![Ansible Lint for sap_hana_preconfigure](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_preconfigure.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_preconfigure.yml) |
-
 | [sap_hana_install](/roles/sap_hana_install) | [![Ansible Lint for sap_hana_install](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_install.yml/badge.svg)](https://github.com/kksat/community.sap_install/actions/workflows/ansible-lint%20sap_hana_install.yml) |
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+ansible-test

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -1,4 +1,4 @@
-sap_general_preconfigure
+sap_general_preconfigure - test
 ================
 
 This role installs required packages and performs configuration steps which are required for installing and running SAP NetWeaver or SAP HANA. Specific installation and configuration steps on top of these basic steps are performed with roles sap-netweaver-preconfigure and sap-hana-preconfigure. Future implementations may reduce the scope of this role, for example if certain installation or configuration steps are done in the more specific roles.

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -1,4 +1,4 @@
-sap_general_preconfigure - test
+sap_general_preconfigure
 ================
 
 This role installs required packages and performs configuration steps which are required for installing and running SAP NetWeaver or SAP HANA. Specific installation and configuration steps on top of these basic steps are performed with roles sap-netweaver-preconfigure and sap-hana-preconfigure. Future implementations may reduce the scope of this role, for example if certain installation or configuration steps are done in the more specific roles.

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -1,4 +1,4 @@
-sap_general_preconfigure
+sap_general_preconfigure 
 ================
 
 This role installs required packages and performs configuration steps which are required for installing and running SAP NetWeaver or SAP HANA. Specific installation and configuration steps on top of these basic steps are performed with roles sap-netweaver-preconfigure and sap-hana-preconfigure. Future implementations may reduce the scope of this role, for example if certain installation or configuration steps are done in the more specific roles.

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -1,4 +1,4 @@
-sap_general_preconfigure 
+sap_general_preconfigure
 ================
 
 This role installs required packages and performs configuration steps which are required for installing and running SAP NetWeaver or SAP HANA. Specific installation and configuration steps on top of these basic steps are performed with roles sap-netweaver-preconfigure and sap-hana-preconfigure. Future implementations may reduce the scope of this role, for example if certain installation or configuration steps are done in the more specific roles.


### PR DESCRIPTION
Currently there is only one ansible lint workflow for some roles. With this changes several separate workflows are introduced to have one workflow for one role. 

Table with workflow status is added to README.md. Move it as you like, if not correct place. 