### PR TITLE
sap_hana_install: Support checksums for SAPCAR executable and SAR files (issue #44)

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -42,10 +42,10 @@ Place the following files in directory /software/hana or in any other directory 
     -rwxr-xr-x. 1 nobody nobody   89285401 Sep 30 04:24 SAPHOSTAGENT51_51-20009394.SAR
     ```
 
-For security reasons, the file names and checksums of the SAPCAR EXE file and the SAR files need to be specified
-in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find exanples in
-file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info" page for each SAP
-software package in the SAP software center.
+For security reasons, it is recommended to specify the file names and checksums of the SAPCAR EXE file and the
+SAR files in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find
+examples for these in file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info"
+page for each SAP software package in the SAP software center.
 
 Example:
 ```
@@ -59,6 +59,14 @@ sap_hana_install_sarfiles:
 For the SAPCAR EXE file and the SAR files to be installed, a file named `<filename>.sha256sum` containing
 the output of the sha256sum command will be created by the role if it does not yet exist in the software
 download directory `sap_hana_install_software_directory`.
+
+If variable `sap_hana_install_sapcar_file` is not specified, the role will attempt to automatically detect the
+SAPCAR EXE file in the software directory which matches the architecture, and choose the latest available version.
+
+If variable `sap_hana_install_sarfiles` is not specified, the role will extract all SAR files found in the
+software directory, and use them for installation. If more than one version of the same software is found,
+the attempt to move the extracted files from any consecutive SAR file to its final destination in
+`sap_hana_install_software_extract_directory` will fail.
 
 #### Extracted SAP HANA Software Installation Files
 

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -32,7 +32,7 @@ Place the following files in directory /software/hana or in any other directory 
 
 - Sample directory `sap_hana_install_software_directory` containing SAP HANA software installation files
     ```console
-    [root@hanahost SAP_HANA_INSTALLATION]# ll -lrt
+    [root@hanahost SAP_HANA_INSTALLATION]# ls -l *.EXE *.SAR
     -rwxr-xr-x. 1 nobody nobody  149561376 Mar  4  2021 IMDB_AFL20_054_1-80001894.SAR
     -rwxr-xr-x. 1 nobody nobody  211762405 Mar  4  2021 IMDB_CLIENT20_007_23-80002082.SAR
     -rwxr-xr-x. 1 nobody nobody    4483040 Mar  4  2021 SAPCAR_1010-70006178.EXE
@@ -42,22 +42,23 @@ Place the following files in directory /software/hana or in any other directory 
     -rwxr-xr-x. 1 nobody nobody   89285401 Sep 30 04:24 SAPHOSTAGENT51_51-20009394.SAR
     ```
 
-If more than one SAPCAR EXE file is present in the software directory, the role will select the latest version
-for the current hardware architecture. Alternatively, the file name of the SAPCAR EXE file can also be set with
-variable `sap_hana_install_sapcar_filename`.
-
-If more than one SAR file for a certain software product is present in the software directory, the automatic
-handling of such SAR files will fail after extraction, when moving the newly created product directories
-(like `SAP_HOST_AGENT`) to already existing destinations.
-For avoiding such situations, use following variable to provide a list of SAR files to extract:
-`sap_hana_install_sarfiles_list`.
+For security reasons, the file names and checksums of the SAPCAR EXE file and the SAR files need to be specified
+in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find exanples in
+file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info" page for each SAP
+software package in the SAP software center.
 
 Example:
 ```
-sap_hana_install_sarfiles_list:
-  - SAPHOSTAGENT54_54-80004822.SAR
-  - IMDB_SERVER20_060_0-80002031.SAR
+sap_hana_install_sapcar_file:
+- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
+sap_hana_install_sarfiles:
+- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
+- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
 ```
+
+For the SAPCAR EXE file and the SAR files to be installed, a file named `<filename>.sha256sum` containing
+the output of the sha256sum command will be created by the role if it does not yet exist in the software
+download directory `sap_hana_install_software_directory`.
 
 #### Extracted SAP HANA Software Installation Files
 

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -10,25 +10,14 @@ sap_hana_install_software_directory: '/software/hana'
 # Note: This directory will be removed and created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
-# File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
-#sap_hana_install_sapcar_filename: SAPCAR_1234-12345678.EXE
-
 # File name and checksum of SAPCAR EXE file:
 sap_hana_install_sapcar_file:
-# x86_64:
- - { name: 'SAPCAR_1115-70006178.EXE', checksum: '765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5' } # SAPCAR 7.22
-# ppc64le:
-# - { name: 'SAPCAR_1115-70006238.EXE', checksum: 'efd23b616e7b8745a72d11b3b497ce6c93a4bbc24d3f12349b51db05b9cac4a3' } # SAPCAR 7.22
+- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
 
+# File name and checksum of SAR files:
 sap_hana_install_sarfiles:
-# x86_64:
-  - { name: 'IMDB_SERVER20_060_0-80002031.SAR', checksum: '7d58473d0f0b03edc3be27465b562688c44c0ddde7e44d5d89c0c64606503e87' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
-#  - { name: 'SAPHOSTAGENT54_54-80004822.SAR', checksum: '5899a0934bd8d37a887d0d67de6ac0520f907a66ff7c3bc79176fff99171a878' } # SAP HOST AGENT 7.22 SP54
-
-#  ppc64le:
-#  - { name: 'IMDB_SERVER20_060_0-80002046.SAR' , checksum: '9d32042496fb010901e56571110825807612e898412eba54704528f73c57aa22' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
-#  - { name: 'SAPHOSTAGENT54_54-80004831.SAR', checksum: '5d54fde8fc470df01820e86ac3105501b8cd6715fd2fab43787d4c9fb0139d49' } # SAP HOST AGENT 7.22 SP54
-
+- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
+- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -13,11 +13,22 @@ sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_direc
 # File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
 #sap_hana_install_sapcar_filename: SAPCAR_1234-12345678.EXE
 
-# List of file names of SAR files to extract. Can be set in case there are more SAR files in the software directory
-# than needed or desired for the HANA installation
-#sap_hana_install_sarfiles_list:
-#  - SAPHOSTAGENT54_54-80004822.SAR
-#  - IMDB_SERVER20_060_0-80002031.SAR
+# File name and checksum of SAPCAR EXE file:
+sap_hana_install_sapcar_file:
+# x86_64:
+ - { name: 'SAPCAR_1115-70006178.EXE', checksum: '765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5' } # SAPCAR 7.22
+# ppc64le:
+# - { name: 'SAPCAR_1115-70006238.EXE', checksum: 'efd23b616e7b8745a72d11b3b497ce6c93a4bbc24d3f12349b51db05b9cac4a3' } # SAPCAR 7.22
+
+sap_hana_install_sarfiles:
+# x86_64:
+  - { name: 'IMDB_SERVER20_060_0-80002031.SAR', checksum: '7d58473d0f0b03edc3be27465b562688c44c0ddde7e44d5d89c0c64606503e87' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
+#  - { name: 'SAPHOSTAGENT54_54-80004822.SAR', checksum: '5899a0934bd8d37a887d0d67de6ac0520f907a66ff7c3bc79176fff99171a878' } # SAP HOST AGENT 7.22 SP54
+
+#  ppc64le:
+#  - { name: 'IMDB_SERVER20_060_0-80002046.SAR' , checksum: '9d32042496fb010901e56571110825807612e898412eba54704528f73c57aa22' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
+#  - { name: 'SAPHOSTAGENT54_54-80004831.SAR', checksum: '5d54fde8fc470df01820e86ac3105501b8cd6715fd2fab43787d4c9fb0139d49' } # SAP HOST AGENT 7.22 SP54
+
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -11,13 +11,13 @@ sap_hana_install_software_directory: '/software/hana'
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
 # File name and checksum of SAPCAR EXE file:
-sap_hana_install_sapcar_file:
-- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
+#sap_hana_install_sapcar_file:
+#- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
 
 # File name and checksum of SAR files:
-sap_hana_install_sarfiles:
-- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
-- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
+#sap_hana_install_sarfiles:
+#- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
+#- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Warn if the role is used without specifying SAPCAR executable and SAR files
+  debug:
+    msg: "WARN: The role is used without variables 'sap_hana_install_sapcar_file'
+          or 'sap_hana_install_sarfiles' being configured, so the SAPCAR executable
+          and the SAR files in directory {{ sap_hana_install_software_directory }}
+          will be determined automatically."
+  when: sap_hana_install_sapcar_file is undefined or
+        sap_hana_install_sarfiles is undefined
+
 - import_tasks: hana_exists.yml
   when: sap_hana_install_new_system|d(true)
 

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -1,13 +1,19 @@
 ---
 
-- name: Warn if the role is used without specifying SAPCAR executable and SAR files
+- name: Notify if the role is used without specifying the SAPCAR executable
   debug:
-    msg: "WARN: The role is used without variables 'sap_hana_install_sapcar_file'
-          or 'sap_hana_install_sarfiles' being configured, so the SAPCAR executable
-          and the SAR files in directory {{ sap_hana_install_software_directory }}
-          will be determined automatically."
-  when: sap_hana_install_sapcar_file is undefined or
-        sap_hana_install_sarfiles is undefined
+    msg: "INFO: The role is used without variable 'sap_hana_install_sapcar_file'
+          being configured, so the SAPCAR executable in directory
+          {{ sap_hana_install_software_directory }} will be determined automatically."
+  when: sap_hana_install_sapcar_file is undefined
+
+- name: Notify if the role is used without specifying SAR files
+  debug:
+    msg: "INFO: The role is used without variable 'sap_hana_install_sarfiles'
+          being configured, so all SAR files in directory
+          {{ sap_hana_install_software_directory }} will be extracted
+          and used for the installation."
+  when: sap_hana_install_sarfiles is undefined
 
 - import_tasks: hana_exists.yml
   when: sap_hana_install_new_system|d(true)

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -84,7 +84,7 @@
           set_fact:
             __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0].path }}"
 
