### PR TITLE
sap_hana_install: Modify and describe defaults in defaults/main.yml

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -59,10 +59,6 @@
       changed_when: no
       ignore_errors: yes
 
-    - name: Display the output of the subscription-manager release command
-      debug:
-        var: __sap_general_preconfigure_register_subscription_manager_release_assert
-
     - name: Assert that the RHEL release is locked correctly
       assert:
         that: "__sap_general_preconfigure_register_subscription_manager_release_assert.stdout == '{{ ansible_distribution_version }}'"

--- a/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests-s390x.py
+++ b/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests-s390x.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import subprocess
+
+# output field delimiter for displaying the results:
+_field_delimiter = '\t'
+
+if (len(sys.argv) == 1):
+    _managed_node=input("Provide name of managed node: ")
+else:
+    _managed_node=sys.argv[1]
+
+print('Running tests for role sap_general_preconfigure...\n')
+print('Managed node: ' + _managed_node)
+
+_mn_rhel_release = subprocess.getoutput("ssh root@" + _managed_node + " cat /etc/redhat-release | awk 'BEGIN{FS=\"release \"}{split ($2, a, \" \"); print a[1]}'")
+print('Managed node Red Hat release: ' + _mn_rhel_release)
+_mn_hw_arch = subprocess.getoutput("ssh root@" + _managed_node + " uname -m")
+print('Managed node HW architecture: ' + _mn_hw_arch)
+
+__tests = [
+    {
+        'number': '1',
+        'name': 'Run in check mode on new system.',
+        'command_line_parameter': '--check ',
+        'ignore_error_final': True,
+        'compact_assert_output': False,
+        'rc': '99',
+        'role_vars': []
+    },
+    {
+        'number': '2',
+        'name': 'Run in assert mode on new system, check for enabled repos and for minor release lock, check for possible RHEL update, ignore any assert error.',
+        'command_line_parameter': '',
+        'ignore_error_final': False,
+        'compact_assert_output': False,
+        'rc': '99',
+        'role_vars': [
+            {
+                'sap_general_preconfigure_assert': True,
+                'sap_general_preconfigure_assert_ignore_errors': True,
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_use_hana_repos': False,
+                'sap_general_preconfigure_set_minor_release': True
+            }
+        ]
+    },
+    {
+        'number': '3',
+        'name': 'Run in normal mode on new system, no reboot.',
+        'command_line_parameter': '',
+        'ignore_error_final': False,
+        'compact_assert_output': False,
+        'rc': '99',
+        'role_vars': [
+            {
+                'sap_general_preconfigure_fail_if_reboot_required': False
+            }
+        ]
+    },
+    {
+        'number': '4',
+        'name': 'Run in normal mode on modified system, enable repos and set minor release lock, check for possible RHEL update, set SELinux to permisive, allow a reboot.',
+        'command_line_parameter': '',
+        'ignore_error_final': False,
+        'compact_assert_output': False,
+        'rc': '99',
+        'role_vars': [
+            {
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_use_hana_repos': False,
+                'sap_general_preconfigure_set_minor_release': True,
+                'sap_general_preconfigure_selinux_state': 'permissive',
+                'sap_general_preconfigure_reboot_ok': True
+            }
+        ]
+    },
+    {
+        'number': '5',
+        'name': 'Run in assert mode on modified system, enable repos and set minor release lock, check for possible RHEL update, set SELinux to permisive, ignore any assert errors.',
+        'command_line_parameter': '',
+        'ignore_error_final': False,
+        'compact_assert_output': False,
+        'rc': '99',
+        'role_vars': [
+            {
+                'sap_general_preconfigure_assert': True,
+                'sap_general_preconfigure_assert_ignore_errors': True,
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_use_hana_repos': False,
+                'sap_general_preconfigure_set_minor_release': True,
+                'sap_general_preconfigure_selinux_state': 'permissive'
+            }
+        ]
+    },
+    {
+        'number': '6',
+        'name': 'Run in assert mode on modified system, enable repos and set minor release lock, check for possible RHEL update, set SELinux to permisive, ignore any assert errors.',
+        'command_line_parameter': '',
+        'ignore_error_final': False,
+        'compact_assert_output': True,
+        'rc': '99',
+        'role_vars': [
+            {
+                'sap_general_preconfigure_assert': True,
+                'sap_general_preconfigure_assert_ignore_errors': True,
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_use_hana_repos': False,
+                'sap_general_preconfigure_set_minor_release': True,
+                'sap_general_preconfigure_selinux_state': 'permissive'
+            }
+        ]
+    },
+]
+
+for par1 in __tests:
+    print ('\n' + 'Test ' + par1['number'] + ': ' + par1['name'])
+    command = ('ansible-playbook sap_general_preconfigure-default-settings.yml '
+               + par1['command_line_parameter']
+               + '-l '
+               + _managed_node
+               + ' '
+               + '-e "')
+    for par2 in par1['role_vars']:
+        command += str(par2)
+    command += '"'
+    if (par1['compact_assert_output'] == True):
+        command += ' | ../tools/beautify-assert-output.sh font_color_white'
+    print ("command: " + command)
+    _py_rc = os.system(command)
+    par1['rc'] = str(int(_py_rc/256))
+    if (_py_rc != 0):
+        if (par1['ignore_error_final'] == True):
+            print('Test ' + par1['number'] + ' finished with return code ' + par1['rc'] + '. Continuing with the next test')
+        else:
+            print('Test ' + par1['number'] + ' finished with return code ' + par1['rc'] + '.')
+            exit(_py_rc)
+    else:
+        print('Test ' + par1['number'] + ' finished with return code ' + par1['rc'] + '.')
+
+print ('\nResults for role sap_general_preconfigure: ' + _managed_node + ' - RHEL ' + _mn_rhel_release + ' - ' + _mn_hw_arch + ':')
+
+print ('\n#'
+       + _field_delimiter
+       + 'RC' + _field_delimiter
+       + 'name' + _field_delimiter
+       + 'argument' + _field_delimiter
+       + 'compact' + _field_delimiter
+       + 'role_vars')
+
+for par1 in __tests:
+    print (par1['number'] + _field_delimiter
+           + par1['rc'] + _field_delimiter
+           + par1['name'] + _field_delimiter
+           + par1['command_line_parameter'] + _field_delimiter
+           + str(par1['compact_assert_output']) + _field_delimiter, end='')
+    if (len(par1['role_vars']) == 0):
+        print ("")
+    else:
+        for par2 in par1['role_vars']:
+            print (str(par2))

