### PR TITLE
sap_hana_preconfigure: Support for custom tuned profile; sap_hana_install: Support for checksum verification

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-selinux.yml
@@ -41,7 +41,7 @@
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors|d(false) }}"
   when: __sap_general_preconfigure_register_stat_selinux_conf_assert.stat.isreg
 
-- name: Check for the current SELinux state
+- name: Assert - Determine the current SELinux state
   command: getenforce
   register: __sap_general_preconfigure_register_getenforce_assert
   changed_when: no

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
@@ -18,31 +18,78 @@
   register: __sap_general_preconfigure_register_selinux_config_type_changed
   notify: __sap_general_preconfigure_reboot_handler
 
+- name: Determine the current SELinux state
+  command: getenforce
+  register: __sap_general_preconfigure_register_getenforce
+  changed_when: false
+
 # Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
 - name: SELinux - Set the flag that reboot is needed to apply changes # noqa no-handler
   set_fact:
     sap_general_preconfigure_fact_reboot_required: true
   when: __sap_general_preconfigure_register_selinux_config_state_changed.changed or
-        __sap_general_preconfigure_register_selinux_config_type_changed.changed
+        __sap_general_preconfigure_register_selinux_config_type_changed.changed or
+        __sap_general_preconfigure_register_getenforce.stdout | lower !=
+          sap_general_preconfigure_selinux_state
 
-- name: SELinux - Display the content of sap_general_preconfigure_fact_reboot_required
-  debug:
-    var: sap_general_preconfigure_fact_reboot_required
+- name: Call Reboot handler if necessary
+  command: /bin/true
+  notify: __sap_general_preconfigure_reboot_handler
+  when: __sap_general_preconfigure_register_getenforce.stdout | lower !=
+          sap_general_preconfigure_selinux_state
 
 - name: Set or unset SELinux kernel parameter, RHEL 8 and RHEL 9
   block:
 
-    - name: Disable SELinux also on the kernel command line, RHEL 8 and RHEL 9
-      command: grubby --args="selinux=0" --update-kernel=ALL
-      when: sap_general_preconfigure_selinux_state == 'disabled'
+    - name: SELinux - Examine grub entries
+      shell: grubby --info=ALL | awk 'BEGIN{a=0;b=0}/^args/{a++}/selinux=0/{b++}END{print a, b}'
+      register: __sap_general_preconfigure_register_grubby_info_all_selinux
+      changed_when: false
 
-    - name: Make sure SELinux is not disabled on the kernel command line, RHEL 8 and RHEL 9
-      command: grubby --remove-args="selinux" --update-kernel=ALL
-      when: sap_general_preconfigure_selinux_state == 'enforcing' or
-            sap_general_preconfigure_selinux_state == 'permissive'
+    - name: Disable SELinux on the kernel command line, RHEL 8 and RHEL 9
+      block:
+# If the number of grub entries for args is different from the number of grub entries with "selinux=0",
+# we know that at least one grub entry is missing "selinux=0", so we make sure that all grub entries
+# contain "selinux=0"
+        - name: Disable SELinux also on the kernel command line, RHEL 8 and RHEL 9
+          command: grubby --args="selinux=0" --update-kernel=ALL
+          notify: __sap_general_preconfigure_reboot_handler
+
+# Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
+        - name: SELinux, disable on the kernel command line - Set the flag that reboot is needed to apply changes # noqa no-handler
+          set_fact:
+            sap_general_preconfigure_fact_reboot_required: true
+
+      when:
+        - sap_general_preconfigure_selinux_state == 'disabled'
+        - __sap_general_preconfigure_register_grubby_info_all_selinux.stdout.split(' ').1 != 
+          __sap_general_preconfigure_register_grubby_info_all_selinux.stdout.split(' ').0
+
+    - name: Enable SELinux on the kernel command line, RHEL 8 and RHEL 9
+      block:
+# If the number of grub entries for args with "selinux=0" is not 0, we know that there is at least
+# one grub entry with "selinux=0", so we make sure that no grub entry contains "selinux=0"
+        - name: Make sure SELinux is not disabled on the kernel command line, RHEL 8 and RHEL 9
+          command: grubby --remove-args="selinux" --update-kernel=ALL
+          notify: __sap_general_preconfigure_reboot_handler
+
+# Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
+        - name: SELinux, enable on the kernel command line - Set the flag that reboot is needed to apply changes # noqa no-handler
+          set_fact:
+            sap_general_preconfigure_fact_reboot_required: true
+
+      when:
+        - sap_general_preconfigure_selinux_state == 'enforcing' or
+          sap_general_preconfigure_selinux_state == 'permissive'
+        - __sap_general_preconfigure_register_grubby_info_all_selinux.stdout.split(' ').1 != '0'
 
   when:
     - ansible_os_family == 'RedHat'
     - ( ansible_distribution_major_version == '8' or
         ansible_distribution_major_version == '9'
       )
+
+- name: SELinux - Display the content of sap_general_preconfigure_fact_reboot_required
+  debug:
+    var: sap_general_preconfigure_fact_reboot_required|d(false)
+

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
@@ -21,6 +21,7 @@
 - name: Determine the current SELinux state
   command: getenforce
   register: __sap_general_preconfigure_register_getenforce
+  check_mode: yes
   changed_when: false
 
 # Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
@@ -44,6 +45,7 @@
     - name: SELinux - Examine grub entries
       shell: grubby --info=ALL | awk 'BEGIN{a=0;b=0}/^args/{a++}/selinux=0/{b++}END{print a, b}'
       register: __sap_general_preconfigure_register_grubby_info_all_selinux
+      check_mode: yes
       changed_when: false
 
     - name: Disable SELinux on the kernel command line, RHEL 8 and RHEL 9

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
@@ -21,7 +21,7 @@
 - name: Determine the current SELinux state
   command: getenforce
   register: __sap_general_preconfigure_register_getenforce
-  check_mode: yes
+  check_mode: no
   changed_when: false
 
 # Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
@@ -45,7 +45,7 @@
     - name: SELinux - Examine grub entries
       shell: grubby --info=ALL | awk 'BEGIN{a=0;b=0}/^args/{a++}/selinux=0/{b++}END{print a, b}'
       register: __sap_general_preconfigure_register_grubby_info_all_selinux
-      check_mode: yes
+      check_mode: no
       changed_when: false
 
     - name: Disable SELinux on the kernel command line, RHEL 8 and RHEL 9

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -83,14 +83,14 @@
   debug:
     msg: "The RHEL minor release lock is set correctly to '{{ __sap_general_preconfigure_register_subscription_manager_release.stdout }}'."
   when:
-    - __sap_general_preconfigure_register_subscription_manager_release.stdout == ansible_distribution_version
     - sap_general_preconfigure_set_minor_release
+    - __sap_general_preconfigure_register_subscription_manager_release.stdout == ansible_distribution_version
 
 - name: Set the minor RHEL release
   command: subscription-manager release --set="{{ ansible_distribution_version }}"
   when:
-    - __sap_general_preconfigure_register_subscription_manager_release.stdout != ansible_distribution_version
     - sap_general_preconfigure_set_minor_release
+    - __sap_general_preconfigure_register_subscription_manager_release.stdout != ansible_distribution_version
 
 - name: Ensure that the required package groups are installed, RHEL 7
   command: "yum install {{ sap_general_preconfigure_packagegroups|join(' ') }} -y"

--- a/roles/sap_general_preconfigure/tests/sap_general_preconfigure-default-settings.yml
+++ b/roles/sap_general_preconfigure/tests/sap_general_preconfigure-default-settings.yml
@@ -1,4 +1,6 @@
 ---
 - hosts: all
+  collections:
+    - community.sap_install
   roles:
-    - role: sap_general_preconfigure
+    - sap_general_preconfigure

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -192,51 +192,53 @@ You can find more complex playbooks in directory `playbooks` of the collection `
 
 #### Pre-Install 
 
-- Set all passwords to follow master password if set to 'y'
+- Set all passwords to follow master password if set to 'y'.
 
-- Prepare software located in directory `sap_hana_install_software_directory`
+- Prepare software located in directory `sap_hana_install_software_directory`:
 
-    - If file `hdblcm` is found, proceed to 4.
+    - If file `hdblcm` is found, skip the next step and proceed with the `hdblcm` existence check.
 
-    - If not, proceed to 3.
+    - If file `hdblcm` ist not found, proceed with the next step.
 
-- Prepare .SAR files for `hdblcm` 
+- Prepare SAR files for `hdblcm`:
 
-    - Get all .SAR files from `sap_hana_install_software_directory`
+    - Get the correct SAPCAR executable from `sap_hana_install_software_directory` in case its file name is not provided by role variable.
 
-    - Extract all .SAR files from `sap_hana_install_software_directory`
+    - Get all SAR files from `sap_hana_install_software_directory` or use the SAR files provided by role variable.
 
-- Check existence of `hdblcm` in `SAP_HANA_DATABASE` directory from the extracted SAR files
+    - Extract all SAR files from `sap_hana_install_software_directory`.
 
-- Process SAP HANA `configfile` based on input parameters
+- Check existence of `hdblcm` in `SAP_HANA_DATABASE` directory from the extracted SAR files.
+
+- Process SAP HANA `configfile` based on input parameters.
 
 #### SAP HANA Install
 
-- Execute hdblcm
+- Execute hdblcm.
 
 #### Post-Install
 
-- Create and Store Connection Info in hdbuserstore
+- Create and Store Connection Info in hdbuserstore.
 
-- Set Log Mode key to overwrite value and apply to system
+- Set Log Mode key to overwrite value and apply to system.
 
-- Apply SAP HANA license to the new deployed instance if set to 'y'
+- Apply SAP HANA license to the new deployed instance if set to `y`.
 
-- Set expiry of Unix created users to 'never'
+- Set expiry of Unix created users to `never`.
 
-- Update `/etc/hosts` (optional - yes by default)
+- Update `/etc/hosts` (optional - `yes` by default).
 
-- Apply firewall rules (optional - no by default)
+- Apply firewall rules (optional - `no` by default).
 
-- Generate input file for `sap_swpm`
+- Generate input file for `sap_swpm`.
 
-- Print a short summary of the result of the installation
+- Print a short summary of the result of the installation.
 
 ### Add hosts to an existing SAP HANA Installation
 
 #### Pre-Install 
 
-- Process SAP HANA `configfile` based on input parameters
+- Process SAP HANA configfile based on input parameters.
 
 #### SAP HANA Add Hosts
 
@@ -246,8 +248,8 @@ You can find more complex playbooks in directory `playbooks` of the collection `
   - an entry in the output of `./hdblcm --list_systems`
   If any of the above is true, abort the role.
 
