### PR TITLE
sap_hana_install: Solve issues #29, #32, #33, #36, #37, #39, and #40

### DIFF
--- a/.github/workflows/ansible-lint sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_general_preconfigure.yml
@@ -21,7 +21,7 @@ jobs:
         targets: |
           ./roles/sap_general_preconfigure
         override-deps: |
-          ansible-core==2.12.1
+          ansible==5.3.0
           ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint sap_hana_install.yml
+++ b/.github/workflows/ansible-lint sap_hana_install.yml
@@ -20,8 +20,8 @@ jobs:
       with:
         targets: |
           ./roles/sap_hana_install
-#        override-deps: |
-#          ansible-core==2.12.1
-#          ansible-lint==5.3.2
+        override-deps: |
+          ansible==5.3.0
+          ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint sap_hana_install.yml
+++ b/.github/workflows/ansible-lint sap_hana_install.yml
@@ -21,7 +21,7 @@ jobs:
         targets: |
           ./roles/sap_hana_install
         override-deps: |
-          ansible-core==2.12.2
+          ansible-core==2.12.1
           ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint sap_hana_install.yml
+++ b/.github/workflows/ansible-lint sap_hana_install.yml
@@ -20,8 +20,8 @@ jobs:
       with:
         targets: |
           ./roles/sap_hana_install
-        override-deps: |
-          ansible-core==2.12.1
-          ansible-lint==5.3.2
+#        override-deps: |
+#          ansible-core==2.12.1
+#          ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint sap_hana_install.yml
+++ b/.github/workflows/ansible-lint sap_hana_install.yml
@@ -21,7 +21,7 @@ jobs:
         targets: |
           ./roles/sap_hana_install
         override-deps: |
-          ansible-core==2.12.1
+          ansible-core==2.12.2
           ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint sap_hana_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_hana_preconfigure.yml
@@ -21,7 +21,7 @@ jobs:
         targets: |
           ./roles/sap_hana_preconfigure
         override-deps: |
-          ansible-core==2.12.1
+          ansible==5.3.0
           ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint sap_netweaver_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_netweaver_preconfigure.yml
@@ -21,7 +21,7 @@ jobs:
         targets: |
           ./roles/sap_netweaver_preconfigure
         override-deps: |
-          ansible-core==2.12.1
+          ansible==5.3.0
           ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -19,7 +19,7 @@ jobs:
           ./roles/sap_hana_preconfigure
           ./roles/sap_hana_install
         override-deps: |
-          ansible-core==2.12.1
+          ansible==5.3.0
           ansible-lint==5.3.2
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -46,6 +46,19 @@ If more than one SAPCAR EXE file is present in the software directory, the role 
 for the current hardware architecture. Alternatively, the file name of the SAPCAR EXE file can also be set with
 variable `sap_hana_install_sapcar_filename`.
 