-        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' if found initially
+        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm' if found initially
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
           register: __sap_hana_install_register_stat_hdblcm_initial
@@ -110,7 +110,7 @@
           debug:
             var: __sap_hana_install_fact_hdblcm_path
 
-        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}'
+        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm'
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
           register: __sap_hana_install_register_stat_hdblcm

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -62,7 +62,7 @@
       failed_when: no
 
 # In case more than on installation is ongoing and extracting to the same shared directory, wait until the extraction has completed:
-    - name: SAP HANA Pre Install - Proceed if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' is absent
+    - name: SAP HANA Pre Install - Suspending if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' exists
       wait_for:
         path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
         state: absent

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -23,27 +23,32 @@
   debug:
     msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
 
-- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
-  stat:
-    path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-  register: __sap_hana_install_register_sarfile_sha256sum_stat_result
-  changed_when: no
-  failed_when: no
+- name: SAP HANA hdblcm prepare - Verify checksum for SAR file
+  block:
 
-- name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
-  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-  when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
+    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
+      stat:
+        path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+      register: __sap_hana_install_register_sarfile_sha256sum_stat_result
+      changed_when: no
+      failed_when: no
 
-- name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
-  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-  register: __sap_hana_install_register_sarfile_sha256sum
-  changed_when: no
+    - name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
+      shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+      when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
 