-- Execute hdblcm
+- Execute hdblcm.
 
 #### Post-Install
 
-- Print a short summary of the result of the installation
+- Print a short summary of the result of the installation.

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -42,31 +42,30 @@ Place the following files in directory /software/hana or in any other directory 
     -rwxr-xr-x. 1 nobody nobody   89285401 Sep 30 04:24 SAPHOSTAGENT51_51-20009394.SAR
     ```
 
-For security reasons, it is recommended to specify the file names and checksums of the SAPCAR EXE file and the
-SAR files in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find
-examples for these in file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info"
-page for each SAP software package in the SAP software center.
+If more than one SAPCAR EXE file is present in the software directory, the role will select the latest version
+for the current hardware architecture. Alternatively, the file name of the SAPCAR EXE file can also be set with
+variable `sap_hana_install_sapcar_filename`. Example:
+```
+sap_hana_install_sapcar_filename: SAPCAR_1115-70006178.EXE
+```
+
+If more than one SAR file for a certain software product is present in the software directory, the automatic
+handling of such SAR files will fail after extraction, when moving the newly created product directories
+(like `SAP_HOST_AGENT`) to already existing destinations.
+For avoiding such situations, use following variable to provide a list of SAR files to extract:
+`sap_hana_install_sarfiles_list`.
 
 Example:
 ```
-sap_hana_install_sapcar_file:
-- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
-sap_hana_install_sarfiles:
-- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
-- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
+sap_hana_install_sarfiles_list:
+  - SAPHOSTAGENT54_54-80004822.SAR
+  - IMDB_SERVER20_060_0-80002031.SAR
 ```
 
-For the SAPCAR EXE file and the SAR files to be installed, a file named `<filename>.sha256sum` containing
-the output of the sha256sum command will be created by the role if it does not yet exist in the software
-download directory `sap_hana_install_software_directory`.
-
-If variable `sap_hana_install_sapcar_file` is not specified, the role will attempt to automatically detect the
-SAPCAR EXE file in the software directory which matches the architecture, and choose the latest available version.
-
-If variable `sap_hana_install_sarfiles` is not specified, the role will extract all SAR files found in the
-software directory, and use them for installation. If more than one version of the same software is found,
-the attempt to move the extracted files from any consecutive SAR file to its final destination in
-`sap_hana_install_software_extract_directory` will fail.
+If there is a file named `<filename>.sha256sum` in the software download directory
+`sap_hana_install_software_directory` which contains the checksum and the file name similar to the output
+of the sha256sum command, the role will examine the sha256sum for the corresponding SAPCAR or SAR file and the
+processing will continue only if the checksum matches.
 
 #### Extracted SAP HANA Software Installation Files
 

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -42,10 +42,10 @@ Place the following files in directory /software/hana or in any other directory 
     -rwxr-xr-x. 1 nobody nobody   89285401 Sep 30 04:24 SAPHOSTAGENT51_51-20009394.SAR
     ```
 
-For security reasons, the file names and checksums of the SAPCAR EXE file and the SAR files need to be specified
-in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find exanples in
-file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info" page for each SAP
-software package in the SAP software center.
+For security reasons, it is recommended to specify the file names and checksums of the SAPCAR EXE file and the
+SAR files in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find
+examples for these in file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info"
+page for each SAP software package in the SAP software center.
 
 Example:
 ```
@@ -59,6 +59,14 @@ sap_hana_install_sarfiles:
 For the SAPCAR EXE file and the SAR files to be installed, a file named `<filename>.sha256sum` containing
 the output of the sha256sum command will be created by the role if it does not yet exist in the software
 download directory `sap_hana_install_software_directory`.
+
+If variable `sap_hana_install_sapcar_file` is not specified, the role will attempt to automatically detect the
+SAPCAR EXE file in the software directory which matches the architecture, and choose the latest available version.
+
+If variable `sap_hana_install_sarfiles` is not specified, the role will extract all SAR files found in the
+software directory, and use them for installation. If more than one version of the same software is found,
+the attempt to move the extracted files from any consecutive SAR file to its final destination in
+`sap_hana_install_software_extract_directory` will fail.
 
 #### Extracted SAP HANA Software Installation Files
 

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -32,7 +32,7 @@ Place the following files in directory /software/hana or in any other directory 
 
 - Sample directory `sap_hana_install_software_directory` containing SAP HANA software installation files
     ```console
-    [root@hanahost SAP_HANA_INSTALLATION]# ll -lrt
+    [root@hanahost SAP_HANA_INSTALLATION]# ls -l *.EXE *.SAR
     -rwxr-xr-x. 1 nobody nobody  149561376 Mar  4  2021 IMDB_AFL20_054_1-80001894.SAR
     -rwxr-xr-x. 1 nobody nobody  211762405 Mar  4  2021 IMDB_CLIENT20_007_23-80002082.SAR
     -rwxr-xr-x. 1 nobody nobody    4483040 Mar  4  2021 SAPCAR_1010-70006178.EXE
@@ -42,22 +42,23 @@ Place the following files in directory /software/hana or in any other directory 
     -rwxr-xr-x. 1 nobody nobody   89285401 Sep 30 04:24 SAPHOSTAGENT51_51-20009394.SAR
     ```
 
-If more than one SAPCAR EXE file is present in the software directory, the role will select the latest version
-for the current hardware architecture. Alternatively, the file name of the SAPCAR EXE file can also be set with
-variable `sap_hana_install_sapcar_filename`.
-
-If more than one SAR file for a certain software product is present in the software directory, the automatic
-handling of such SAR files will fail after extraction, when moving the newly created product directories
-(like `SAP_HOST_AGENT`) to already existing destinations.
-For avoiding such situations, use following variable to provide a list of SAR files to extract:
-`sap_hana_install_sarfiles_list`.
+For security reasons, the file names and checksums of the SAPCAR EXE file and the SAR files need to be specified
+in two role variables: `sap_hana_install_sapcar_file` and `sap_hana_install_sarfiles`. You can find exanples in
+file `defaults/main.yml`. The checksums can be found in the "Related Info" -> "Content Info" page for each SAP
+software package in the SAP software center.
 
 Example:
 ```
