### PR TITLE
sap-hana-install: New feature: Copy SAR files before extracting

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -53,11 +53,11 @@ If more than one SAR file for a certain software product is present in the softw
 handling of such SAR files will fail after extraction, when moving the newly created product directories
 (like `SAP_HOST_AGENT`) to already existing destinations.
 For avoiding such situations, use following variable to provide a list of SAR files to extract:
-`sap_hana_install_sarfiles_list`.
+`sap_hana_install_sarfilest`.
 
 Example:
 ```
-sap_hana_install_sarfiles_list:
+sap_hana_install_sarfiles:
   - SAPHOSTAGENT54_54-80004822.SAR
   - IMDB_SERVER20_060_0-80002031.SAR
 ```

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -10,6 +10,13 @@ sap_hana_install_software_directory: '/software/hana'
 # Note: This directory will be removed and created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
+# Set this variabe to yes if you want to copy the sarfiles from `sap_hana_install_software_directory`
+# to `sap_hana_install_software_extract_directory` before extracting.
+# This might be useful if the sarfiles are on a slow fileshare
+sap_hana_install_copy_sarfiles: no
+# set the following to yes, if you want to keep the copied sarfiles
+sap_hana_install_keep_copied_sarfiles: no
+
 # File name of SAPCAR*EXE. Can be set in case the automatic detection of the SAPCAR*EXE file fails.
 #sap_hana_install_sapcar_filename: SAPCAR_1115-70006178.EXE
 

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -22,7 +22,7 @@ sap_hana_install_keep_copied_sarfiles: no
 
 # List of file names of SAR files to extract. Can be set in case there are more SAR files in the software directory
 # than needed or desired for the HANA installation
-#sap_hana_install_sarfiles_list:
+#sap_hana_install_sarfiles:
 #  - SAPHOSTAGENT54_54-80004822.SAR
 #  - IMDB_SERVER20_060_0-80002031.SAR
 

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -41,12 +41,12 @@
   when: sap_hana_install_copy_sarfiles 
 
 - name: SAP HANA hdblcm prepare - Define Path to sarfile (local copy)
-  setfact:
+  set_fact:
      __sap_hana_install_path_to_sarfile: "{{ sap_hana_install_software_extract_directory }}/sarfiles/"
   when: sap_hana_install_copy_sarfiles 
 
 - name: SAP HANA hdblcm prepare - Keep path to sarfile
-  setfact:
+  set_fact:
      __sap_hana_install_path_to_sarfile: "{{ sap_hana_install_software_directory }}"
   when: not sap_hana_install_copy_sarfiles 
 

--- a/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sar.yml
@@ -10,6 +10,7 @@
     __sap_hana_install_tmp_software_extract_directory: "{{ sap_hana_install_software_extract_directory }}/tmp/SAP_HOST_AGENT"
   when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
+### TODO: Why is the when statement in this task. It's probably not necessary ...
 - name: SAP HANA hdblcm prepare - Create temporary extraction destination '{{ __sap_hana_install_tmp_software_extract_directory }}'
   ansible.builtin.file:
     path: "{{ __sap_hana_install_tmp_software_extract_directory }}"
@@ -19,9 +20,35 @@
     group: root
   when: "'SAPHOST' in passed_sap_hana_install_components_sar"
 
-- name: Display the name of the SAR file
+- name: SAP HANA hdblcm prepare - Create tempory sar file destination 
+  ansible.builtin.file:
+    path: "{{ sap_hana_install_software_extract_directory }}/sarfiles"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  when: sap_hana_install_copy_sarfiles 
+
+- name: SAP HANA hdblcm prepare - Display the name of the SAR file
   debug:
     msg: "Name of SAR file: '{{ passed_sap_hana_install_components_sar }}'"
+
+- name: SAP HANA hdblcm prepare - Copy '{{ passed_sap_hana_install_components_sar }}' to '{{ sap_hana_install_software_extract_directory }}/sarfiles'
+  copy:
+     src: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}"
+     dest: "{{ sap_hana_install_software_extract_directory }}/sarfiles/{{ passed_sap_hana_install_components_sar }}"
+     remote_src: true
+  when: sap_hana_install_copy_sarfiles 
+
+- name: SAP HANA hdblcm prepare - Define Path to sarfile (local copy)
+  setfact:
+     __sap_hana_install_path_to_sarfile: "{{ sap_hana_install_software_extract_directory }}/sarfiles/"
+  when: sap_hana_install_copy_sarfiles 
+
+- name: SAP HANA hdblcm prepare - Keep path to sarfile
+  setfact:
+     __sap_hana_install_path_to_sarfile: "{{ sap_hana_install_software_directory }}"
+  when: not sap_hana_install_copy_sarfiles 
 
 - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'
   stat:
@@ -46,9 +73,9 @@
       register: __sap_hana_install_register_sarfile_sha256sum_from_file
       changed_when: no
 
-    - name: SAP HANA hdblcm prepare - Get info about file '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'
+    - name: SAP HANA hdblcm prepare - Get info about file '{{ __sap_hana_install_path_to_sarfile }}/{{ passed_sap_hana_install_components_sar }}'
       stat:
-        path: "{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}"
+        path: "{{ __sap_hana_install_path_to_sarfile }}/{{ passed_sap_hana_install_components_sar }}"
         checksum_algorithm: sha256
       register: __sap_hana_install_register_sarfile_stat_result
       changed_when: no
@@ -58,11 +85,11 @@
         that: __sap_hana_install_register_sarfile_stat_result.stat.checksum ==
               __sap_hana_install_register_sarfile_sha256sum_from_file.stdout.split(' ').0
         fail_msg: "FAIL: The checksum of file
-           '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'
+           '{{ __sap_hana_install_path_to_sarfile }}/{{ passed_sap_hana_install_components_sar }}'
            does not match the checksum stored in file
            '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'!"
         success_msg: "PASS: The checksum of file
-           '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}'
+           '{{ __sap_hana_install_path_to_sarfile }}/{{ passed_sap_hana_install_components_sar }}'
            matches the checksum stored in file
            '{{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }}.sha256sum'."
 
@@ -72,11 +99,11 @@
   command: >-
     {{ sap_hana_install_software_extract_directory }}/{{ __sap_hana_install_fact_sapcar_filename }} \
     -R {{ __sap_hana_install_tmp_software_extract_directory }} \
-    -xvf {{ sap_hana_install_software_directory }}/{{ passed_sap_hana_install_components_sar }} \
+    -xvf {{ __sap_hana_install_path_to_sarfile }}/{{ passed_sap_hana_install_components_sar }} \
     -manifest SIGNATURE.SMF
   register: __sap_hana_install_register_extract
   args:
-    chdir: "{{ sap_hana_install_software_directory }}"
+    chdir: "{{ sap_hana_install_software_extract_directory }}"
   changed_when: "'SAPCAR: processing archive' in __sap_hana_install_register_extract.stdout"
 
 - name: SAP HANA hdblcm prepare - Move files into the correct place, default
@@ -98,3 +125,12 @@
   ansible.builtin.file:
     path: "{{ sap_hana_install_software_extract_directory }}/tmp"
     state: absent
+
+- name: SAP HANA hdblcm prepare - remove temporary copied archive
+  ansible.builtin.file:
+    path: "{{ __sap_hana_install_path_to_sarfile }}/{{ passed_sap_hana_install_components_sar }}"
+    state: absent
+  when: 
+    - sap_hana_install_copy_sarfiles 
+    - not sap_hana_install_keep_copied_sarfiles
+


### PR DESCRIPTION
These patches implement the feature described in Issue #53 and fixed a documentation bug.