-- name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
-  assert:
-    that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
-    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
-    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+    - name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
+      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+      register: __sap_hana_install_register_sarfile_sha256sum
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
+      assert:
+        that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
+        fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
+        success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+
+  when: sap_hana_install_sarfiles is defined
 
 - name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar.name }}'
   command: >-
@@ -75,4 +80,3 @@
   ansible.builtin.file:
     path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -19,11 +19,26 @@
     group: root
   when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
-- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar }}'
+- name: Display name and checksum of SAR file
+  debug:
+    msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
+
+- name: SAP HANA hdblcm prepare - Get sha256sum of the SAR file
+  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+  register: __sap_hana_install_register_sarfile_sha256sum
+  changed_when: no
+
+- name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
+  assert:
+    that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
+    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
+    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+
+- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar.name }}'
   command: >-
     {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} \
     -R {{ __sap_hana_install_tmp_software_extract_directory }} \
-    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }} \
+    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} \
     -manifest SIGNATURE.SMF
   register: __sap_hana_install_register_extract
   args:
@@ -37,13 +52,13 @@
     mv ${extracted_dir} ..
   args:
     chdir: "{{ __sap_hana_install_tmp_software_extract_directory }}"
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Move files into the correct place, SAP Host Agent
   command: mv ./tmp/SAP_HOST_AGENT .
   args:
     chdir: "{{ sap_hana_install_software_extract_directory }}"
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Remove temporary extraction directory '{{ sap_hana_install_software_extract_directory }}/tmp'
   ansible.builtin.file:

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -3,12 +3,12 @@
 - name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, default
   set_fact:
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp"
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, SAP Host Agent
   set_fact:
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp/SAP_HOST_AGENT"
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Create temporary extraction destination '{{ __sap_hana_install_tmp_software_extract_directory }}'
   ansible.builtin.file:
@@ -17,13 +17,24 @@
     mode: 0755
     owner: root
     group: root
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
 
 - name: Display name and checksum of SAR file
   debug:
     msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
 
-- name: SAP HANA hdblcm prepare - Get sha256sum of the SAR file
+- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+  register: __sap_hana_install_register_sarfile_sha256sum_stat_result
+  changed_when: no
+  failed_when: no
+
+- name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
+  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+  when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
+
+- name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
   command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
   register: __sap_hana_install_register_sarfile_sha256sum
   changed_when: no
@@ -64,3 +75,4 @@
   ansible.builtin.file:
     path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -21,61 +21,33 @@
     state: touch
     mode: '0755'
 
-- name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable if sap_hana_install_sapcar_filename is defined
+- name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
   set_fact:
-    __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_filename }}"
-  when: sap_hana_install_sapcar_filename is defined
-
-- name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
-  block:
-# We need the file package for the file command, which we need in the next task.
-# RHEL: The file package is contained in the Base software group, which should be installed already.
-
-# In case there is more than one SAPCAR*EXE file in the software directory, we need to get the correct one.
-# In case of ppc64 and ppc64le, the file command displays the same architecture in the second column.
-# We could use the binutils package but we can also find out the correct file by just attempting to execute it.
-# Inner loop, loop variable sapcar_any:
-#   We first replace the architecture string as reported by the file command by the string as reported by uname -m.
-#   Next, we select only the SAPCAR*EXE files which matches the architecture of the managed node.
-# Outer loop, loop variable sapcar_matching_arch:
-#   We then execute each of the matching SAPCAR*EXE files and if the return code is 0, we execute it again,
-#   print the version and patch number, sort numerically by the version and patch number and finally
-#   select the SAPCAR*EXE file with the highest version.
-    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
-      shell: |
-        set -o pipefail && for sapcar_matching_arch in $(
-             for sapcar_any in SAPCAR*EXE; do
-                file ${sapcar_any} |
-                  awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");
-                  split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]); printf ("%s %s\n", a[1], b[2])}'
-             done | awk '/'"{{ ansible_architecture }}"'/{print $1}'); do
-          ./${sapcar_matching_arch} --version >/dev/null 2>&1 && (
-          printf "%s " ${sapcar_matching_arch}
-          ./${sapcar_matching_arch} --version |
-            awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}')
-          done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
-      args:
-        chdir: "{{ sap_hana_install_software_directory }}"
-      register: __sap_hana_install_register_sapcar_file
-      changed_when: no
-
-    - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
-      set_fact:
-        __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
-
-  when: sap_hana_install_sapcar_filename is not defined
+    __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_file[0].name }}"
 
 - name: SAP HANA hdblcm prepare - Get info about the SAPCAR executable
   stat:
     path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}"
   register: __sap_hana_install_register_sapcar_stat_result
+  changed_when: no
   failed_when: no
 
 - name: SAP HANA hdblcm prepare - Assert that the SAPCAR executable is available
   assert:
     that: __sap_hana_install_register_sapcar_stat_result.stat.exists
-    fail_msg: "FAIL: No valid SAPCAR executable could be found. Consider setting variable 'sap_hana_install_sapcar_filename'."
-    success_msg: "Using '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' for extracting SAR files."
+    fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
+    success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
+
+- name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
+  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+  register: __sap_hana_install_register_sapcar_sha256sum
+  changed_when: no
+
+- name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
+  assert:
+    that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
+    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
+    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
 
 - name: SAP HANA hdblcm prepare - Make sure SAPCAR has execute permissions and is owned by root
   ansible.builtin.file:
@@ -84,28 +56,10 @@
     owner: root
     group: root
 
-- name: Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
-  block:
-
-    - name: SAP HANA hdblcm prepare - Get all SAR files in folder '{{ sap_hana_install_software_directory }}'
-      shell: |
-        ls *.SAR
-      args:
-        chdir: "{{ sap_hana_install_software_directory }}"
-      register: __sap_hana_install_register_sarfiles_list
-      changed_when: no
-
-    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
-      set_fact:
-        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
-      when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
-
-  when: sap_hana_install_sarfiles_list is not defined
-
 - name: SAP HANA hdblcm prepare - Set fact list of SAR files from variable if defined
   set_fact:
-    __sap_hana_install_fact_components_sar: "{{ sap_hana_install_sarfiles_list }}"
-  when: sap_hana_install_sarfiles_list is defined
+    __sap_hana_install_fact_components_sar: "{{ sap_hana_install_sarfiles }}"
+  when: sap_hana_install_sarfiles is defined
 
 - name: SAP HANA hdblcm prepare - Display SAR files to be extracted
   debug:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -24,6 +24,52 @@
 - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
   set_fact:
     __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_file[0].name }}"
+  when: sap_hana_install_sapcar_file is defined
+
+- name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
+  block:
+# We need the 'file' package for the 'file' command, which we need in the next task.
+# RHEL: The 'file' package is contained in the Base software group, which should be installed already.
+
+# In case there is more than one SAPCAR EXE file in the software directory, we want to identify the correct one.
+# Inner loop, loop variable sapcar_any:
+#   For each SAPCAR*EXE file, the 'file' command is executed. It displays the hardware architecture in the
+#   second output field, using a string which is different from the output of the 'uname -m' command. So we
+#   replace those strings by the "correct" ones. For ppc64 ad ppc64le, the second output field is identical
+#   so in this case, we also look at the third output field.
+#   Next, we select only the SAPCAR EXE file(s) which match(es) the architecture of the managed node.
+# Outer loop, loop variable sapcar_matching_arch:
+#   We then print the name, version, and patch number for each SAPCAR EXE file for the architecture, sort numerically
+#   by the version and patch number and finally select the SAPCAR EXE file with the highest version.
+    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
+      shell: |
+        set -o pipefail &&
+        for sapcar_matching_arch in $(
+                for sapcar_any in SAPCAR*EXE; do
+                   file ${sapcar_any} | awk '{
+                      split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]);
+                      sub ("x86-64", "x86_64", b[2]);
+                      if (index (b[3], "OpenPOWER") > 0) {sub ("64-bit PowerPC", "ppc64le", b[2])};
+                      if (index (b[3], "OpenPOWER") == 0) {sub ("64-bit PowerPC", "ppc64", b[2])};
+                      sub ("IBM S/390", "s390x", b[2]);
+                      printf ("%s %s\n", a[1], b[2])}'
+                   done | awk '$2=="{{ ansible_architecture }}"{print $1}'
+                ); do
+           ( printf "%s " ${sapcar_matching_arch}
+             ./${sapcar_matching_arch} --version |
+             awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}'
+           )
+        done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
+      args:
+        chdir: "{{ sap_hana_install_software_directory }}"
+      register: __sap_hana_install_register_sapcar_file
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
+      set_fact:
+        __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
+
+  when: sap_hana_install_sapcar_file is not defined
 
 - name: SAP HANA hdblcm prepare - Get info about the SAPCAR executable
   stat:
@@ -38,27 +84,32 @@
     fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
     success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
 
-- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
-  stat:
-    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-  register: __sap_hana_install_register_sapcar_sha256sum_stat_result
-  changed_when: no
-  failed_when: no
+- name: SAP HANA hdblcm prepare - Verify checksum for SAPCAR executable
+  block:
 
-- name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
-  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-  when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
+    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
+      stat:
+        path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+      register: __sap_hana_install_register_sapcar_sha256sum_stat_result
+      changed_when: no
+      failed_when: no
 
-- name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
-  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-  register: __sap_hana_install_register_sapcar_sha256sum
-  changed_when: no
+    - name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
+      shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+      when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
 