-sap_hana_install_sarfiles_list:
-  - SAPHOSTAGENT54_54-80004822.SAR
-  - IMDB_SERVER20_060_0-80002031.SAR
+sap_hana_install_sapcar_file:
+- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
+sap_hana_install_sarfiles:
+- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
+- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
 ```
+
+For the SAPCAR EXE file and the SAR files to be installed, a file named `<filename>.sha256sum` containing
+the output of the sha256sum command will be created by the role if it does not yet exist in the software
+download directory `sap_hana_install_software_directory`.
 
 #### Extracted SAP HANA Software Installation Files
 

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -10,25 +10,14 @@ sap_hana_install_software_directory: '/software/hana'
 # Note: This directory will be removed and created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
-# File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
-#sap_hana_install_sapcar_filename: SAPCAR_1234-12345678.EXE
-
 # File name and checksum of SAPCAR EXE file:
 sap_hana_install_sapcar_file:
-# x86_64:
- - { name: 'SAPCAR_1115-70006178.EXE', checksum: '765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5' } # SAPCAR 7.22
-# ppc64le:
-# - { name: 'SAPCAR_1115-70006238.EXE', checksum: 'efd23b616e7b8745a72d11b3b497ce6c93a4bbc24d3f12349b51db05b9cac4a3' } # SAPCAR 7.22
+- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
 
+# File name and checksum of SAR files:
 sap_hana_install_sarfiles:
-# x86_64:
-  - { name: 'IMDB_SERVER20_060_0-80002031.SAR', checksum: '7d58473d0f0b03edc3be27465b562688c44c0ddde7e44d5d89c0c64606503e87' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
-#  - { name: 'SAPHOSTAGENT54_54-80004822.SAR', checksum: '5899a0934bd8d37a887d0d67de6ac0520f907a66ff7c3bc79176fff99171a878' } # SAP HOST AGENT 7.22 SP54
-
-#  ppc64le:
-#  - { name: 'IMDB_SERVER20_060_0-80002046.SAR' , checksum: '9d32042496fb010901e56571110825807612e898412eba54704528f73c57aa22' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
-#  - { name: 'SAPHOSTAGENT54_54-80004831.SAR', checksum: '5d54fde8fc470df01820e86ac3105501b8cd6715fd2fab43787d4c9fb0139d49' } # SAP HOST AGENT 7.22 SP54
-
+- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
+- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -13,11 +13,22 @@ sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_direc
 # File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
 #sap_hana_install_sapcar_filename: SAPCAR_1234-12345678.EXE
 
-# List of file names of SAR files to extract. Can be set in case there are more SAR files in the software directory
-# than needed or desired for the HANA installation
-#sap_hana_install_sarfiles_list:
-#  - SAPHOSTAGENT54_54-80004822.SAR
-#  - IMDB_SERVER20_060_0-80002031.SAR
+# File name and checksum of SAPCAR EXE file:
+sap_hana_install_sapcar_file:
+# x86_64:
+ - { name: 'SAPCAR_1115-70006178.EXE', checksum: '765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5' } # SAPCAR 7.22
+# ppc64le:
+# - { name: 'SAPCAR_1115-70006238.EXE', checksum: 'efd23b616e7b8745a72d11b3b497ce6c93a4bbc24d3f12349b51db05b9cac4a3' } # SAPCAR 7.22
+
+sap_hana_install_sarfiles:
+# x86_64:
+  - { name: 'IMDB_SERVER20_060_0-80002031.SAR', checksum: '7d58473d0f0b03edc3be27465b562688c44c0ddde7e44d5d89c0c64606503e87' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
+#  - { name: 'SAPHOSTAGENT54_54-80004822.SAR', checksum: '5899a0934bd8d37a887d0d67de6ac0520f907a66ff7c3bc79176fff99171a878' } # SAP HOST AGENT 7.22 SP54
+
+#  ppc64le:
+#  - { name: 'IMDB_SERVER20_060_0-80002046.SAR' , checksum: '9d32042496fb010901e56571110825807612e898412eba54704528f73c57aa22' } # Revision 2.00.060.0 (SPS06) for HANA DB 2.0
+#  - { name: 'SAPHOSTAGENT54_54-80004831.SAR', checksum: '5d54fde8fc470df01820e86ac3105501b8cd6715fd2fab43787d4c9fb0139d49' } # SAP HOST AGENT 7.22 SP54
+
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -11,13 +11,13 @@ sap_hana_install_software_directory: '/software/hana'
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
 # File name and checksum of SAPCAR EXE file:
-sap_hana_install_sapcar_file:
-- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
+#sap_hana_install_sapcar_file:
+#- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
 
 # File name and checksum of SAR files:
-sap_hana_install_sarfiles:
-- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
-- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
+#sap_hana_install_sarfiles:
+#- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
+#- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -10,14 +10,14 @@ sap_hana_install_software_directory: '/software/hana'
 # Note: This directory will be removed and created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
-# File name and checksum of SAPCAR EXE file:
-#sap_hana_install_sapcar_file:
-#- { name: 'SAPCAR_XXXX-XXXXXXXX.EXE', checksum: 'XXX' }
+# File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
+#sap_hana_install_sapcar_filename: SAPCAR_1115-70006178.EXE
 
-# File name and checksum of SAR files:
-#sap_hana_install_sarfiles:
-#- { name: 'IMDB_SERVERXXXXX_X-XXXXXXXX.SAR', checksum: 'XXX' }
-#- { name: 'SAPHOSTAGENTXXXXX-XXXXXXXX.SAR', checksum: 'XXX' }
+# List of file names of SAR files to extract. Can be set in case there are more SAR files in the software directory
+# than needed or desired for the HANA installation
+#sap_hana_install_sarfiles_list:
+#  - SAPHOSTAGENT54_54-80004822.SAR
+#  - IMDB_SERVER20_060_0-80002031.SAR
 
 # If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `yes`.

--- a/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
+++ b/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
@@ -7,17 +7,17 @@
 
 - name: SAP HANA Add Hosts - Show the path name of the instance profile
   debug:
-    msg: "Instance profile: /hana/shared/{{ sap_hana_install_sid }}/profile/\
-          {{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}_{{ line_item }}"
+    msg: "Instance profile: '/hana/shared/{{ sap_hana_install_sid }}/profile/\
+          {{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}_{{ line_item }}'"
 
 - name: SAP HANA Add Hosts - Assert that there is no instance profile for the addional hosts
   assert:
     that: not __sap_hana_install_register_instance_profile_addhost.stat.exists
     fail_msg:
-      - "FAIL: There is already an instance profile for host {{ line_item }}, at location:"
-      - "  /hana/shared/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}_{{ line_item }} ."
+      - "FAIL: There is already an instance profile for host '{{ line_item }}', at location:"
+      - "  '/hana/shared/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}_{'{ line_item }}."
       - "Because of this, the addhost operation will not be performed."
-    success_msg: "PASS: No instance profile was found for host {{ line_item }}."
+    success_msg: "PASS: No instance profile was found for host '{{ line_item }}'."
 
 - name: SAP HANA Add Hosts - Check for SAP HANA instance directory in '/usr/sap'
   stat:
@@ -26,13 +26,13 @@
 
 - name: SAP HANA Add Hosts - Show the path name of the instance directory in '/usr/sap'
   debug:
-    msg: "Instance directory in /usr/sap: /usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_instance_number }}/{{ line_item }}"
+    msg: "Instance directory in /usr/sap: '/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_instance_number }}/{{ line_item }}'"
 
 - name: SAP HANA Add Hosts - Assert that there is no SAP HANA instance directory in '/usr/sap' for the addional hosts
   assert:
     that: not __sap_hana_install_register_usr_sap_instance_directory.stat.exists
     fail_msg:
-      - "FAIL: There is already an instance directory for host {{ sap_hana_install_addhosts.split(':')[0] }}, at location:"
-      - "  /usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_instance_number }}/{{ line_item }} ."
+      - "FAIL: There is already an instance directory for host '{{ sap_hana_install_addhosts.split(':')[0] }}', at location:"
+      - "  '/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_instance_number }}/{{ line_item }}' ."
       - "Because of this, the addhost operation will not be performed."
-    success_msg: "PASS: No instance directory was found for host {{ line_item }} in /usr/sap."
+    success_msg: "PASS: No instance directory was found for host '{{ line_item }}' in /usr/sap."

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -47,6 +47,8 @@
       loop_control:
         loop_var: line_item
 
+  when: not ansible_check_mode
+
 - name: SAP HANA Add Hosts - Add hosts to the existing SAP HANA installation
   command: "./hdblcm {{ sap_hana_install_hdblcm_extraargs }}
             --action=add_hosts
@@ -58,10 +60,12 @@
   args:
     chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
   changed_when: "'SAP HANA Lifecycle Management' in __sap_hana_install_register_hdblcm_add_hosts.stdout"
+  when: not ansible_check_mode
 
 - name: SAP HANA Add Hosts - Show the result of hdblcm add_hosts
   debug:
     var: __sap_hana_install_register_hdblcm_add_hosts.stdout
+  when: not ansible_check_mode
 
 - name: SAP HANA Add Hosts - Run 'hdblcm --list_systems' after the installation
   shell: |
@@ -76,7 +80,9 @@
     chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
   register: __sap_hana_install_register_addhosts_result
   changed_when: no
+  when: not ansible_check_mode
 
 - name: SAP HANA Add Hosts - Show the HANA version and hosts
   debug:
     msg: "HANA system '{{ sap_hana_install_sid }}': {{ __sap_hana_install_register_addhosts_result.stdout }}"
+  when: not ansible_check_mode

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -22,7 +22,7 @@
 - name: SAP HANA Add Hosts - Make sure the additional hosts are not yet part of the exiting SAP HANA system - hdblcm checks
   block:
 
-    - name: SAP HANA Add Hosts - Run hdblcm --list_systems
+    - name: SAP HANA Add Hosts - Run 'hdblcm --list_systems'
       shell: |
         ./hdblcm --list_systems | awk '/\/hana\/shared\/{{ sap_hana_install_sid }}/{a=1}
           /hosts:/{if (a==1){
@@ -63,7 +63,7 @@
   debug:
     var: __sap_hana_install_register_hdblcm_add_hosts.stdout
 
-- name: SAP HANA Add Hosts - Run hdblcm --list_systems after the installation
+- name: SAP HANA Add Hosts - Run 'hdblcm --list_systems' after the installation
   shell: |
       set -o pipefail && ./hdblcm --list_systems | awk '/\/hana\/shared\/{{ sap_hana_install_sid }}/{a=1}
       /version:/{if (a==1){

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -11,7 +11,7 @@
 
 - name: SAP HANA Add Hosts - Show the additional hosts to be added
   debug:
-    msg: "Additional hosts: {{ __sap_hana_install_addhosts_hosts }}"
+    msg: "Additional hosts: '{{ __sap_hana_install_addhosts_hosts }}'"
 
 - name: SAP HANA Add Hosts - Make sure the additional hosts are not yet part of the exiting SAP HANA system - file checks
   include_tasks: assert-addhosts-loop-block.yml
@@ -40,7 +40,7 @@
       assert:
         that: "'{{ line_item }}' not in __sap_hana_install_register_hdblcm_list_systems.stdout"
         fail_msg:
-          - "FAIL: Host {{ line_item }} is already part of system '{{ sap_hana_install_sid }}'"
+          - "FAIL: Host '{{ line_item }}' is already part of system '{{ sap_hana_install_sid }}'"
           - "Because of this, the addhost operation will not be performed."
         success_msg: "PASS: Host '{{ line_item }}' is not yet part of system '{{ sap_hana_install_sid }}'."
       loop: "{{ __sap_hana_install_addhosts_hosts }}"
@@ -79,4 +79,4 @@
 
 - name: SAP HANA Add Hosts - Show the HANA version and hosts
   debug:
-    msg: "HANA system {{ sap_hana_install_sid }}: {{ __sap_hana_install_register_addhosts_result.stdout }}"
+    msg: "HANA system '{{ sap_hana_install_sid }}': {{ __sap_hana_install_register_addhosts_result.stdout }}"

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -12,9 +12,9 @@
     - name: Assert that there is no sidadm user # noqa var-spacing
       assert:
         that: __sap_hana_install_register_getent_passwd_sidadm.rc != 0
-        fail_msg: "FAIL: User {{ sap_hana_install_sid | lower}}adm exists.
-                   Because of this, SAP HANA with SID {{ sap_hana_install_sid }} will not be installed."
-        success_msg: "PASS: User {{ sap_hana_install_sid | lower}}adm does not exist."
+        fail_msg: "FAIL: User '{{ sap_hana_install_sid | lower}}adm' exists!
+                   Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
+        success_msg: "PASS: User '{{ sap_hana_install_sid | lower}}adm' does not exist."
 
   when: sap_hana_install_check_sidadm_user|d(true)
 
@@ -31,11 +31,11 @@
     - name: In case there is a group sapsys, assert that its group ID is identical to sap_hana_install_groupid
       assert:
         that: "{{ __sap_hana_install_register_getent_group_sapsys.stdout.split(':')[2] }} == {{ sap_hana_install_groupid }}"
+        success_msg: "PASS: The group ID of 'sapsys' is identical to the value of variable
+                      sap_hana_install_groupid, which is '{{ sap_hana_install_groupid }}'"
         fail_msg: "FAIL: Group sapsys exists but with a different group ID than '{{ sap_hana_install_groupid }}',
 	           which has been specified in variable sap_hana_install_groupid.
 	           Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
-        success_msg: "PASS: The group is of sapsys is identical to the value of variable
-                      sap_hana_install_groupid, which is '{{ sap_hana_install_groupid }}'"
       when: __sap_hana_install_register_getent_group_sapsys.rc == 0
 
   when:
@@ -52,7 +52,7 @@
 - name: "Assert that directory '/hana/shared/{{ sap_hana_install_sid }}' does not exist"
   assert:
     that: not __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
-    fail_msg: "FAIL: Directory '/hana/shared/{{ sap_hana_install_sid }}' exists.
+    fail_msg: "FAIL: Directory '/hana/shared/{{ sap_hana_install_sid }}' exists!
                Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
     success_msg: "PASS: Directory '/hana/shared/{{ sap_hana_install_sid }}' does not exist."
 
@@ -65,7 +65,7 @@
 - name: "Assert that directory '/usr/sap/{{ sap_hana_install_sid }}' does not exist"
   assert:
     that: not __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
-    fail_msg: "FAIL: Directory '/usr/sap/{{ sap_hana_install_sid }}' exists.
+    fail_msg: "FAIL: Directory '/usr/sap/{{ sap_hana_install_sid }}' exists!
                Because of this, SAP HANA with SID '{{ sap_hana_install_sid }}' will not be installed."
     success_msg: "PASS: Directory '/usr/sap/{{ sap_hana_install_sid }}' does not exist."
 

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -4,6 +4,7 @@
   block:
     - name: Check for sidadm user
       command: getent passwd {{ sap_hana_install_sid | lower }}adm
+      check_mode: no
       register: __sap_hana_install_register_getent_passwd_sidadm
       changed_when: no
       failed_when: no
@@ -22,8 +23,10 @@
 # The SAP HANA installation will fail if there is already a group named sapsys but with a different ID. Let's better fail before.
 - name: Check HANA admin group
   block:
+
     - name: Get info about the ID of the sapsys group
       command: getent group sapsys
+      check_mode: no
       register: __sap_hana_install_register_getent_group_sapsys
       changed_when: no
       failed_when: no
@@ -46,6 +49,7 @@
 - name: "Get info about directory '/hana/shared/{{ sap_hana_install_sid }}'"
   stat:
     path: "/hana/shared/{{ sap_hana_install_sid }}"
+  check_mode: no
   register: __sap_hana_install_register_stat_hana_shared_sid_assert
   failed_when: no
 
@@ -59,6 +63,7 @@
 - name: "Get info about directory '/usr/sap/{{ sap_hana_install_sid }}'"
   stat:
     path: "/usr/sap/{{ sap_hana_install_sid }}"
+  check_mode: no
   register: __sap_hana_install_register_stat_usr_sap_sid_assert
   failed_when: no
 

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Warn if the role is used without specifying SAPCAR executable and SAR files
+  debug:
+    msg: "WARN: The role is used without variables 'sap_hana_install_sapcar_file'
+          or 'sap_hana_install_sarfiles' being configured, so the SAPCAR executable
+          and the SAR files in directory {{ sap_hana_install_software_directory }}
+          will be determined automatically."
+  when: sap_hana_install_sapcar_file is undefined or
+        sap_hana_install_sarfiles is undefined
+
 - import_tasks: hana_exists.yml
   when: sap_hana_install_new_system|d(true)
 

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -1,20 +1,5 @@
 ---
 
-- name: Notify if the role is used without specifying the SAPCAR executable
-  debug:
-    msg: "INFO: The role is used without variable 'sap_hana_install_sapcar_file'
-          being configured, so the SAPCAR executable in directory
-          {{ sap_hana_install_software_directory }} will be determined automatically."
-  when: sap_hana_install_sapcar_file is undefined
-
-- name: Notify if the role is used without specifying SAR files
-  debug:
-    msg: "INFO: The role is used without variable 'sap_hana_install_sarfiles'
-          being configured, so all SAR files in directory
-          {{ sap_hana_install_software_directory }} will be extracted
-          and used for the installation."
-  when: sap_hana_install_sarfiles is undefined
-
 - import_tasks: hana_exists.yml
   when: sap_hana_install_new_system|d(true)
 

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -1,13 +1,19 @@
 ---
 
-- name: Warn if the role is used without specifying SAPCAR executable and SAR files
+- name: Notify if the role is used without specifying the SAPCAR executable
   debug:
-    msg: "WARN: The role is used without variables 'sap_hana_install_sapcar_file'
-          or 'sap_hana_install_sarfiles' being configured, so the SAPCAR executable
-          and the SAR files in directory {{ sap_hana_install_software_directory }}
-          will be determined automatically."
-  when: sap_hana_install_sapcar_file is undefined or
-        sap_hana_install_sarfiles is undefined
+    msg: "INFO: The role is used without variable 'sap_hana_install_sapcar_file'
+          being configured, so the SAPCAR executable in directory
+          {{ sap_hana_install_software_directory }} will be determined automatically."
+  when: sap_hana_install_sapcar_file is undefined
+
+- name: Notify if the role is used without specifying SAR files
+  debug:
+    msg: "INFO: The role is used without variable 'sap_hana_install_sarfiles'
+          being configured, so all SAR files in directory
+          {{ sap_hana_install_software_directory }} will be extracted
+          and used for the installation."
+  when: sap_hana_install_sarfiles is undefined
 
 - import_tasks: hana_exists.yml
   when: sap_hana_install_new_system|d(true)

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -61,14 +61,17 @@
     chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
   register: __sap_hana_install_register_install_result
   changed_when: no
+  when: not ansible_check_mode
 
 - name: Set fact - HANA version
   set_fact:
     __sap_hana_install_fact_hana_version: "{{ __sap_hana_install_register_install_result.stdout.split(';')[0] }}"
+  when: not ansible_check_mode
 
 - name: Set fact - HANA hosts
   set_fact:
     __sap_hana_install_fact_hana_hosts: "{{ __sap_hana_install_register_install_result.stdout.split(';')[1] }}"
+  when: not ansible_check_mode
 
 - name: SAP HANA Deployment - Finished
   debug:
@@ -83,3 +86,4 @@
 #      - '  IP               -       {{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}'
 #      - '  Host             -       {{ ansible_hostname }}'
 #      - '  FQDN             -       {{ ansible_fqdn }}'
+  when: not ansible_check_mode

--- a/roles/sap_hana_install/tasks/post_install/hdbuserstore.yml
+++ b/roles/sap_hana_install/tasks/post_install/hdbuserstore.yml
@@ -10,6 +10,5 @@
      executable: /bin/bash
   become: true
   become_user: "{{ sap_hana_install_sid | lower }}adm"
+  when: not ansible_check_mode
   changed_when: no
-# variable not used:
-#  register: __sap_hana_install_register_post_install_hdbuserstore

--- a/roles/sap_hana_install/tasks/post_install/log_mode.yml
+++ b/roles/sap_hana_install/tasks/post_install/log_mode.yml
@@ -17,6 +17,5 @@
      executable: /bin/bash
   become: true
   become_user: "{{ sap_hana_install_sid | lower }}adm"
+  when: not ansible_check_mode
   changed_when: no
-# Variable not used:
-#  register: __sap_hana_install_register_post_install_log_mode

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -24,6 +24,7 @@
     - name: SAP HANA Pre Install - Check availability of software directory '{{ sap_hana_install_software_directory }}'
       stat:
         path: "{{ sap_hana_install_software_directory }}"
+      check_mode: no
       register: __sap_hana_install_register_stat_software_directory
       failed_when: no
 
@@ -58,6 +59,7 @@
     - name: SAP HANA Pre Install - Get info about software extract directory '{{ sap_hana_install_software_extract_directory }}'
       stat:
         path: "{{ sap_hana_install_software_extract_directory }}"
+      check_mode: no
       register: __sap_hana_install_register_stat_software_extract_directory
       failed_when: no
 
@@ -87,6 +89,7 @@
         - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm' if found initially
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
+          check_mode: no
           register: __sap_hana_install_register_stat_hdblcm_initial
           failed_when: no
 
@@ -113,6 +116,7 @@
         - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm'
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
+          check_mode: no
           register: __sap_hana_install_register_stat_hdblcm
           failed_when: no
 
@@ -135,6 +139,12 @@
     state: directory
     suffix: hanaconfig
   register: __sap_hana_install_register_tmpdir
+
+- name: SAP HANA Pre Install - Fill variable __sap_hana_install_register_tmpdir for check mode only
+  set_fact:
+    __sap_hana_install_register_tmpdir:
+      path: '/tmp'
+  when: ansible_check_mode
 
 - name: SAP HANA Pre Install - Process HANA configfile template
   template:

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -84,7 +84,7 @@
           set_fact:
             __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0].path }}"
 
-        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' if found initially
+        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm' if found initially
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
           register: __sap_hana_install_register_stat_hdblcm_initial
@@ -110,7 +110,7 @@
           debug:
             var: __sap_hana_install_fact_hdblcm_path
 
-        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}'
+        - name: SAP HANA Pre Install - Get info about '{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm'
           stat:
             path: "{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}"
           register: __sap_hana_install_register_stat_hdblcm

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -62,7 +62,7 @@
       failed_when: no
 
 # In case more than on installation is ongoing and extracting to the same shared directory, wait until the extraction has completed:
-    - name: SAP HANA Pre Install - Proceed if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' is absent
+    - name: SAP HANA Pre Install - Suspending if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' exists
       wait_for:
         path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
         state: absent

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -23,27 +23,32 @@
   debug:
     msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
 
-- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
-  stat:
-    path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-  register: __sap_hana_install_register_sarfile_sha256sum_stat_result
-  changed_when: no
-  failed_when: no
+- name: SAP HANA hdblcm prepare - Verify checksum for SAR file
+  block:
 
-- name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
-  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-  when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
+    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
+      stat:
+        path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+      register: __sap_hana_install_register_sarfile_sha256sum_stat_result
+      changed_when: no
+      failed_when: no
 
-- name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
-  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-  register: __sap_hana_install_register_sarfile_sha256sum
-  changed_when: no
+    - name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
+      shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+      when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
 
-- name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
-  assert:
-    that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
-    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
-    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+    - name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
+      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+      register: __sap_hana_install_register_sarfile_sha256sum
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
+      assert:
+        that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
+        fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
+        success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+
+  when: sap_hana_install_sarfiles is defined
 
 - name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar.name }}'
   command: >-
@@ -75,4 +80,3 @@
   ansible.builtin.file:
     path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -26,6 +26,7 @@
 - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'
   stat:
     path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum"
+  check_mode: no
   register: __sap_hana_install_register_sarfile_sha256sum_stat_result
   changed_when: no
 
@@ -41,6 +42,7 @@
 
     - name: SAP HANA hdblcm prepare - Read the sha256sum from the checksum file
       command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum"
+      check_mode: no
       register: __sap_hana_install_register_sarfile_sha256sum_from_file
       changed_when: no
 

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -19,11 +19,26 @@
     group: root
   when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
-- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar }}'
+- name: Display name and checksum of SAR file
+  debug:
+    msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
+
+- name: SAP HANA hdblcm prepare - Get sha256sum of the SAR file
+  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+  register: __sap_hana_install_register_sarfile_sha256sum
+  changed_when: no
+
+- name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
+  assert:
+    that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
+    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
+    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+
+- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar.name }}'
   command: >-
     {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} \
     -R {{ __sap_hana_install_tmp_software_extract_directory }} \
-    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }} \
+    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} \
     -manifest SIGNATURE.SMF
   register: __sap_hana_install_register_extract
   args:
@@ -37,13 +52,13 @@
     mv ${extracted_dir} ..
   args:
     chdir: "{{ __sap_hana_install_tmp_software_extract_directory }}"
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Move files into the correct place, SAP Host Agent
   command: mv ./tmp/SAP_HOST_AGENT .
   args:
     chdir: "{{ sap_hana_install_software_extract_directory }}"
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Remove temporary extraction directory '{{ sap_hana_install_software_extract_directory }}/tmp'
   ansible.builtin.file:

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -3,12 +3,12 @@
 - name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, default
   set_fact:
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp"
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, SAP Host Agent
   set_fact:
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp/SAP_HOST_AGENT"
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
 
 - name: SAP HANA hdblcm prepare - Create temporary extraction destination '{{ __sap_hana_install_tmp_software_extract_directory }}'
   ansible.builtin.file:
@@ -17,13 +17,24 @@
     mode: 0755
     owner: root
     group: root
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
 
 - name: Display name and checksum of SAR file
   debug:
     msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
 
-- name: SAP HANA hdblcm prepare - Get sha256sum of the SAR file
+- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+  register: __sap_hana_install_register_sarfile_sha256sum_stat_result
+  changed_when: no
+  failed_when: no
+
+- name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
+  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
+  when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
+
+- name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
   command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
   register: __sap_hana_install_register_sarfile_sha256sum
   changed_when: no
@@ -64,3 +75,4 @@
   ansible.builtin.file:
     path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -3,12 +3,12 @@
 - name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, default
   set_fact:
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp"
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
 
 - name: SAP HANA hdblcm prepare - Set fact for temporary extraction destination, SAP Host Agent
   set_fact:
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp/SAP_HOST_AGENT"
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
 - name: SAP HANA hdblcm prepare - Create temporary extraction destination '{{ __sap_hana_install_tmp_software_extract_directory }}'
   ansible.builtin.file:
@@ -17,44 +17,60 @@
     mode: 0755
     owner: root
     group: root
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
-- name: Display name and checksum of SAR file
+- name: Display the name of the SAR file
   debug:
-    msg: "Name and checksum of SAR file: {{ passed_sap_hana_install_components_sar.name }}, {{ passed_sap_hana_install_components_sar.checksum }}"
+    msg: "Name of SAR file: '{{ passed_sap_hana_install_components_sar }}'"
 
-- name: SAP HANA hdblcm prepare - Verify checksum for SAR file
+- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum"
+  register: __sap_hana_install_register_sarfile_sha256sum_stat_result
+  changed_when: no
+
+- name: SAP HANA hdblcm prepare - Notify if checksum verification will be skipped for SAR file
+  debug:
+    msg: "INFO: File '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sh256sum' does not exist,
+          so no checksum verification will be performed for file
+          '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'."
+  when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
+
+- name: SAP HANA hdblcm prepare - Verify checksum for SAR file if checksum file exists
   block:
 
-    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum'
-      stat:
-        path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-      register: __sap_hana_install_register_sarfile_sha256sum_stat_result
+    - name: SAP HANA hdblcm prepare - Read the sha256sum from the checksum file
+      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum"
+      register: __sap_hana_install_register_sarfile_sha256sum_from_file
       changed_when: no
-      failed_when: no
 
-    - name: SAP HANA hdblcm prepare - Create checksum file for the SAR file if it does not exist
-      shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} > {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-      when: not __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
-
-    - name: SAP HANA hdblcm prepare - Get sha256sum from the SAR file
-      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}.sha256sum"
-      register: __sap_hana_install_register_sarfile_sha256sum
+    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'
+      stat:
+        path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}"
+        checksum_algorithm: sha256
+      register: __sap_hana_install_register_sarfile_stat_result
       changed_when: no
 
     - name: SAP HANA hdblcm prepare - Assert that the checksum of the SAR file is correct
       assert:
-        that: __sap_hana_install_register_sarfile_sha256sum.stdout == passed_sap_hana_install_components_sar.checksum
-        fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' does not match the content of variable sap_hana_install_sarfiles[].checksum."
-        success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }}' matches the content of variable sap_hana_install_sarfiles[].checksum."
+        that: __sap_hana_install_register_sarfile_stat_result.stat.checksum ==
+              __sap_hana_install_register_sarfile_sha256sum_from_file.stdout.split(' ').0
+        fail_msg: "FAIL: The checksum of file
+           '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'
+           does not match the checksum stored in file
+           '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'!"
+        success_msg: "PASS: The checksum of file
+           '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'
+           matches the checksum stored in file
+           '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'."
 
-  when: sap_hana_install_sarfiles is defined
+  when: __sap_hana_install_register_sarfile_sha256sum_stat_result.stat.exists
 
-- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar.name }}'
+- name: SAP HANA hdblcm prepare - Extracting file '{{ passed_sap_hana_install_components_sar }}'
   command: >-
-    {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} \
+    {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }} \
     -R {{ __sap_hana_install_tmp_software_extract_directory }} \
-    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar.name }} \
+    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }} \
     -manifest SIGNATURE.SMF
   register: __sap_hana_install_register_extract
   args:
@@ -68,13 +84,13 @@
     mv ${extracted_dir} ..
   args:
     chdir: "{{ __sap_hana_install_tmp_software_extract_directory }}"
-  when: "'SAPHOST' not in passed_sap_hana_install_components_sar.name"
+  when: "'SAPHOST' not in passed_sap_hana_install_components_sar"
 
 - name: SAP HANA hdblcm prepare - Move files into the correct place, SAP Host Agent
   command: mv ./tmp/SAP_HOST_AGENT .
   args:
     chdir: "{{ sap_hana_install_software_extract_directory }}"
-  when: "'SAPHOST' in passed_sap_hana_install_components_sar.name"
+  when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
 - name: SAP HANA hdblcm prepare - Remove temporary extraction directory '{{ sap_hana_install_software_extract_directory }}/tmp'
   ansible.builtin.file:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -21,61 +21,33 @@
     state: touch
     mode: '0755'
 
-- name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable if sap_hana_install_sapcar_filename is defined
+- name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
   set_fact:
-    __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_filename }}"
-  when: sap_hana_install_sapcar_filename is defined
-
-- name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
-  block:
-# We need the file package for the file command, which we need in the next task.
-# RHEL: The file package is contained in the Base software group, which should be installed already.
-
-# In case there is more than one SAPCAR*EXE file in the software directory, we need to get the correct one.
-# In case of ppc64 and ppc64le, the file command displays the same architecture in the second column.
-# We could use the binutils package but we can also find out the correct file by just attempting to execute it.
-# Inner loop, loop variable sapcar_any:
-#   We first replace the architecture string as reported by the file command by the string as reported by uname -m.
-#   Next, we select only the SAPCAR*EXE files which matches the architecture of the managed node.
-# Outer loop, loop variable sapcar_matching_arch:
-#   We then execute each of the matching SAPCAR*EXE files and if the return code is 0, we execute it again,
-#   print the version and patch number, sort numerically by the version and patch number and finally
-#   select the SAPCAR*EXE file with the highest version.
-    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
-      shell: |
-        set -o pipefail && for sapcar_matching_arch in $(
-             for sapcar_any in SAPCAR*EXE; do
-                file ${sapcar_any} |
-                  awk '{gsub ("x86-64", "x86_64"); gsub ("64-bit PowerPC", "ppc64le"); gsub ("IBM S/390", "s390x");
-                  split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]); printf ("%s %s\n", a[1], b[2])}'
-             done | awk '/'"{{ ansible_architecture }}"'/{print $1}'); do
-          ./${sapcar_matching_arch} --version >/dev/null 2>&1 && (
-          printf "%s " ${sapcar_matching_arch}
-          ./${sapcar_matching_arch} --version |
-            awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}')
-          done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
-      args:
-        chdir: "{{ sap_hana_install_software_directory }}"
-      register: __sap_hana_install_register_sapcar_file
-      changed_when: no
-
-    - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
-      set_fact:
-        __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
-
-  when: sap_hana_install_sapcar_filename is not defined
+    __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_file[0].name }}"
 
 - name: SAP HANA hdblcm prepare - Get info about the SAPCAR executable
   stat:
     path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}"
   register: __sap_hana_install_register_sapcar_stat_result
+  changed_when: no
   failed_when: no
 
 - name: SAP HANA hdblcm prepare - Assert that the SAPCAR executable is available
   assert:
     that: __sap_hana_install_register_sapcar_stat_result.stat.exists
-    fail_msg: "FAIL: No valid SAPCAR executable could be found. Consider setting variable 'sap_hana_install_sapcar_filename'."
-    success_msg: "Using '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' for extracting SAR files."
+    fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
+    success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
+
+- name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
+  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+  register: __sap_hana_install_register_sapcar_sha256sum
+  changed_when: no
+
+- name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
+  assert:
+    that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
+    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
+    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
 
 - name: SAP HANA hdblcm prepare - Make sure SAPCAR has execute permissions and is owned by root
   ansible.builtin.file:
@@ -84,28 +56,10 @@
     owner: root
     group: root
 
-- name: Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
-  block:
-
-    - name: SAP HANA hdblcm prepare - Get all SAR files in folder '{{ sap_hana_install_software_directory }}'
-      shell: |
-        ls *.SAR
-      args:
-        chdir: "{{ sap_hana_install_software_directory }}"
-      register: __sap_hana_install_register_sarfiles_list
-      changed_when: no
-
-    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
-      set_fact:
-        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
-      when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
-
-  when: sap_hana_install_sarfiles_list is not defined
-
 - name: SAP HANA hdblcm prepare - Set fact list of SAR files from variable if defined
   set_fact:
-    __sap_hana_install_fact_components_sar: "{{ sap_hana_install_sarfiles_list }}"
-  when: sap_hana_install_sarfiles_list is defined
+    __sap_hana_install_fact_components_sar: "{{ sap_hana_install_sarfiles }}"
+  when: sap_hana_install_sarfiles is defined
 
 - name: SAP HANA hdblcm prepare - Display SAR files to be extracted
   debug:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -23,8 +23,8 @@
 
 - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
   set_fact:
-    __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_file[0].name }}"
-  when: sap_hana_install_sapcar_file is defined
+    __sap_hana_install_fact_sapcar_filename: "{{ sap_hana_install_sapcar_filename }}"
+  when: sap_hana_install_sapcar_filename is defined
 
 - name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
   block:
@@ -69,13 +69,14 @@
 
     - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
       set_fact:
-        __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
+        __sap_hana_install_fact_sapcar_filename: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
 
   when: sap_hana_install_sapcar_file is not defined
 
 - name: SAP HANA hdblcm prepare - Get info about the SAPCAR executable
   stat:
-    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}"
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}"
+    checksum_algorithm: sha256
   register: __sap_hana_install_register_sapcar_stat_result
   changed_when: no
   failed_when: no
@@ -83,66 +84,66 @@
 - name: SAP HANA hdblcm prepare - Assert that the SAPCAR executable is available
   assert:
     that: __sap_hana_install_register_sapcar_stat_result.stat.exists
-    fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
-    success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
+    fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}' does not exist!"
+    success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}' exists."
 
-- name: SAP HANA hdblcm prepare - Verify checksum for SAPCAR executable
+- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum'
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum"
+  register: __sap_hana_install_register_sapcar_sha256sum_stat_result
+  changed_when: no
+
+- name: SAP HANA hdblcm prepare - Notify if checksum verification will be skipped for SAPCAR executable
+  debug:
+    msg: "INFO: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sh256sum' does not exist,
+          so no checksum verification will be performed for file
+          '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}'."
+  when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
+
+- name: SAP HANA hdblcm prepare - Verify checksum for SAPCAR executable if checksum file exists
   block:
 
-    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
-      stat:
-        path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-      register: __sap_hana_install_register_sapcar_sha256sum_stat_result
-      changed_when: no
-      failed_when: no
-
-    - name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
-      shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-      when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
-
-    - name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
-      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-      register: __sap_hana_install_register_sapcar_sha256sum
+    - name: SAP HANA hdblcm prepare - Read the sha256sum from the checksum file
+      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum"
+      register: __sap_hana_install_register_sapcar_sha256sum_from_file
       changed_when: no
 
     - name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
       assert:
-        that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
-        fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
-        success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
+        that: __sap_hana_install_register_sapcar_stat_result.stat.checksum ==
+              __sap_hana_install_register_sapcar_sha256sum_from_file.stdout.split(' ').0
+        fail_msg: "FAIL: The checksum of file
+           '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}'
+           does not match the checksum stored in file
+           {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum!"
+        success_msg: "PASS: The checksum of file
+           '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}'
+           matches the checksum stored in file
+           {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum."
 
-  when: sap_hana_install_sapcar_file is defined
+  when: __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
 
 - name: SAP HANA hdblcm prepare - Make sure SAPCAR has execute permissions and is owned by root
   ansible.builtin.file:
-    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}"
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}"
     mode: '0755'
     owner: root
     group: root
 
-- name: Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
+- name: SAP HANA hdblcm prepare - Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
   block:
 
     - name: SAP HANA hdblcm prepare - Get all SAR files in folder '{{ sap_hana_install_software_directory }}'
       shell: |
-        ls *.SAR | awk '{print $0, "0"}'
+        ls *.SAR
       args:
         chdir: "{{ sap_hana_install_software_directory }}"
       register: __sap_hana_install_register_sarfiles_list
       changed_when: no
 
-# We add a dummy field to the list of SAR file names so that type of variable
-# __sap_hana_install_fact_components_sar is identical to the type of role variable
-# sap_hana_install_sarfiles, if configured. With this solution, we can avoid some
-# duplicate code in the following processing steps.
     - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
       set_fact:
-        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_fact_components_sar|d([]) + [ __sap_hana_install_tmp_dict ] }}"
-      with_items: "{{ __sap_hana_install_register_sarfiles_list.stdout_lines }}"
-      vars:
-        __sap_hana_install_tmp_dict:
-          name: "{{ item.split(' ').0 }}"
-          checksum: "{{ item.split(' ').1 }}"
+        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
       when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
 
   when: sap_hana_install_sarfiles is not defined

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -24,6 +24,52 @@
 - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
   set_fact:
     __sap_hana_install_fact_sapcar_file_name: "{{ sap_hana_install_sapcar_file[0].name }}"
+  when: sap_hana_install_sapcar_file is defined
+
+- name: SAP HANA hdblcm prepare - Determine file name of SAPCAR*EXE
+  block:
+# We need the 'file' package for the 'file' command, which we need in the next task.
+# RHEL: The 'file' package is contained in the Base software group, which should be installed already.
+
+# In case there is more than one SAPCAR EXE file in the software directory, we want to identify the correct one.
+# Inner loop, loop variable sapcar_any:
+#   For each SAPCAR*EXE file, the 'file' command is executed. It displays the hardware architecture in the
+#   second output field, using a string which is different from the output of the 'uname -m' command. So we
+#   replace those strings by the "correct" ones. For ppc64 ad ppc64le, the second output field is identical
+#   so in this case, we also look at the third output field.
+#   Next, we select only the SAPCAR EXE file(s) which match(es) the architecture of the managed node.
+# Outer loop, loop variable sapcar_matching_arch:
+#   We then print the name, version, and patch number for each SAPCAR EXE file for the architecture, sort numerically
+#   by the version and patch number and finally select the SAPCAR EXE file with the highest version.
+    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
+      shell: |
+        set -o pipefail &&
+        for sapcar_matching_arch in $(
+                for sapcar_any in SAPCAR*EXE; do
+                   file ${sapcar_any} | awk '{
+                      split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]);
+                      sub ("x86-64", "x86_64", b[2]);
+                      if (index (b[3], "OpenPOWER") > 0) {sub ("64-bit PowerPC", "ppc64le", b[2])};
+                      if (index (b[3], "OpenPOWER") == 0) {sub ("64-bit PowerPC", "ppc64", b[2])};
+                      sub ("IBM S/390", "s390x", b[2]);
+                      printf ("%s %s\n", a[1], b[2])}'
+                   done | awk '$2=="{{ ansible_architecture }}"{print $1}'
+                ); do
+           ( printf "%s " ${sapcar_matching_arch}
+             ./${sapcar_matching_arch} --version |
+             awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}'
+           )
+        done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{print $1}'
+      args:
+        chdir: "{{ sap_hana_install_software_directory }}"
+      register: __sap_hana_install_register_sapcar_file
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Set fact for SAPCAR executable
+      set_fact:
+        __sap_hana_install_fact_sapcar_file_name: "{{ __sap_hana_install_register_sapcar_file.stdout }}"
+
+  when: sap_hana_install_sapcar_file is not defined
 
 - name: SAP HANA hdblcm prepare - Get info about the SAPCAR executable
   stat:
@@ -38,27 +84,32 @@
     fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
     success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
 
-- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
-  stat:
-    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-  register: __sap_hana_install_register_sapcar_sha256sum_stat_result
-  changed_when: no
-  failed_when: no
+- name: SAP HANA hdblcm prepare - Verify checksum for SAPCAR executable
+  block:
 
-- name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
-  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-  when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
+    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
+      stat:
+        path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+      register: __sap_hana_install_register_sapcar_sha256sum_stat_result
+      changed_when: no
+      failed_when: no
 
-- name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
-  command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
-  register: __sap_hana_install_register_sapcar_sha256sum
-  changed_when: no
+    - name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
+      shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+      when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
 
-- name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
-  assert:
-    that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
-    fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
-    success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
+    - name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
+      command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+      register: __sap_hana_install_register_sapcar_sha256sum
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Assert that the SAPCAR checksum is correct
+      assert:
+        that: __sap_hana_install_register_sapcar_sha256sum.stdout == sap_hana_install_sapcar_file[0].checksum
+        fail_msg: "FAIL: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' executable does not match the content of variable sap_hana_install_sapcar_file[0].checksum."
+        success_msg: "PASS: The checksum of file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' matches the content of variable sap_hana_install_sapcar_file[0].checksum."
+
+  when: sap_hana_install_sapcar_file is defined
 
 - name: SAP HANA hdblcm prepare - Make sure SAPCAR has execute permissions and is owned by root
   ansible.builtin.file:
@@ -66,6 +117,33 @@
     mode: '0755'
     owner: root
     group: root
+
+- name: Handle SAR files in folder '{{ sap_hana_install_software_directory }}'
+  block:
+
+    - name: SAP HANA hdblcm prepare - Get all SAR files in folder '{{ sap_hana_install_software_directory }}'
+      shell: |
+        ls *.SAR | awk '{print $0, "0"}'
+      args:
+        chdir: "{{ sap_hana_install_software_directory }}"
+      register: __sap_hana_install_register_sarfiles_list
+      changed_when: no
+
+    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
+      set_fact:
+        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_fact_components_sar|d([]) + [ __sap_hana_install_tmp_dict ] }}"
+      with_items: "{{ __sap_hana_install_register_sarfiles_list.stdout_lines }}"
+      vars:
+        __sap_hana_install_tmp_dict:
+          name: "{{ item.split(' ').0 }}"
+          checksum: "{{ item.split(' ').1 }}"
+      when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
+
+#    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
+#      set_fact:
+#        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
+
+  when: sap_hana_install_sarfiles is not defined
 
 - name: SAP HANA hdblcm prepare - Set fact list of SAR files from variable if defined
   set_fact:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -131,6 +131,10 @@
       register: __sap_hana_install_register_sarfiles_list
       changed_when: no
 
+# We add a dummy field to the list of SAR file names so that type of variable
+# __sap_hana_install_fact_components_sar is identical to the type of role variable
+# sap_hana_install_sarfiles, if configured. With this solution, we can avoid some
+# duplicate code in the following processing steps.
     - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
       set_fact:
         __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_fact_components_sar|d([]) + [ __sap_hana_install_tmp_dict ] }}"
@@ -140,10 +144,6 @@
           name: "{{ item.split(' ').0 }}"
           checksum: "{{ item.split(' ').1 }}"
       when: __sap_hana_install_register_sarfiles_list.stdout | length > 0
-
-#    - name: SAP HANA hdblcm prepare - Set fact list of SAR files from output of ls command
-#      set_fact:
-#        __sap_hana_install_fact_components_sar: "{{ __sap_hana_install_register_sarfiles_list.stdout.split() }}"
 
   when: sap_hana_install_sarfiles is not defined
 

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -38,6 +38,17 @@
     fail_msg: "FAIL: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' does not exist."
     success_msg: "PASS: File '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}' exists."
 
+- name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum'
+  stat:
+    path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+  register: __sap_hana_install_register_sapcar_sha256sum_stat_result
+  changed_when: no
+  failed_when: no
+
+- name: SAP HANA hdblcm prepare - Create checksum file for SAPCAR executable if it does not exist
+  shell: "sha256sum {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }} > {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
+  when: not __sap_hana_install_register_sapcar_sha256sum_stat_result.stat.exists
+
 - name: SAP HANA hdblcm prepare - Get sha256sum of the SAPCAR executable
   command: "awk '{print $1}' {{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_file_name }}.sha256sum"
   register: __sap_hana_install_register_sapcar_sha256sum

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -35,13 +35,15 @@
 # Inner loop, loop variable sapcar_any:
 #   For each SAPCAR*EXE file, the 'file' command is executed. It displays the hardware architecture in the
 #   second output field, using a string which is different from the output of the 'uname -m' command. So we
-#   replace those strings by the "correct" ones. For ppc64 ad ppc64le, the second output field is identical
-#   so in this case, we also look at the third output field.
-#   Next, we select only the SAPCAR EXE file(s) which match(es) the architecture of the managed node.
+#   replace those strings by the "correct" ones. For ppc64 and ppc64le, the second output field is identical.
+#   So in this case, we also look at the third output field, to handle cases where a ppc64 SAPCAR executable
+#   is present in the software directory.
+#   The resulting list of the inner loop contains the SAPCAR EXE file(s) which match(es) the architecture
+#   of the managed node.
 # Outer loop, loop variable sapcar_matching_arch:
-#   We then print the name, version, and patch number for each SAPCAR EXE file for the architecture, sort numerically
-#   by the version and patch number and finally select the SAPCAR EXE file with the highest version.
-    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder - {{ sap_hana_install_software_directory }}
+#   We then print the name, version, and patch number for each SAPCAR EXE file for the architecture, sort
+#   numerically by the version and patch number and finally select the SAPCAR EXE file with the highest version.
+    - name: SAP HANA hdblcm prepare - Get SAPCAR executable file from folder '{{ sap_hana_install_software_directory }}'
       shell: |
         set -o pipefail &&
         for sapcar_matching_arch in $(

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_prepare.yml
@@ -77,6 +77,7 @@
   stat:
     path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}"
     checksum_algorithm: sha256
+  check_mode: no
   register: __sap_hana_install_register_sapcar_stat_result
   changed_when: no
   failed_when: no
@@ -90,6 +91,7 @@
 - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum'
   stat:
     path: "{{ sap_hana_install_software_directory }}/{{ __sap_hana_install_fact_sapcar_filename }}.sha256sum"
+  check_mode: no
   register: __sap_hana_install_register_sapcar_sha256sum_stat_result
   changed_when: no
 

--- a/roles/sap_hana_preconfigure/README.md
+++ b/roles/sap_hana_preconfigure/README.md
@@ -244,11 +244,20 @@ sap_hana_preconfigure_fail_if_reboot_required
 ```
 
 ### Use tuned profile sap-hana