--- a/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
+++ b/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
@@ -179,7 +179,7 @@ for par1 in __tests:
         command += str(par2)
     command += '"'
     if (par1['compact_assert_output'] == True):
-        command += ' | ./beautify-assert-output.sh'
+        command += ' | ../tools/beautify-assert-output.sh font_color_white'
     print ("command: " + command)
     _py_rc = os.system(command)
     par1['rc'] = str(int(_py_rc/256))

--- a/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
+++ b/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
@@ -32,20 +32,7 @@ __tests = [
     },
     {
         'number': '2',
-        'name': 'Run in assert mode on new system. Ignore a final error.',
-        'command_line_parameter': '',
-        'ignore_error_final': True,
-        'compact_assert_output': False,
-        'rc': '99',
-        'role_vars': [
-            {
-                'sap_general_preconfigure_assert': True
-            }
-        ]
-    },
-    {
-        'number': '3',
-        'name': 'Run in assert mode on new system, check for possible RHEL update, ignore any assert error.',
+        'name': 'Run in assert mode on new system, check for enabled repos and for minor release lock, check for possible RHEL update, ignore any assert error.',
         'command_line_parameter': '',
         'ignore_error_final': False,
         'compact_assert_output': False,
@@ -54,27 +41,14 @@ __tests = [
             {
                 'sap_general_preconfigure_assert': True,
                 'sap_general_preconfigure_assert_ignore_errors': True,
-                'sap_general_preconfigure_update': True
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_set_minor_release': True
             }
         ]
     },
     {
-        'number': '4',
-        'name': 'Run in assert mode on new system, check for possible RHEL update, compact output, ignore any assert or final error.',
-        'command_line_parameter': '',
-        'ignore_error_final': True,
-        'compact_assert_output': True,
-        'rc': '99',
-        'role_vars': [
-            {
-                'sap_general_preconfigure_assert': True,
-                'sap_general_preconfigure_assert_ignore_errors': True,
-                'sap_general_preconfigure_update': True
-            }
-        ]
-    },
-    {
-        'number': '5',
+        'number': '3',
         'name': 'Run in normal mode on new system, no reboot.',
         'command_line_parameter': '',
         'ignore_error_final': False,
@@ -87,45 +61,8 @@ __tests = [
         ]
     },
     {
-        'number': '6',
-        'name': 'Run in check mode on configured system.',
-        'command_line_parameter': '--check ',
-        'ignore_error_final': False,
-        'compact_assert_output': False,
-        'rc': '99',
-        'role_vars': []
-    },
-    {
-        'number': '7',
-        'name': 'Run in assert mode on modified system. Ignore a final error.',
-        'command_line_parameter': '',
-        'ignore_error_final': True,
-        'compact_assert_output': False,
-        'rc': '99',
-        'role_vars': [
-            {
-                'sap_general_preconfigure_assert': True
-            }
-        ]
-    },
-    {
-        'number': '8',
-        'name': 'Run in assert mode on modified system, check for possible RHEL update, ignore any assert or final error.',
-        'command_line_parameter': '',
-        'ignore_error_final': True,
-        'compact_assert_output': True,
-        'rc': '99',
-        'role_vars': [
-            {
-                'sap_general_preconfigure_assert': True,
-                'sap_general_preconfigure_assert_ignore_errors': True,
-                'sap_general_preconfigure_update': True
-            }
-        ]
-    },
-    {
-        'number': '9',
-        'name': 'Run in normal mode. Update to the latest packages. Allow a reboot.',
+        'number': '4',
+        'name': 'Run in normal mode on modified system, enable repos and set minor release lock, check for possible RHEL update, set SELinux to permisive, allow a reboot.',
         'command_line_parameter': '',
         'ignore_error_final': False,
         'compact_assert_output': False,
@@ -133,38 +70,49 @@ __tests = [
         'role_vars': [
             {
                 'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_set_minor_release': True,
+                'sap_general_preconfigure_selinux_state': 'permissive',
                 'sap_general_preconfigure_reboot_ok': True
             }
         ]
     },
     {
-        'number': '10',
-        'name': 'Run in assert mode on modified system. Ignore a final error.',
+        'number': '5',
+        'name': 'Run in assert mode on modified system, enable repos and set minor release lock, check for possible RHEL update, set SELinux to permisive, ignore any assert errors.',
         'command_line_parameter': '',
-        'ignore_error_final': True,
+        'ignore_error_final': False,
         'compact_assert_output': False,
         'rc': '99',
         'role_vars': [
             {
-                'sap_general_preconfigure_assert': True
+                'sap_general_preconfigure_assert': True,
+                'sap_general_preconfigure_assert_ignore_errors': True,
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_set_minor_release': True,
+                'sap_general_preconfigure_selinux_state': 'permissive'
             }
         ]
     },
     {
-        'number': '11',
-        'name': 'Run in assert mode on modified system, check for possible RHEL update, compact output, ignore any assert error.',
+        'number': '6',
+        'name': 'Run in assert mode on modified system, enable repos and set minor release lock, check for possible RHEL update, set SELinux to permisive, ignore any assert errors.',
         'command_line_parameter': '',
-        'ignore_error_final': True,
+        'ignore_error_final': False,
         'compact_assert_output': True,
         'rc': '99',
         'role_vars': [
             {
                 'sap_general_preconfigure_assert': True,
                 'sap_general_preconfigure_assert_ignore_errors': True,
-                'sap_general_preconfigure_update': True
+                'sap_general_preconfigure_update': True,
+                'sap_general_preconfigure_enable_repos': True,
+                'sap_general_preconfigure_set_minor_release': True,
+                'sap_general_preconfigure_selinux_state': 'permissive'
             }
         ]
-    }
+    },
 ]
 
 for par1 in __tests:

--- a/roles/sap_general_preconfigure/tools/beautify-assert-output.sh
+++ b/roles/sap_general_preconfigure/tools/beautify-assert-output.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-if [[ ${1}. == "bright_font". ]]; then
-   awk 'BEGIN{printf ("\033[37mResetting font color\n")}'
-   exit
-elif [[ ${1}. == "dark_font". ]]; then
-   awk 'BEGIN{printf ("\033[30mResetting font color\n")}'
-   exit
+if [[ ${1}. == "font_color_white". ]]; then
+   __FONT_COLOR=37m
+elif [[ ${1}. == "font_color_black". ]]; then
+   __FONT_COLOR=30m
 fi
 
-if [[ ${__FONT_COLOR}. = "." ]]; then
-    __FONT_COLOR=30m
+if [[ ${2}. == "reset." ]]; then
+   awk 'BEGIN{printf ("\033['${__FONT_COLOR}'Resetting font color\n")}'
+   exit
 fi
 
 awk '{sub ("    \"msg\": ", "")}

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -110,6 +110,8 @@ sap_hana_install_certificates_hostmap:
 sap_hana_install_system_restart: 'n'
 
 # If the following variable is undefined or set to `y`, the role will create an initial tenant database.
+# corresponding entry in the hdblcm configfile:
+# create_initial_tenant, default: 'y'
 sap_hana_install_create_initial_tenant: 'y'
 
 # If the following variable is specified, the role will perform a scaleout installation or it will add additional