-- name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
-  assert:
-    that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
-    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
-    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
+    - name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
+      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+      register: __sap_hana_install_register_sapcar_sha256sum
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
+      assert:
+        that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
+        fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
+        success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
+
+  when: sap_hana_install_sapcar_file is defined
 
 - name: SAP HANA hdblcm prepare - Make sure SAPCAR has execute permissions and is owned by root
   ansible.builtin.file:
@@ -66,6 +117,33 @@
     mode: '0755'
     owner: root
     group: root
+
+- name: Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
+  block:
+
+    - name: SAP HANA hdblcm prepare - Get all SAR files in folder '{{ sap_hana_install_software_directory }}'
+      shell: |
+        ls *.SAR | awk '{print $0, "0"}'
+      args:
+        chdir: "{{ sap_hana_install_software_directory }}"
+      register: __sap_hana_install_register_sarfiles_list
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
+      set_fact:
+        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_fact_components_sar|d([]) + [ __sap_hana_install_tmp_dict ] }}"
+      with_items: "{{ __sap_hana_install_register_sarfiles_list.stdout_lines }}"
+      vars:
+        __sap_hana_install_tmp_dict:
+          name: "{{ item.split(' ').0 }}"
+          checksum: "{{ item.split(' ').1 }}"
+      when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
+
+#    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
+#      set_fact:
+#        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
+
+  when: sap_hana_install_sarfiles is not defined
 
 - name: SAP HANA hdblcm prepare - Set fact list of SAR files from variable if defined
   set_fact:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -131,6 +131,10 @@
       register: __sap_hana_install_register_sarfiles_list
       changed_when: no
 
+# We add a dummy field to the list of SAR file names so that type of variable
+# __sap_hana_install_fact_components_sar is identical to the type of role variable
+# sap_hana_install_sarfiles, if configured. With this solution, we can avoid some
+# duplicate code in the following processing steps.
     - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
       set_fact:
         __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_fact_components_sar|d([]) + [ __sap_hana_install_tmp_dict ] }}"
@@ -140,10 +144,6 @@
           name: "{{ item.split(' ').0 }}"
           checksum: "{{ item.split(' ').1 }}"
       when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
-
-#    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
-#      set_fact:
-#        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
 
   when: sap_hana_install_sarfiles is not defined
 

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -38,6 +38,17 @@
     fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
     success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
 
+- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+  register: __sap_hana_install_register_sapcar_sha256sum_stat_result
+  changed_when: no
+  failed_when: no
+
+- name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
+  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+  when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
+
 - name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
   command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
   register: __sap_hana_install_register_sapcar_sha256sum

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -35,13 +35,15 @@
 # Inner loop, loop variable sapcar_any:
 #   For each SAPCAR*EXE file, the 'file' command is executed. It displays the hardware architecture in the
 #   second output field, using a string which is different from the output of the 'uname -m' command. So we
-#   replace those strings by the "correct" ones. For ppc64 ad ppc64le, the second output field is identical
-#   so in this case, we also look at the third output field.
-#   Next, we select only the SAPCAR EXE file(s) which match(es) the architecture of the managed node.
+#   replace those strings by the "correct" ones. For ppc64 and ppc64le, the second output field is identical.
+#   So in this case, we also look at the third output field, to handle cases where a ppc64 SAPCAR executable
+#   is present in the software directory.
+#   The resulting list of the inner loop contains the SAPCAR EXE file(s) which match(es) the architecture
+#   of the managed node.
 # Outer loop, loop variable sapcar_matching_arch:
-#   We then print the name, version, and patch number for each SAPCAR EXE file for the architecture, sort numerically
-#   by the version and patch number and finally select the SAPCAR EXE file with the highest version.
-    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
+#   We then print the name, version, and patch number for each SAPCAR EXE file for the architecture, sort
+#   numerically by the version and patch number and finally select the SAPCAR EXE file with the highest version.
+    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder '{{ sap_hana_install_software_directory }}'
       shell: |
         set -o pipefail &&
         for sapcar_matching_arch in $(


### PR DESCRIPTION
This commit adds support for verifying checksums of SAPCAR executable and SAR files. Automatic detection of SAPCAR executables and automatic extraction of SAR files remains in place.