-By default, the role will activate tuned profile `sap-hana` for configuring kernel parameters (where possible). If you do not want to use the tuned profile sap-hana,
-set the following variable to `no`. In this case, the role will also modify GRUB_CMDLINE_LINUX, no matter how variable `sap_hana_preconfigure_modify_grub_cmdline_linux` (see below) is set.
-Note: If this variable is set to `yes`, the role may still modify GRUB_CMDLINE_LINUX in /etc/default/grub, by setting variable `sap_hana_preconfigure_modify_grub_cmdline_linux` to `yes`. This provides more flexibility for setting certain kernel parameters.
+By default, the role will activate tuned profile `sap-hana` for configuring kernel parameters (where possible). If you do not want
+to use the tuned profile sap-hana, set the following variable to `no`. In this case, the role will also modify GRUB_CMDLINE_LINUX,
+no matter how variable `sap_hana_preconfigure_modify_grub_cmdline_linux` (see below) is set.
+Note: If this variable is set to `yes`, the role may still modify GRUB_CMDLINE_LINUX in /etc/default/grub, by setting variable
+`sap_hana_preconfigure_modify_grub_cmdline_linux` to `yes`. This provides more flexibility for setting certain kernel parameters.
 ```yaml
 sap_hana_preconfigure_use_tuned
+```
+
+### Specify your own tuned profile
+Use the following variable to set a tuned profile string other than the default `sap-hana`. The tuned profile must reside in directory
+`/etc/tuned/my_own_profile`, as file named `tuned.conf` (example for a tuned profile named `my_own_profile`).
+```yaml
+sap_hana_preconfigure_tuned_profile
 ```
 
 ### Modify grub2 line GRUB_CMDLINE_LINUX