@@ -118,23 +120,43 @@ sap_hana_install_create_initial_tenant: 'y'
 # Example:
 #sap_hana_install_addhosts: 'host2:role=worker,host3:role=worker:group=g02,host4:role=standby:group=g02'
 
-sap_hana_install_hostname:
+# The hostname is set by 'hdblcm --dump_configfile_template' during the preinstall phase but can also
+# be set to a different value in your playbook or hostvars:
+# sap_hana_install_hostname:
 sap_hana_install_ip:
 sap_hana_install_fqdn:
 
+# corresponding entry in the hdblcm configfile:
+# xs_use_default_tenant, default: 'n'
 sap_hana_install_xs_install: 'n'
 sap_hana_install_xs_path:
+# corresponding entry in the hdblcm configfile:
+# orgname, default: 'orgname'
 sap_hana_install_xs_orgname: 'orgname'
+# corresponding entry in the hdblcm configfile:
+# org_manager_user, default: 'XSA_ADMIN'
 sap_hana_install_xs_org_user: 'XSA_ADMIN'
+# corresponding entry in the hdblcm configfile:
+# prod_space_name, default: 'PROD'
 sap_hana_install_xs_prod_space: 'PROD'
 sap_hana_install_xs_routing_mode: 'ports'
 sap_hana_install_xs_domain_name:
+# corresponding entry in the hdblcm configfile:
+# xs_sap_space_user_id
 sap_hana_install_xs_sap_space_user:
+# corresponding entry in the hdblcm configfile:
+# xs_customer_space_user_id
 sap_hana_install_xs_customer_space_user:
 sap_hana_install_xs_components:
 sap_hana_install_xs_components_nostart: 'none'
 
+# corresponding entry in the hdblcm configfile:
+# lss_userid
 sap_hana_install_lss_user:
+# corresponding entry in the hdblcm configfile:
+# lss_groupid
 sap_hana_install_lss_group:
 
+# corresponding entry in the hdblcm configfile:
+# install_hostagent, default: 'y'
 sap_hana_install_deploy_hostagent: 'y'

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
@@ -42,7 +42,7 @@
     - name: SAP HANA Pre Install - Create a Jinja2 template from the hdblcm configfile template
       shell: |
         set -o pipefail &&
-        awk 'BEGIN{FS="="}
+        awk 'BEGIN{FS="="; printf ("\{\{ ansible_managed | comment \}\}\n# File created on: \{\{ template_host \}\}\n# Template file:   \{\{ template_path \}\}\n#\n")}
           !/^[a-z]/{print}
           /^[a-z]/{printf ("%s=\{\{ sap_hana_install_%s|d(\047%s\047) \}\}\n", $1, $1, $2)}' {{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.cfg > {{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.j2
       register: __sap_hana_install_create_jinja2_template

--- a/roles/sap_hana_install/templates/configfile.j2
+++ b/roles/sap_hana_install/templates/configfile.j2
@@ -1,3 +1,8 @@
+{{ ansible_managed | comment }}
+# File created on: {{ template_host }}
+# Template file:   {{ template_path }}
+#
+
 [General]
 
 # Location of Installation Medium