+If more than one SAR file for a certain software product is present in the software directory, the automatic
+handling of such SAR files will fail after extraction, when moving the newly created product directories
+(like `SAP_HOST_AGENT`) to already existing destinations.
+For avoiding such situations, use following variable to provide a list of SAR files to extract:
+`sap_hana_install_sarfiles_list`.
+
+Example:
+```
+sap_hana_install_sarfiles_list:
+  - SAPHOSTAGENT54_54-80004822.SAR
+  - IMDB_SERVER20_060_0-80002031.SAR
+```
+
 #### Extracted SAP HANA Software Installation Files
 
 This role will detect if there is a file `hdblcm` already present in the directory specified by variable

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -41,6 +41,11 @@ Place the following files in directory /software/hana or in any other directory 
     -rwxr-xr-x. 1 nobody nobody 3694683699 Mar  4  2021 IMDB_SERVER20_054_0-80002031.SAR
     -rwxr-xr-x. 1 nobody nobody   89285401 Sep 30 04:24 SAPHOSTAGENT51_51-20009394.SAR
     ```
+
+If more than one SAPCAR EXE file is present in the software directory, the role will select the latest version
+for the current hardware architecture. Alternatively, the file name of the SAPCAR EXE file can also be set with
+variable `sap_hana_install_sapcar_filename`.
+
 #### Extracted SAP HANA Software Installation Files
 
 This role will detect if there is a file `hdblcm` already present in the directory specified by variable

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -6,7 +6,7 @@
 # Directory containing the IMDB SAR files and all components
 sap_hana_install_software_directory: '/software/hana'
 
-# If the following variable is set to `no`, the role will install SAP HANA even if there is already a sidadm user.
+# If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.
 sap_hana_install_check_sidadm_user: yes
 

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -6,6 +6,13 @@
 # Directory containing the IMDB SAR files and all components
 sap_hana_install_software_directory: '/software/hana'
 
+# Directory into which the SAR files will be extracted. Defaults is {{ sap_hana_install_software_directory }}/extracted .
+# Note: This directory will be removed and created again before the extraction starts.
+sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
+
+# File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
+#sap_hana_install_sapcar_filename: SAPCAR_1234-12345678.EXE
+
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.
 sap_hana_install_check_sidadm_user: yes

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -16,8 +16,8 @@ sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_direc
 # List of file names of SAR files to extract. Can be set in case there are more SAR files in the software directory
 # than needed or desired for the HANA installation
 #sap_hana_install_sarfiles_list:
-#- SAPHOSTAGENT54_54-80004822.SAR
-#- IMDB_SERVER20_060_0-80002031.SAR
+#  - SAPHOSTAGENT54_54-80004822.SAR
+#  - IMDB_SERVER20_060_0-80002031.SAR
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -13,6 +13,12 @@ sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_direc
 # File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
 #sap_hana_install_sapcar_filename: SAPCAR_1234-12345678.EXE
 
+# List of file names of SAR files to extract. Can be set in case there are more SAR files in the software directory
+# than needed or desired for the HANA installation
+#sap_hana_install_sarfiles_list:
+#- SAPHOSTAGENT54_54-80004822.SAR
+#- IMDB_SERVER20_060_0-80002031.SAR
+
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.
 sap_hana_install_check_sidadm_user: yes

--- a/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
+++ b/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: SAP HANA Add Hosts - Check for SAP HANA instance profile for {{ line_item }}
+- name: SAP HANA Add Hosts - Check for SAP HANA instance profile for '{{ line_item }}'
   stat:
     path: "/hana/shared/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}_{{ line_item }}"
   register: __sap_hana_install_register_instance_profile_addhost
@@ -19,16 +19,16 @@
       - "Because of this, the addhost operation will not be performed."
     success_msg: "PASS: No instance profile was found for host {{ line_item }}."
 
-- name: SAP HANA Add Hosts - Check for SAP HANA instance directory in /usr/sap
+- name: SAP HANA Add Hosts - Check for SAP HANA instance directory in '/usr/sap'
   stat:
     path: "/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_instance_number }}/{{ line_item }}"
   register: __sap_hana_install_register_usr_sap_instance_directory
 
-- name: SAP HANA Add Hosts - Show the path name of the instance directory in /usr/sap
+- name: SAP HANA Add Hosts - Show the path name of the instance directory in '/usr/sap'
   debug:
     msg: "Instance directory in /usr/sap: /usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_instance_number }}/{{ line_item }}"
 
-- name: SAP HANA Add Hosts - Assert that there is no SAP HANA instance directory in /usr/sap for the addional hosts
+- name: SAP HANA Add Hosts - Assert that there is no SAP HANA instance directory in '/usr/sap' for the addional hosts
   assert:
     that: not __sap_hana_install_register_usr_sap_instance_directory.stat.exists
     fail_msg:

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -11,7 +11,7 @@
 
 - name: SAP HANA Add Hosts - Show the additional hosts to be added
   debug:
-    msg: "Additional hosts: __sap_hana_install_addhosts_hosts"
+    msg: "Additional hosts: {{ __sap_hana_install_addhosts_hosts }}"
 
 - name: SAP HANA Add Hosts - Make sure the additional hosts are not yet part of the exiting SAP HANA system - file checks
   include_tasks: assert-addhosts-loop-block.yml
@@ -40,9 +40,9 @@
       assert:
         that: "'{{ line_item }}' not in __sap_hana_install_register_hdblcm_list_systems.stdout"
         fail_msg:
-          - "FAIL: Host {{ line_item }} is already part of system {{ sap_hana_install_sid }}"
+          - "FAIL: Host {{ line_item }} is already part of system '{{ sap_hana_install_sid }}'"
           - "Because of this, the addhost operation will not be performed."
-        success_msg: "PASS: Host {{ line_item }} is not yet part of system {{ sap_hana_install_sid }}."
+        success_msg: "PASS: Host '{{ line_item }}' is not yet part of system '{{ sap_hana_install_sid }}'."
       loop: "{{ __sap_hana_install_addhosts_hosts }}"
       loop_control:
         loop_var: line_item

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -5,6 +5,7 @@
     - name: Check for sidadm user
       command: getent passwd {{ sap_hana_install_sid | lower }}adm
       register: __sap_hana_install_register_getent_passwd_sidadm
+      changed_when: no
       failed_when: no
 
 # Reason for noqa: The variable is a substring of a user name
@@ -16,6 +17,31 @@
         success_msg: "PASS: User {{ sap_hana_install_sid | lower}}adm does not exist."
 
   when: sap_hana_install_check_sidadm_user|d(true)
+
+# The role supports specifying the SAP HANA group id in variable `sap_hana_install_groupid`, which is the id of the sapsys group.
+# The SAP HANA installation will fail if there is already a group named sapsys but with a different ID. Let's better fail before.
+- name: HANA admin group check
+  block:
+    - name: Get info about the ID of the sapsys group
+      command: getent group sapsys
+      register: __sap_hana_install_register_getent_group_sapsys
+      changed_when: no
+      failed_when: no
+
+    - name: In case there is a group sapsys, assert that its group ID is identical to sap_hana_install_groupid
+      assert:
+        that: "{{ __sap_hana_install_register_getent_group_sapsys.stdout.split(':')[2] }} == {{ sap_hana_install_groupid }}"
+        fail_msg: "FAIL: Group sapsys exists but with a different group ID than {{ sap_hana_install_groupid }},
+	           which has been specified in variable sap_hana_install_groupid.
+	           Because of this, SAP HANA with SID {{ sap_hana_install_sid }} will not be installed."
+        success_msg: "PASS: The group is of sapsys is identical to the value of variable
+                      sap_hana_install_groupid, which is {{ sap_hana_install_groupid }}"
+      when: __sap_hana_install_register_getent_group_sapsys.rc == 0
+
+  when:
+    - sap_hana_install_groupid is defined
+    - sap_hana_install_groupid | string != "None"
+    - sap_hana_install_groupid | string | length > 0
 
 - name: "Get info about directory /hana/shared/{{ sap_hana_install_sid }}"
   stat:

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -20,7 +20,7 @@
 
 # The role supports specifying the SAP HANA group id in variable `sap_hana_install_groupid`, which is the id of the sapsys group.
 # The SAP HANA installation will fail if there is already a group named sapsys but with a different ID. Let's better fail before.
-- name: HANA admin group check
+- name: Check HANA admin group
   block:
     - name: Get info about the ID of the sapsys group
       command: getent group sapsys
@@ -31,11 +31,11 @@
     - name: In case there is a group sapsys, assert that its group ID is identical to sap_hana_install_groupid
       assert:
         that: "{{ __sap_hana_install_register_getent_group_sapsys.stdout.split(':')[2] }} == {{ sap_hana_install_groupid }}"
-        fail_msg: "FAIL: Group sapsys exists but with a different group ID than {{ sap_hana_install_groupid }},
+        fail_msg: "FAIL: Group sapsys exists but with a different group ID than '{{ sap_hana_install_groupid }}',
 	           which has been specified in variable sap_hana_install_groupid.
-	           Because of this, SAP HANA with SID {{ sap_hana_install_sid }} will not be installed."
+	           Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
         success_msg: "PASS: The group is of sapsys is identical to the value of variable
-                      sap_hana_install_groupid, which is {{ sap_hana_install_groupid }}"
+                      sap_hana_install_groupid, which is '{{ sap_hana_install_groupid }}'"
       when: __sap_hana_install_register_getent_group_sapsys.rc == 0
 
   when:
@@ -43,31 +43,31 @@
     - sap_hana_install_groupid | string != "None"
     - sap_hana_install_groupid | string | length > 0
 
-- name: "Get info about directory /hana/shared/{{ sap_hana_install_sid }}"
+- name: "Get info about directory '/hana/shared/{{ sap_hana_install_sid }}'"
   stat:
     path: "/hana/shared/{{ sap_hana_install_sid }}"
   register: __sap_hana_install_register_stat_hana_shared_sid_assert
   failed_when: no
 
-- name: "Assert that directory /hana/shared/{{ sap_hana_install_sid }} does not exist"
+- name: "Assert that directory '/hana/shared/{{ sap_hana_install_sid }}' does not exist"
   assert:
     that: not __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
-    fail_msg: "FAIL: Directory /hana/shared/{{ sap_hana_install_sid }} exists.
-               Because of this, SAP HANA with SID {{ sap_hana_install_sid }} will not be installed."
-    success_msg: "PASS: Directory /hana/shared/{{ sap_hana_install_sid }} does not exist."
+    fail_msg: "FAIL: Directory '/hana/shared/{{ sap_hana_install_sid }}' exists.
+               Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
+    success_msg: "PASS: Directory '/hana/shared/{{ sap_hana_install_sid }}' does not exist."
 
-- name: "Get info about directory /usr/sap/{{ sap_hana_install_sid }}"
+- name: "Get info about directory '/usr/sap/{{ sap_hana_install_sid }}'"
   stat:
     path: "/usr/sap/{{ sap_hana_install_sid }}"
   register: __sap_hana_install_register_stat_usr_sap_sid_assert
   failed_when: no
 
-- name: "Assert that directory /usr/sap/{{ sap_hana_install_sid }} does not exist"
+- name: "Assert that directory '/usr/sap/{{ sap_hana_install_sid }}' does not exist"
   assert:
     that: not __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
-    fail_msg: "FAIL: Directory /usr/sap/{{ sap_hana_install_sid }} exists.
-               Because of this, SAP HANA with SID {{ sap_hana_install_sid }} will not be installed."
-    success_msg: "PASS: Directory /usr/sap/{{ sap_hana_install_sid }} does not exist."
+    fail_msg: "FAIL: Directory '/usr/sap/{{ sap_hana_install_sid }}' exists.
+               Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
+    success_msg: "PASS: Directory '/usr/sap/{{ sap_hana_install_sid }}' does not exist."
 
 #    - name: Check if there is already a SAP HANA system with SID {{ sap_hana_install_sid }} and instance {{ sap_hana_install_instance_number }}
 #      command: sapcontrol -nr {{ sap_hana_install_instance_number }} -function GetProcessList

--- a/roles/sap_hana_install/tasks/hana_install.yml
+++ b/roles/sap_hana_install/tasks/hana_install.yml
@@ -20,10 +20,18 @@
       - 'Alternatively, you can run the following command on the control node:'
       - "ssh {{ inventory_hostname }} {{ __sap_hana_install_register_tmpdir.path }}/tail-f-hdblcm-install-trc.sh"
 
+- name: Set fact for hdblcm command line
+  set_fact:
+    __sap_hana_install_hdblcm_command_line: "./hdblcm {{ sap_hana_install_hdblcm_extraargs }}
+      --configfile={{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg
+      -b"
+
+- name: Show the hdblcm command line
+  debug:
+    msg: "SAP HANA install command: '{{ __sap_hana_install_hdblcm_command_line }}'"
+
 - name: Installing SAP HANA - {{ sap_hana_install_sid }} {{ sap_hana_install_instance_number }}
-  command: "./hdblcm {{ sap_hana_install_hdblcm_extraargs }}
-            --configfile={{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg
-            -b"
+  command: "{{ __sap_hana_install_hdblcm_command_line }}"
   register: __sap_hana_install_register_hdblcm_install
   args:
     chdir: "{{ __sap_hana_install_fact_hdblcm_path }}"

--- a/roles/sap_hana_install/tasks/hana_install.yml
+++ b/roles/sap_hana_install/tasks/hana_install.yml
@@ -26,5 +26,5 @@
             -b"
   register: __sap_hana_install_register_hdblcm_install
   args:
-    chdir: "{{ sap_hana_hdblcm_path }}"
+    chdir: "{{ __sap_hana_install_fact_hdblcm_path }}"
   changed_when: "'SAP HANA Lifecycle Management' in __sap_hana_install_register_hdblcm_install.stdout"

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -13,7 +13,7 @@
       include_tasks: post_install/license.yml
       when: sap_hana_install_apply_license
 
-    - name: SAP HANA Post Install - Set {{ sap_hana_install_sid | lower }}adm to no expire
+    - name: SAP HANA Post Install - Set '{{ sap_hana_install_sid | lower }}adm' to no expire
       shell: |
           chage -m 0 -M 99999 -I -1 -E -1 {{ sap_hana_install_sid | lower }}adm
       args:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -48,7 +48,7 @@
 
 ################
 
-- name: SAP HANA Install - Run hdblcm --list_systems after the installation
+- name: SAP HANA Install - Run 'hdblcm --list_systems' after the installation
   shell: |
       set -o pipefail && ./hdblcm --list_systems | awk '/\/hana\/shared\/{{ sap_hana_install_sid }}/{a=1}
       /version:/{if (a==1){

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -84,10 +84,6 @@
           set_fact:
             __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0].path }}"
 
-        - name: SAP HANA Pre Install - Show the full path name of file 'hdblcm' if found initially
-          debug:
-            msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
-
         - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' if found initially
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
@@ -97,7 +93,7 @@
         - name: SAP HANA Pre Install - Assert that file 'hdblcm' is available if found initially
           assert:
             that: __sap_hana_install_register_stat_hdblcm_initial.stat.exists
-            fail_msg: "FAIL: File 'hdblcm' could not be found. Installation of SAP HANA is not possible."
+            fail_msg: "FAIL: File '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' could not be found. Installation of SAP HANA is not possible."
             success_msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
 
       when:

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -21,18 +21,19 @@
 - name: Prepare the HANA software for installation
   block:
 
-    - name: SAP HANA Pre Install - Check availability of software path - {{ sap_hana_install_software_directory }}
+    - name: SAP HANA Pre Install - Check availability of software directory '{{ sap_hana_install_software_directory }}'
       stat:
         path: "{{ sap_hana_install_software_directory }}"
       register: __sap_hana_install_register_stat_software_directory
+      failed_when: no
 
     - name: SAP HANA Pre Install - Assert that the software directory exists
       assert:
         that: __sap_hana_install_register_stat_software_directory.stat.exists
-        fail_msg: "FAIL: The software path {{ sap_hana_install_software_directory }} does not exist!"
-        success_msg: "PASS: The software path {{ sap_hana_install_software_directory }} exist."
+        fail_msg: "FAIL: The software directory '{{ sap_hana_install_software_directory }}' does not exist!"
+        success_msg: "PASS: The software directory '{{ sap_hana_install_software_directory }}' exist."
 
-    - name: SAP HANA Pre Install - Change ownership of software path - {{ sap_hana_install_software_directory }}
+    - name: SAP HANA Pre Install - Change ownership of software directory '{{ sap_hana_install_software_directory }}'
       ansible.builtin.file:
         path: "{{ sap_hana_install_software_directory }}"
         state: directory
@@ -49,51 +50,64 @@
         owner: root
         group: root
       loop:
-        - "/hana"
-        - "/hana/shared"
-        - "/hana/log"
-        - "/hana/data"
+        - '/hana'
+        - '/hana/shared'
+        - '/hana/log'
+        - '/hana/data'
 
-    - name: SAP HANA Pre Install - Find file 'hdblcm'
+    - name: SAP HANA Pre Install - Get info about software extract directory '{{ sap_hana_install_software_extract_directory }}'
+      stat:
+        path: "{{ sap_hana_install_software_extract_directory }}"
+      register: __sap_hana_install_register_stat_software_extract_directory
+      failed_when: no
+
+    - name: SAP HANA Pre Install - Find file 'hdblcm' if '{{ sap_hana_install_software_extract_directory }}' exists
       find:
-        paths: "{{ sap_hana_install_software_directory }}"
+        paths: "{{ sap_hana_install_software_extract_directory }}"
         recurse: yes
         file_type: file
         patterns: 'hdblcm'
       register: __sap_hana_install_register_find_hdblcm
+      when: __sap_hana_install_register_stat_software_extract_directory.stat.exists
 
-    - name: Set path of 'hdblcm' from find result
+    - name: SAP HANA Pre Install - Set path of 'hdblcm' from successful find result
       block:
 
-        - name: Show the full path name of file 'hdblcm'
-          debug:
-            var: __sap_hana_install_register_find_hdblcm.files[0].path
-
-        - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer path from find result
+        - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer directory if found initially
           set_fact:
-            sap_hana_hdblcm_path:
-              "{{ __sap_hana_install_register_find_hdblcm.files[0].path | dirname }}"
+            __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_hdblcm.files[0].path | dirname }}"
 
-      when: __sap_hana_install_register_find_hdblcm.files[0] is defined
+        - name: SAP HANA Pre Install - Show the full path name of file 'hdblcm'
+          debug:
+            msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
 
-    - name: Extract files if file 'hdblcm' was not found initially
+      when:
+        - __sap_hana_install_register_stat_software_extract_directory.stat.exists
+        - __sap_hana_install_register_find_hdblcm.files[0] is defined
+
+    - name: SAP HANA Pre Install - Extract SAR files if file 'hdblcm' was not found initially
       block:
 
         - name: SAP HANA Pre Install - Run hdblcm prepare
           include_tasks: pre_install/hdblcm_prepare.yml
 
-        - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer path
-          set_fact:
-            sap_hana_hdblcm_path:
-              "{{ __sap_hana_install_register_find_directory_sap_hana_database.files[0].path }}"
+        - name: SAP HANA Pre Install - Display 'hdblcm' installer directory
+          debug:
+            var: __sap_hana_install_fact_hdblcm_path
 
-        - name: SAP HANA Pre Install - Check availability of "{{ sap_hana_hdblcm_path + '/hdblcm' }}"
+        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}'
           stat:
-            path: "{{ sap_hana_hdblcm_path + '/hdblcm' }}"
-          register: __sap_hana_install_register_hdblcm_stat
-          failed_when: not __sap_hana_install_register_hdblcm_stat.stat.exists
+            path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
+          register: __sap_hana_install_register_stat_hdblcm
+          failed_when: no
 
-      when: sap_hana_hdblcm_path is not defined
+        - name: SAP HANA Pre Install - Assert that file 'hdblcm' is available
+          assert:
+            that: __sap_hana_install_register_stat_hdblcm.stat.exists
+            fail_msg: "FAIL: File 'hdblcm' could not be found. Installation of SAP HANA is not possible."
+            success_msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
+
+      when: __sap_hana_install_register_find_hdblcm.files[0] is not defined
 
   when: sap_hana_install_new_system|d(true)
 
@@ -111,5 +125,5 @@
   template:
     src: "{{ role_path }}/templates/configfile.j2"
     dest: "{{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg"
-    mode: 0644
+    mode: '0644'
   register: __sap_hana_install_register_cftemplate

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -61,6 +61,13 @@
       register: __sap_hana_install_register_stat_software_extract_directory
       failed_when: no
 
+# In case more than on installation is ongoing extracting to the same shared directory, wait until the extraction has completed:
+    - name: SAP HANA Pre Install - Proceed if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' is absent
+      wait_for:
+        path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
+        state: absent
+      failed_when: no
+
     - name: SAP HANA Pre Install - Find file 'hdblcm' if '{{ sap_hana_install_software_extract_directory }}' exists
       find:
         paths: "{{ sap_hana_install_software_extract_directory }}"
@@ -127,3 +134,7 @@
     dest: "{{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg"
     mode: '0644'
   register: __sap_hana_install_register_cftemplate
+
+- name: SAP HANA Pre Install - Show location of HANA configfile
+  debug:
+    msg: "HANA configfile is: '{{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg'"

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -72,7 +72,7 @@
         - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer path from find result
           set_fact:
             sap_hana_hdblcm_path:
-              "{{ __sap_hana_install_register_find_hdblcm.files[0].path | regex_replace('/hdblcm$', '') }}"
+              "{{ __sap_hana_install_register_find_hdblcm.files[0].path | dirname }}"
 
       when: __sap_hana_install_register_find_hdblcm.files[0] is defined
 

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -54,36 +54,46 @@
         - "/hana/log"
         - "/hana/data"
 
-    - name: SAP HANA Pre Install - Initial search for directory SAP_HANA_DATABASE
+    - name: SAP HANA Pre Install - Find file 'hdblcm'
       find:
         paths: "{{ sap_hana_install_software_directory }}"
         recurse: yes
-        file_type: directory
-        contains: "SAP_HANA_DATABASE"
-      register: __sap_hana_install_register_find_directory_sap_hana_database
+        file_type: file
+        patterns: 'hdblcm'
+      register: __sap_hana_install_register_find_hdblcm
 
-    - name: SAP HANA Pre Install - Initial check for existence of "/SAP_HANA_DATABASE/hdblcm"
-      stat:
-        path: "{{ __sap_hana_install_register_find_directory_sap_hana_database.files[0].path +
-               '/SAP_HANA_DATABASE/hdblcm' }}"
-      register: __sap_hana_install_register_stat_hdblcm_initial
-      when: __sap_hana_install_register_find_directory_sap_hana_database.files[0].path is defined
+    - name: Set path of 'hdblcm' from find result
+      block:
 
-    - name: SAP HANA Pre Install - Run hdblcm prepare
-      include_tasks: pre_install/hdblcm_prepare.yml
-      when: (not __sap_hana_install_register_find_directory_sap_hana_database.files[0].path is defined) or
-            (not __sap_hana_install_register_stat_hdblcm_initial.stat.exists)
+        - name: Show the full path name of file 'hdblcm'
+          debug:
+            var: __sap_hana_install_register_find_hdblcm.files[0].path
 
-    - name: SAP HANA Pre Install - Set fact for hdblcm installer path
-      set_fact:
-        sap_hana_hdblcm_path:
-          "{{ __sap_hana_install_register_find_directory_sap_hana_database.files[0].path }}/SAP_HANA_DATABASE"
+        - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer path from find result
+          set_fact:
+            sap_hana_hdblcm_path:
+              "{{ __sap_hana_install_register_find_hdblcm.files[0].path | regex_replace('/hdblcm$', '') }}"
 
-    - name: SAP HANA Pre Install - Check availability of "{{ sap_hana_hdblcm_path + '/hdblcm' }}"
-      stat:
-        path: "{{ sap_hana_hdblcm_path + '/hdblcm' }}"
-      register: __sap_hana_install_register_hdblcm_stat
-      failed_when: not __sap_hana_install_register_hdblcm_stat.stat.exists
+      when: __sap_hana_install_register_find_hdblcm.files[0] is defined
+
+    - name: Extract files if file 'hdblcm' was not found initially
+      block:
+
+        - name: SAP HANA Pre Install - Run hdblcm prepare
+          include_tasks: pre_install/hdblcm_prepare.yml
+
+        - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer path
+          set_fact:
+            sap_hana_hdblcm_path:
+              "{{ __sap_hana_install_register_find_directory_sap_hana_database.files[0].path }}"
+
+        - name: SAP HANA Pre Install - Check availability of "{{ sap_hana_hdblcm_path + '/hdblcm' }}"
+          stat:
+            path: "{{ sap_hana_hdblcm_path + '/hdblcm' }}"
+          register: __sap_hana_install_register_hdblcm_stat
+          failed_when: not __sap_hana_install_register_hdblcm_stat.stat.exists
+
+      when: sap_hana_hdblcm_path is not defined
 
   when: sap_hana_install_new_system|d(true)
 

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -61,36 +61,48 @@
       register: __sap_hana_install_register_stat_software_extract_directory
       failed_when: no
 
-# In case more than on installation is ongoing extracting to the same shared directory, wait until the extraction has completed:
+# In case more than on installation is ongoing and extracting to the same shared directory, wait until the extraction has completed:
     - name: SAP HANA Pre Install - Proceed if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' is absent
       wait_for:
         path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
         state: absent
       failed_when: no
 
-    - name: SAP HANA Pre Install - Find file 'hdblcm' if '{{ sap_hana_install_software_extract_directory }}' exists
+    - name: SAP HANA Pre Install - Find directory 'SAP_HANA_DATABASE' if '{{ sap_hana_install_software_extract_directory }}' exists
       find:
         paths: "{{ sap_hana_install_software_extract_directory }}"
         recurse: yes
-        file_type: file
-        patterns: 'hdblcm'
-      register: __sap_hana_install_register_find_hdblcm
+        file_type: directory
+        patterns: 'SAP_HANA_DATABASE'
+      register: __sap_hana_install_register_find_directory_sap_hana_database_initial
       when: __sap_hana_install_register_stat_software_extract_directory.stat.exists
 
-    - name: SAP HANA Pre Install - Set path of 'hdblcm' from successful find result
+    - name: SAP HANA Pre Install - Set directory of 'hdblcm' from successful find result
       block:
 
         - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer directory if found initially
           set_fact:
-            __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_hdblcm.files[0].path | dirname }}"
+            __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0].path }}"
 
-        - name: SAP HANA Pre Install - Show the full path name of file 'hdblcm'
+        - name: SAP HANA Pre Install - Show the full path name of file 'hdblcm' if found initially
           debug:
             msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
 
+        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' if found initially
+          stat:
+            path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
+          register: __sap_hana_install_register_stat_hdblcm_initial
+          failed_when: no
+
+        - name: SAP HANA Pre Install - Assert that file 'hdblcm' is available if found initially
+          assert:
+            that: __sap_hana_install_register_stat_hdblcm_initial.stat.exists
+            fail_msg: "FAIL: File 'hdblcm' could not be found. Installation of SAP HANA is not possible."
+            success_msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
+
       when:
         - __sap_hana_install_register_stat_software_extract_directory.stat.exists
-        - __sap_hana_install_register_find_hdblcm.files[0] is defined
+        - __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0] is defined
 
     - name: SAP HANA Pre Install - Extract SAR files if file 'hdblcm' was not found initially
       block:
@@ -114,7 +126,7 @@
             fail_msg: "FAIL: File 'hdblcm' could not be found. Installation of SAP HANA is not possible."
             success_msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
 
-      when: __sap_hana_install_register_find_hdblcm.files[0] is not defined
+      when: __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0] is not defined
 
   when: sap_hana_install_new_system|d(true)
 
@@ -134,7 +146,3 @@
     dest: "{{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg"
     mode: '0644'
   register: __sap_hana_install_register_cftemplate
-
-- name: SAP HANA Pre Install - Show location of HANA configfile
-  debug:
-    msg: "HANA configfile is: '{{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg'"

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -1,15 +1,28 @@
 ---
 
-- name: SAP HANA hdblcm prepare - Create temp dir - {{ sap_hana_install_software_directory }}/tmp
+- name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, default
+  set_fact:
+    __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
+
+- name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, SAP Host Agent
+  set_fact:
+    __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp/SAP_HOST_AGENT"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+
+- name: SAP HANA hdblcm prepare - Create temporary extraction destination '{{ __sap_hana_install_tmp_software_extract_directory }}'
   file:
-    path: "{{ sap_hana_install_software_directory }}/tmp"
+    path: "{{ __sap_hana_install_tmp_software_extract_directory }}"
     state: directory
     mode: 0755
+    owner: root
+    group: root
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
-- name: SAP HANA hdblcm prepare - Extracting {{ passed_sap_hana_install_components_sar }}
+- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar }}'
   command: >-
     {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} \
-    -R {{ sap_hana_install_software_directory }}/tmp
+    -R {{ __sap_hana_install_tmp_software_extract_directory }} \
     -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }} \
     -manifest SIGNATURE.SMF
   register: __sap_hana_install_register_extract
@@ -17,25 +30,22 @@
     chdir: "{{ sap_hana_install_software_directory }}"
   changed_when: "'SAPCAR: processing archive' in __sap_hana_install_register_extract.stdout"
 
-- name: SAP HANA hdblcm prepare - Create directory if SAP Host Agent
-  file:
-    path: "{{ sap_hana_install_software_directory }}/tmp/SAP_HOST_AGENT"
-    state: directory
-    mode: 0755
-    owner: root
-    group: root
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
-
-- name: SAP HANA hdblcm prepare - Prepare extracted dir
+- name: SAP HANA hdblcm prepare - Move files into the correct place, default
   shell: |
     extracted_dir=$(ls -d */)
-    cp SIGNATURE.SMF $extracted_dir
-    cp -R $extracted_dir ../extracted/$extracted_dir
+    mv SIGNATURE.SMF ${extracted_dir}
+    mv ${extracted_dir} ..
   args:
-    chdir: "{{ sap_hana_install_software_directory }}/tmp"
-  changed_when: no
+    chdir: "{{ __sap_hana_install_tmp_software_extract_directory }}"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
 
-- name: SAP HANA hdblcm prepare - Remove temp dir - {{ sap_hana_install_software_directory }}/tmp
+- name: SAP HANA hdblcm prepare - Move files into the correct place, SAP Host Agent
+  command: mv ./tmp/SAP_HOST_AGENT .
+  args:
+    chdir: "{{ sap_hana_install_software_extract_directory }}"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+
+- name: SAP HANA hdblcm prepare - Remove temporary extraction directory '{{ sap_hana_install_software_extract_directory }}/tmp'
   file:
-    path: "{{ sap_hana_install_software_directory }}/tmp"
+    path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -11,7 +11,7 @@
   when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
 - name: SAP HANA hdblcm prepare - Create temporary extraction destination '{{ __sap_hana_install_tmp_software_extract_directory }}'
-  file:
+  ansible.builtin.file:
     path: "{{ __sap_hana_install_tmp_software_extract_directory }}"
     state: directory
     mode: 0755
@@ -46,6 +46,6 @@
   when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
 - name: SAP HANA hdblcm prepare - Remove temporary extraction directory '{{ sap_hana_install_software_extract_directory }}/tmp'
-  file:
+  ansible.builtin.file:
     path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -61,7 +61,7 @@
 
 - name: Show the full path name of SAPCAR
   debug:
-    msg: "Using {{ __sap_hana_install_register_sapcar_path.stdout }} for extracting SAR files."
+    msg: "Using '{{ __sap_hana_install_register_sapcar_path.stdout }}' for extracting SAR files."
 
 - name: SAP HANA hdblcm prepare - Get all SAR files in folder - {{ sap_hana_install_software_directory }}
   shell: |

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -1,29 +1,36 @@
 ---
 # hdblcm prepare
 
-# Create directory  {{ sap_hana_install_software_directory }}/extracted
+# Create directory {{ sap_hana_install_software_extract_directory }}
 # This is where all extracted .SAR files will be stored
 
-- name: SAP HANA hdblcm prepare - Remove directory - {{ sap_hana_install_software_directory }}/extracted
+- name: SAP HANA hdblcm prepare - Remove directory '{{ sap_hana_install_software_extract_directory }}'
   ansible.builtin.file:
-    path: "{{ sap_hana_install_software_directory }}/extracted"
+    path: "{{ sap_hana_install_software_extract_directory }}"
     state: absent
 
-- name: SAP HANA hdblcm prepare - Create directory - {{ sap_hana_install_software_directory }}/extracted
+- name: SAP HANA hdblcm prepare - Create directory '{{ sap_hana_install_software_extract_directory }}'
   ansible.builtin.file:
-    path: "{{ sap_hana_install_software_directory }}/extracted"
+    path: "{{ sap_hana_install_software_extract_directory }}"
     state: directory
-    mode: 0755
+    mode: '0755'
 
-- name: SAP HANA hdblcm prepare - Change ownership of deployment directory - {{ sap_hana_install_software_directory }}
+- name: SAP HANA hdblcm prepare - Change ownership of deployment directory '{{ sap_hana_install_software_directory }}'
   ansible.builtin.file:
     path: "{{ sap_hana_install_software_directory }}"
     state: directory
     recurse: yes
-    mode: 0755
+    mode: '0755'
     owner: root
     group: root
 
+- name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable if sap_hana_install_sapcar_filename is defined
+  set_fact:
+    __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_filename }}"
+  when: sap_hana_install_sapcar_filename is defined
+
+- name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
+  block:
 # We need the file package for the file command, which we need in the next task.
 # The file package is contained in the Base software group, which should be installed already.
 
@@ -37,31 +44,48 @@
 #   We then execute each of the matching SAPCAR*EXE files and if the return code is 0, we execute it again,
 #   print the version and patch number, sort numerically by the version and patch number and finally
 #   select the SAPCAR*EXE file with the highest version.
-- name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
-  shell: |
-    set -o pipefail && for sapcar_matching_arch in $(
-         for sapcar_any in SAPCAR*EXE; do
-            file ${sapcar_any} |
-              awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");
-              split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]); printf ("%s %s\n", a[1], b[2])}'
-         done | awk '/'"{{ ansible_architecture }}"'/{print $1}'); do
-      ./${sapcar_matching_arch} --version >/dev/null 2>&1 && (
-      printf "%s " ${sapcar_matching_arch}
-      ./${sapcar_matching_arch} --version |
-        awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}')
-      done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
-  args:
-    chdir: "{{ sap_hana_install_software_directory }}"
-  register: __sap_hana_install_register_sapcar_path
-  changed_when: no
+    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
+      shell: |
+        set -o pipefail && for sapcar_matching_arch in $(
+             for sapcar_any in SAPCAR*EXE; do
+                file ${sapcar_any} |
+                  awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");
+                  split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]); printf ("%s %s\n", a[1], b[2])}'
+             done | awk '/'"{{ ansible_architecture }}"'/{print $1}'); do
+          ./${sapcar_matching_arch} --version >/dev/null 2>&1 && (
+          printf "%s " ${sapcar_matching_arch}
+          ./${sapcar_matching_arch} --version |
+            awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}')
+          done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
+      args:
+        chdir: "{{ sap_hana_install_software_directory }}"
+      register: __sap_hana_install_register_sapcar_file
+      changed_when: no
 
-- name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
-  set_fact:
-    __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_path.stdout }}"
+    - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
+      set_fact:
+        __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
 
-- name: Show the full path name of SAPCAR
-  debug:
-    msg: "Using '{{ __sap_hana_install_register_sapcar_path.stdout }}' for extracting SAR files."
+  when: sap_hana_install_sapcar_filename is not defined
+
+- name: SAP HANA hdblcm prepare - Get info about the SAPCAR executable
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}"
+  register: __sap_hana_install_register_sapcar_stat_result
+  failed_when: no
+
+- name: SAP HANA hdblcm prepare - Assert that the SAPCAR executable is available
+  assert:
+    that: __sap_hana_install_register_sapcar_stat_result.stat.exists
+    fail_msg: "FAIL: No valid SAPCAR executable could be found. Consider setting variable 'sap_hana_install_sapcar_filename'."
+    success_msg: "Using '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' for extracting SAR files."
+
+- name: SAP HANA hdblcm prepare - Make sure SAPCAR has execute permissions and is owned by root
+  ansible.builtin.file:
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}"
+    mode: '0755'
+    owner: root
+    group: root
 
 - name: SAP HANA hdblcm prepare - Get all SAR files in folder - {{ sap_hana_install_software_directory }}
   shell: |
@@ -76,29 +100,23 @@
     __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
   when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
 
-- name: SAP HANA hdblcm prepare - Extract all SAR files in folder - {{ sap_hana_install_software_directory }}
+- name: SAP HANA hdblcm prepare - Extract all SAR files in folder '{{ sap_hana_install_software_directory }}'
   include_tasks: extract_sar.yml
-# Variable not used:
-#  register: __sap_hana_preconfigure_register_extract_all_sar_files
   loop: "{{ __sap_hana_install_fact_components_sar }}"
   loop_control:
     loop_var: passed_sap_hana_install_components_sar
   when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
 
-- name: SAP HANA Pre Install - Change ownership of software path - {{ sap_hana_install_software_directory }}
-  ansible.builtin.file:
-    path: "{{ sap_hana_install_software_directory }}"
-    state: directory
-    recurse: yes
-    mode: 0755
-    owner: root
-    group: root
-
-- name: SAP HANA hdblcm prepare - Find SAP_HANA_DATABASE or HDB_SERVER_LINUX_
+- name: SAP HANA hdblcm prepare - Find 'SAP_HANA_DATABASE' in '{{ sap_hana_install_software_extract_directory }}'
   find:
-    paths: "{{ sap_hana_install_software_directory }}"
+    paths: "{{ sap_hana_install_software_extract_directory }}"
     recurse: yes
     file_type: directory
-    patterns: '(SAP_HANA_DATABASE|HDB_SERVER_LINUX_)'
+    patterns: '(SAP_HANA_DATABASE)'
     use_regex: yes
   register: __sap_hana_install_register_find_directory_sap_hana_database
+
+- name: SAP HANA hdblcm prepare - Set fact for 'hdblcm' installer path
+  set_fact:
+    __sap_hana_install_fact_hdblcm_path:
+      "{{ __sap_hana_install_register_find_directory_sap_hana_database.files[0].path }}"

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -67,10 +67,11 @@
     owner: root
     group: root
 
-- name: SAP HANA hdblcm prepare - Find SAP_HANA_DATABASE
+- name: SAP HANA hdblcm prepare - Find SAP_HANA_DATABASE or HDB_SERVER_LINUX_
   find:
     paths: "{{ sap_hana_install_software_directory }}"
     recurse: yes
     file_type: directory
-    contains: "SAP_HANA_DATABASE"
+    patterns: '(SAP_HANA_DATABASE|HDB_SERVER_LINUX_)'
+    use_regex: yes
   register: __sap_hana_install_register_find_directory_sap_hana_database

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -84,25 +84,39 @@
     owner: root
     group: root
 
-- name: SAP HANA hdblcm prepare - Get all SAR files in folder - {{ sap_hana_install_software_directory }}
-  shell: |
-    ls *.SAR
-  args:
-    chdir: "{{ sap_hana_install_software_directory }}"
-  register: __sap_hana_install_register_sarfiles_list
-  changed_when: no
+- name: Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
+  block:
 
-- name: SAP HANA hdblcm prepare - Set fact list of SAR files
+    - name: SAP HANA hdblcm prepare - Get all SAR files in folder '{{ sap_hana_install_software_directory }}'
+      shell: |
+        ls *.SAR
+      args:
+        chdir: "{{ sap_hana_install_software_directory }}"
+      register: __sap_hana_install_register_sarfiles_list
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
+      set_fact:
+        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
+      when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
+
+  when: sap_hana_install_sarfiles_list is not defined
+
+- name: SAP HANA hdblcm prepare - Set fact list of SAR files from variable if defined
   set_fact:
-    __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
-  when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
+    __sap_hana_install_fact_components_sar: "{{ sap_hana_install_sarfiles_list }}"
+  when: sap_hana_install_sarfiles_list is defined
+
+- name: SAP HANA hdblcm prepare - Display SAR files to be extracted
+  debug:
+    var: __sap_hana_install_fact_components_sar
 
 - name: SAP HANA hdblcm prepare - Extract all SAR files in folder '{{ sap_hana_install_software_directory }}'
   include_tasks: extract_sar.yml
   loop: "{{ __sap_hana_install_fact_components_sar }}"
   loop_control:
     loop_var: passed_sap_hana_install_components_sar
-  when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
+  when: __sap_hana_install_fact_components_sar | length > 0
 
 - name: SAP HANA hdblcm prepare - Remove status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__'
   ansible.builtin.file:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -15,14 +15,11 @@
     state: directory
     mode: '0755'
 
-- name: SAP HANA hdblcm prepare - Change ownership of deployment directory '{{ sap_hana_install_software_directory }}'
+- name: SAP HANA hdblcm prepare - Create status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__'
   ansible.builtin.file:
-    path: "{{ sap_hana_install_software_directory }}"
-    state: directory
-    recurse: yes
+    path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
+    state: touch
     mode: '0755'
-    owner: root
-    group: root
 
 - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable if sap_hana_install_sapcar_filename is defined
   set_fact:
@@ -106,6 +103,11 @@
   loop_control:
     loop_var: passed_sap_hana_install_components_sar
   when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
+
+- name: SAP HANA hdblcm prepare - Remove status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__'
+  ansible.builtin.file:
+    path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
+    state: absent
 
 - name: SAP HANA hdblcm prepare - Find 'SAP_HANA_DATABASE' in '{{ sap_hana_install_software_extract_directory }}'
   find:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -29,7 +29,7 @@
 - name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
   block:
 # We need the file package for the file command, which we need in the next task.
-# The file package is contained in the Base software group, which should be installed already.
+# RHEL: The file package is contained in the Base software group, which should be installed already.
 
 # In case there is more than one SAPCAR*EXE file in the software directory, we need to get the correct one.
 # In case of ppc64 and ppc64le, the file command displays the same architecture in the second column.

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -114,8 +114,7 @@
     paths: "{{ sap_hana_install_software_extract_directory }}"
     recurse: yes
     file_type: directory
-    patterns: '(SAP_HANA_DATABASE)'
-    use_regex: yes
+    patterns: 'SAP_HANA_DATABASE'
   register: __sap_hana_install_register_find_directory_sap_hana_database
 
 - name: SAP HANA hdblcm prepare - Set fact for 'hdblcm' installer path

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -39,7 +39,7 @@
 #   select the SAPCAR*EXE file with the highest version.
 - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
   shell: |
-    for sapcar_matching_arch in $(
+    set -o pipefail && for sapcar_matching_arch in $(
          for sapcar_any in SAPCAR*EXE; do
             file ${sapcar_any} |
               awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -24,9 +24,34 @@
     owner: root
     group: root
 
+- name: SAP HANA hdblcm prepare - Install the file package if not yet present
+  package:
+    name: file
+    state: present
+
+# In case there is more than one SAPCAR*EXE file in the software directory, we need to get the correct one.
+# In case of ppc64 and ppc64le, the file command displays the same architecture in the second column.
+# We could use the binutils package but we can also find out the correct file by just attempting to execute it.
+# Inner loop, loop variable sapcar_any:
+#   We first replace the architecture string as reported by the file command by the string as reported by uname -m.
+#   Next, we select only the SAPCAR*EXE files which matches the architecture of the managed node.
+# Outer loop, loop variable sapcar_matching_arch:
+#   We then execute each of the matching SAPCAR*EXE files and if the return code is 0, we execute it again,
+#   print the version and patch number, sort numerically by the version and patch number and finally
+#   select the SAPCAR*EXE file with the highest version.
 - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
   shell: |
-    ls SAPCAR*EXE
+    for sapcar_matching_arch in $(
+         for sapcar_any in SAPCAR*EXE; do
+            file ${sapcar_any} |
+              awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");
+              split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]); printf ("%s %s\n", a[1], b[2])}'
+         done | awk '/'"{{ ansible_architecture }}"'/{print $1}'); do
+      ${sapcar_matching_arch} --version >/dev/null 2>&1 && (
+      printf "%s " ${sapcar_matching_arch}
+      ${sapcar_matching_arch} --version |
+        awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}')
+      done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
   args:
     chdir: "{{ sap_hana_install_software_directory }}"
   register: __sap_hana_install_register_sapcar_path
@@ -35,6 +60,10 @@
 - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
   set_fact:
     __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_path.stdout }}"
+
+- name: Show the full path name of SAPCAR
+  debug:
+    msg: "Using {{ __sap_hana_install_register_sapcar_path.stdout }} for extracting SAR files."
 
 - name: SAP HANA hdblcm prepare - Get all SAR files in folder - {{ sap_hana_install_software_directory }}
   shell: |

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -24,10 +24,8 @@
     owner: root
     group: root
 
-- name: SAP HANA hdblcm prepare - Install the file package if not yet present
-  package:
-    name: file
-    state: present
+# We need the file package for the file command, which we need in the next task.
+# The file package is contained in the Base software group, which should be installed already.
 
 # In case there is more than one SAPCAR*EXE file in the software directory, we need to get the correct one.
 # In case of ppc64 and ppc64le, the file command displays the same architecture in the second column.
@@ -47,9 +45,9 @@
               awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");
               split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]); printf ("%s %s\n", a[1], b[2])}'
          done | awk '/'"{{ ansible_architecture }}"'/{print $1}'); do
-      ${sapcar_matching_arch} --version >/dev/null 2>&1 && (
+      ./${sapcar_matching_arch} --version >/dev/null 2>&1 && (
       printf "%s " ${sapcar_matching_arch}
-      ${sapcar_matching_arch} --version |
+      ./${sapcar_matching_arch} --version |
         awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}')
       done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
   args:

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-services.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-services.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Disable service {{ __sap_hana_preconfigure_packages_and_services[line_item].svc }} if
+- name: Disable service {{ __sap_hana_preconfigure_packages_and_services[line_item].svc }}
           if package {{ __sap_hana_preconfigure_packages_and_services[line_item].pkg }} is installed
   systemd:
     name: "{{ __sap_hana_preconfigure_packages_and_services[line_item].svc }}"


### PR DESCRIPTION
This is mainly a rework of the pre_install part, allowing greater flexibility and avoiding some pitfalls:
- We select the directory in which the file hdblcm is located by searching for this file instead of searching for directory SAP_HANA_DATABASE (#29).
- The role now detects the correct SAPCAR EXE file and selects the latest version found, to support one or more SAPCAR EXE files in the software directory. Alternatively, the file name of the SAPCAR EXE file can be set with a variable (#32).
- The role will abort if a user group exists with a different group ID than specified in variable sap_hana_install_groupid (#33).
- The HANA software extraction directory can be set to a different location than ./extracted below the software directory (#36).
- If the role is executed on more than one host at the same time and the extraction directory is shared, the installation will pause until SAR file extraction has completed on the first host (#37).