--- a/roles/sap_hana_preconfigure/defaults/main.yml
+++ b/roles/sap_hana_preconfigure/defaults/main.yml
@@ -124,6 +124,8 @@ sap_hana_preconfigure_ppcle_tso_if: "{{ ansible_interfaces| difference(['lo']) }
 
 sap_hana_preconfigure_use_tuned: yes
 
+sap_hana_preconfigure_tuned_profile: "{{ __sap_hana_preconfigure_tuned_profile }}"
+
 sap_hana_preconfigure_modify_grub_cmdline_linux: no
 
 sap_hana_preconfigure_run_grub2_mkconfig: "{{ __sap_hana_preconfigure_run_grub2_mkconfig }}"

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-tuned.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-tuned.yml
@@ -63,7 +63,7 @@
     - "'tuned.service' in ansible_facts.services"
     - not sap_hana_preconfigure_use_tuned
 
-- name: Display the version of tuned-profiles-sap-hana
+- name: Display the version of package tuned-profiles-sap-hana
   debug:
     msg: "INFO: The installed version of package 'tuned-profiles-sap-hana' is: {{ ansible_facts.packages['tuned-profiles-sap-hana'][0].version }}"
   when: "'tuned-profiles-sap-hana' in ansible_facts.packages and
@@ -88,32 +88,12 @@
   when: sap_hana_preconfigure_use_tuned or
         sap_hana_preconfigure_assert_all_config
 