--- a/roles/sap_hana_install/templates/sap-nw-input.j2
+++ b/roles/sap_hana_install/templates/sap-nw-input.j2
@@ -1,3 +1,8 @@
+{{ ansible_managed | comment }}
+# File created on: {{ template_host }}
+# Template file:   {{ template_path }}
+#
+
 # SAP HANA Instance Parameters
 sap_swpm_db_ip: '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}'
 sap_swpm_db_fqdn: '{{ ansible_fqdn }}'

--- a/roles/sap_hana_preconfigure/tests/run-sap_hana_preconfigure-tests.py
+++ b/roles/sap_hana_preconfigure/tests/run-sap_hana_preconfigure-tests.py
@@ -248,7 +248,7 @@ for par1 in __tests:
         command += str(par2)
     command += '"'
     if (par1['compact_assert_output'] == True):
-        command += ' | ./beautify-assert-output.sh'
+        command += ' | ../tools/beautify-assert-output.sh font_color_white'
     print ("command: " + command)
     _py_rc = os.system(command)
     par1['rc'] = str(int(_py_rc/256))

--- a/roles/sap_hana_preconfigure/tools/beautify-assert-output.sh
+++ b/roles/sap_hana_preconfigure/tools/beautify-assert-output.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-if [[ ${1}. == "bright_font". ]]; then
-   awk 'BEGIN{printf ("\033[37mResetting font color\n")}'
-   exit
-elif [[ ${1}. == "dark_font". ]]; then
-   awk 'BEGIN{printf ("\033[30mResetting font color\n")}'
-   exit
+if [[ ${1}. == "font_color_white". ]]; then
+   __FONT_COLOR=37m
+elif [[ ${1}. == "font_color_black". ]]; then
+   __FONT_COLOR=30m
 fi
 
-if [[ ${__FONT_COLOR}. = "." ]]; then
-    __FONT_COLOR=30m
+if [[ ${2}. == "reset." ]]; then
+   awk 'BEGIN{printf ("\033['${__FONT_COLOR}'Resetting font color\n")}'
+   exit
 fi
 
 awk '{sub ("    \"msg\": ", "")}

--- a/roles/sap_netweaver_preconfigure/tests/run-sap_netweaver_preconfigure-tests.py
+++ b/roles/sap_netweaver_preconfigure/tests/run-sap_netweaver_preconfigure-tests.py
@@ -134,7 +134,7 @@ for par1 in __tests:
         command += str(par2)
     command += '"'
     if (par1['compact_assert_output'] == True):
-        command += ' | ./beautify-assert-output.sh'
+        command += ' | ../tools/beautify-assert-output.sh font_color_white'
     print ("command: " + command)
     _py_rc = os.system(command)
     par1['rc'] = str(int(_py_rc/256))

--- a/roles/sap_netweaver_preconfigure/tools/beautify-assert-output.sh
+++ b/roles/sap_netweaver_preconfigure/tools/beautify-assert-output.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-if [[ ${1}. == "bright_font". ]]; then
-   awk 'BEGIN{printf ("\033[37mResetting font color\n")}'
-   exit
-elif [[ ${1}. == "dark_font". ]]; then
-   awk 'BEGIN{printf ("\033[30mResetting font color\n")}'
-   exit
+if [[ ${1}. == "font_color_white". ]]; then
+   __FONT_COLOR=37m
+elif [[ ${1}. == "font_color_black". ]]; then
+   __FONT_COLOR=30m
 fi
 
-if [[ ${__FONT_COLOR}. = "." ]]; then
-    __FONT_COLOR=30m
+if [[ ${2}. == "reset." ]]; then
+   awk 'BEGIN{printf ("\033['${__FONT_COLOR}'Resetting font color\n")}'
+   exit
 fi
 
 awk '{sub ("    \"msg\": ", "")}


### PR DESCRIPTION
The hdblcm --dump_configfile_template command already puts a default
into the `hostname` parameter, so the corresponding variable in
defaults/main.yml needs to be commented out.

For other hdblcm parameters in defaults/main.yml, additional comments
should assist in determining the relationship between the role variables
and the hdblcm parameters. Future releases could remove all deviating
role variables in favor of just using the hdblcm parameter names
prepended by the name of the role and an underscore.

Examples:
hdblcm parameter: org_manager_user
Current role variable: sap_hana_install_xs_org_user
Matching role variable: sap_hana_install_org_manager_user

hdblcm parameter: lss_userid
Current role variable: sap_hana_install_lss_user
Matching role variable: sap_hana_install_lss_userid