-- name: Assert that tuned profile sap-hana is currently active for non-RHEL 8.0, non-ppc64le
+- name: Assert that tuned profile '{{ sap_hana_preconfigure_tuned_profile }}' is currently active
   assert:
-    that: "__sap_hana_preconfigure_register_current_tuned_profile_assert.stdout == 'sap-hana'"
-    fail_msg: "FAIL: The tuned profile 'sap-hana' is currently not active!
+    that: "__sap_hana_preconfigure_register_current_tuned_profile_assert.stdout == '{{ sap_hana_preconfigure_tuned_profile }}'"
+    fail_msg: "FAIL: The tuned profile '{{ sap_hana_preconfigure_tuned_profile }}' is currently not active!
       Currently active profile: '{{ __sap_hana_preconfigure_register_current_tuned_profile_assert.stdout }}'."
-    success_msg: "PASS: The tuned profile 'sap-hana' is currently active."
+    success_msg: "PASS: The tuned profile '{{ sap_hana_preconfigure_tuned_profile }}' is currently active."
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors|d(false) }}"
-  when: (ansible_architecture != "ppc64le" or
-          (ansible_architecture == "ppc64le" and
-             ansible_distribution_version != "8.0"
-          )
-        ) and
-        (sap_hana_preconfigure_use_tuned or
-           sap_hana_preconfigure_assert_all_config
-        )
-
-- name: Assert that tuned profiles sap-hana and sap-hana-ppc64le are currently active for RHEL 8.0 on ppc64le
-  assert:
-    that: "__sap_hana_preconfigure_register_current_tuned_profile_assert.stdout == 'sap-hana sap-hana-ppc64le'"
-    fail_msg: "FAIL: The tuned profiles 'sap-hana sap-hana-ppc64le' are currently not active!
-      Currently active profile: '{{ __sap_hana_preconfigure_register_current_tuned_profile_assert.stdout }}'."
-    success_msg: "PASS: The tuned profiles 'sap-hana sap-hana-ppc64le' are currently active."
-  ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors|d(false) }}"
-  when: (ansible_architecture == "ppc64le" and
-           ansible_distribution_version == "8.0"
-        ) and
-        (sap_hana_preconfigure_use_tuned or
-           sap_hana_preconfigure_assert_all_config
-        )
+  when: sap_hana_preconfigure_use_tuned or
+        sap_hana_preconfigure_assert_all_config

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-tuned.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-tuned.yml
@@ -1,14 +1,40 @@
 ---
 
-- name: Perform steps configuring tuned
+- name: Perform specific steps for tuned profile on RHEL 8.0 ppc64le
   block:
+
+    - name: RHEL 8.0 ppc64le - Create directory /etc/tuned/sap-hana-ppc64le
+      file:
+        path: /etc/tuned/sap-hana-ppc64le
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: RHEL 8.0 ppc64le - Copy file /etc/tuned/sap-hana-ppc64le/tuned.conf
+      copy:
+        src: etc/tuned/sap-hana-ppc64le/tuned.conf
+        dest: /etc/tuned/sap-hana-ppc64le/tuned.conf
+        owner: root
+        group: root
+        mode: '0644'
+        backup: yes
+
+  when:
+    - sap_hana_preconfigure_use_tuned
+    - ansible_architecture == "ppc64le"
+    - ansible_distribution_version == "8.0"
+
+- name: Perform steps for setting tuned profile
+  block:
+
     - name: Enable and start tuned
       service:
         name: tuned
         state: started
         enabled: yes
 
-    - name: Show currently active tuned profile
+    - name: Get currently active tuned profile
       shell: /usr/sbin/tuned-adm active | grep ":" | cut -d ":" -f 2 | awk '{$1=$1;print}'
       check_mode: no
       register: __sap_hana_preconfigure_register_current_tuned_profile
@@ -18,10 +44,10 @@
       debug:
         var: __sap_hana_preconfigure_register_current_tuned_profile.stdout_lines, __sap_hana_preconfigure_register_current_tuned_profile.stderr_lines
 
-    - name: Switch to tuned profile sap-hana if not currently active
+    - name: Switch to tuned profile '{{ sap_hana_preconfigure_tuned_profile }}' if not currently active
       block:
-        - name: Switch to tuned profile sap-hana
-          command: /usr/sbin/tuned-adm profile sap-hana
+        - name: Switch to tuned profile '{{ sap_hana_preconfigure_tuned_profile }}'
+          command: /usr/sbin/tuned-adm profile '{{ sap_hana_preconfigure_tuned_profile }}'
 
         - name: Show new active tuned profile
           shell: /usr/sbin/tuned-adm active | grep ":" | cut -d ":" -f 2 | awk '{$1=$1;print}'
@@ -29,66 +55,12 @@
           register: __sap_hana_preconfigure_register_new_tuned_profile
           changed_when: false
 
-        - name: Display the output of the tuned-adm active command after switching to profile sap-hana
+        - name: Display the output of the tuned-adm active command after switching to profile '{{ sap_hana_preconfigure_tuned_profile }}'
           debug:
             var: __sap_hana_preconfigure_register_new_tuned_profile.stdout_lines, __sap_hana_preconfigure_register_new_tuned_profile.stderr_lines
 
       when:
-        - __sap_hana_preconfigure_register_current_tuned_profile.stdout != 'sap-hana'
+        - __sap_hana_preconfigure_register_current_tuned_profile.stdout != sap_hana_preconfigure_tuned_profile
 
   when:
     - sap_hana_preconfigure_use_tuned
-    - (ansible_architecture != "ppc64le" or (ansible_architecture == "ppc64le" and ansible_distribution_version != "8.0"))
-
-- name: Perform additional steps for RHEL 8.0 ppc64le
-  block:
-    - name: RHEL 8.0 ppc64le - create directory /etc/tuned/sap-hana-ppc64le
-      file:
-        path: /etc/tuned/sap-hana-ppc64le
-        state: directory
-        owner: root
-        group: root
-        mode: '0755'
-
-    - name: RHEL 8.0 ppc64le - copy file /etc/tuned/sap-hana-ppc64le/tuned.conf
-      copy:
-        src: etc/tuned/sap-hana-ppc64le/tuned.conf
-        dest: /etc/tuned/sap-hana-ppc64le/tuned.conf
-        owner: root
-        group: root
-        mode: '0644'
-        backup: yes
-
-    - name: RHEL 8.0 ppc64le - show currently active tuned profile
-      shell: set -o pipefail && /usr/sbin/tuned-adm active | grep ":" | cut -d ":" -f 2 | awk '{$1=$1;print}'
-      check_mode: no
-      register: __sap_hana_preconfigure_register_current_tuned_profile_ppc64le
-      changed_when: false
-
-    - name: RHEL 8.0 ppc64le - Display the output of the tuned-adm active command
-      debug:
-        var: __sap_hana_preconfigure_register_current_tuned_profile_ppc64le.stdout_lines,
-             __sap_hana_preconfigure_register_current_tuned_profile_ppc64le.stderr_lines
-
-    - name: RHEL 8.0 ppc64le - switch to tuned profiles sap-hana sap-hana-ppc64le if not currently active
-      block:
-        - name: Switch to tuned profiles sap-hana sap-hana-ppc64le
-          command: /usr/sbin/tuned-adm profile sap-hana sap-hana-ppc64le
-
-        - name: RHEL 8.0 ppc64le - Show new active tuned profile
-          shell: set -o pipefail && /usr/sbin/tuned-adm active | grep ":" | cut -d ":" -f 2 | awk '{$1=$1;print}'
-          register: __sap_hana_preconfigure_register_new_tuned_profile_ppc64le
-          changed_when: false
-
-        - name: RHEL 8.0 ppc64le - Display the output of the tuned-adm active command
-          debug:
-            var: __sap_hana_preconfigure_register_new_tuned_profile_ppc64le.stdout_lines,
-                 __sap_hana_preconfigure_register_new_tuned_profile_ppc64le.stderr_lines
-
-      when:
-        - __sap_hana_preconfigure_register_current_tuned_profile_ppc64le.stdout != 'sap-hana sap-hana-ppc64le'
-
-  when:
-    - sap_hana_preconfigure_use_tuned
-    - ansible_architecture == "ppc64le"
-    - ansible_distribution_version == "8.0"

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-ksm.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-ksm.yml
@@ -19,6 +19,7 @@
 
 - name: Configure - Get initial status of KSM
   command: cat /sys/kernel/mm/ksm/run
+  check_mode: no
   register: __sap_hana_preconfigure_register_ksm_status_before
   ignore_errors: true
   changed_when: false

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2777782/02-configure-tuned.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2777782/02-configure-tuned.yml
@@ -2,5 +2,5 @@
 
 - name: Configure 2777782-2
   debug:
-    msg: "SAP note 2777782 Step 2: Configure tuned to use profile sap-hana"
+    msg: "SAP note 2777782 Step 2: Configure tuned to use profile for SAP HANA"
 - import_tasks: ../../RedHat/generic/configure-tuned.yml

--- a/roles/sap_hana_preconfigure/tests/sap_hana_preconfigure-default-settings.yml
+++ b/roles/sap_hana_preconfigure/tests/sap_hana_preconfigure-default-settings.yml
@@ -1,4 +1,6 @@
 ---
 - hosts: all
+  collections:
+    - community.sap_install
   roles:
-    - role: sap_hana_preconfigure
+    - sap_hana_preconfigure

--- a/roles/sap_hana_preconfigure/vars/main.yml
+++ b/roles/sap_hana_preconfigure/vars/main.yml
@@ -13,4 +13,6 @@ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf: /etc/sysctl.d/91-NetApp-HAN
 # SELinux is already configured in role sap_general_preconfigure:
 #__sap_hana_preconfigure_selinux_state: disabled
 
+__sap_hana_preconfigure_tuned_profile: 'sap-hana'
+
 __sap_hana_preconfigure_run_grub2_mkconfig: yes

--- a/roles/sap_netweaver_preconfigure/tests/sap_netweaver_preconfigure-default-settings.yml
+++ b/roles/sap_netweaver_preconfigure/tests/sap_netweaver_preconfigure-default-settings.yml
@@ -1,4 +1,6 @@
 ---
 - hosts: all
+  collections:
+    - community.sap_install
   roles:
-    - role: sap_netweaver_preconfigure
+    - sap_netweaver_preconfigure


### PR DESCRIPTION
This pull request contains two separate modifications:
- sap_hana_preconfigure now supports a custom tuned profile, set in new variable `sap_hana_preconfigure_tuned_profile`. If the variable is not set, the default tuned profile 'sap-hana' will be used (issue #43).
- sap_hana_install now supports checksum verification for the SAPCAR executable and the SAR files in the software directory (either specified in role variables `sap_hana_install_sapcar_filename` and/or `sap_hana_install_sarfiles_list` or found by the role) for which a file named `FILE.sha256sum` exists in the same directory, where `FILE` is the name of the SAPCAR executable or SAR file (issue #44).