### PR TITLE
sap_hana_install: quickfix 

### DIFF
--- a/roles/sap_hana_install/tasks/pre_install/prepare_sapcar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/prepare_sapcar.yml
@@ -20,7 +20,7 @@
     - name: SAP HANA hdblcm prepare - SAPCAR defined - Copy the SAPCAR executable to '{{ sap_hana_install_software_extract_directory }}/sapcar'
       ansible.builtin.copy:
         src: "{{ sap_hana_install_software_directory }}/{{ sap_hana_install_sapcar_filename }}"
-        dest: "{{ sap_hana_install_software_extract_directory }}/sapcar/{{ sap_hana_install_sapcar_filename }}"
+        dest: "{{ sap_hana_install_software_extract_directory }}/sapcar/{{ sap_hana_install_sapcar_filename | basename }}"
         remote_src: true
         owner: 'root'
         group: 'root'
@@ -30,7 +30,7 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_dict_tmp: {
           dir: "{{ sap_hana_install_software_extract_directory }}/sapcar",
-          file: "{{ sap_hana_install_sapcar_filename }}",
+          file: "{{ sap_hana_install_sapcar_filename | basename }}",
           checksum_file: "{{ sap_hana_install_global_checksum_file }}",
         }
       when: sap_hana_install_global_checksum_file is defined
@@ -39,7 +39,7 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_dict_tmp: {
             dir: "{{ sap_hana_install_software_extract_directory }}/sapcar",
-            file: "{{ sap_hana_install_sapcar_filename }}",
+            file: "{{ sap_hana_install_sapcar_filename | basename }}",
             checksum_file: "{{ sap_hana_install_software_directory }}/{{ sap_hana_install_sapcar_filename }}.sha256",
         }
       when: sap_hana_install_global_checksum_file is not defined
@@ -59,7 +59,7 @@
 
     - name: SAP HANA hdblcm prepare - SAPCAR defined - Set fact for the SAPCAR executable from variable
       ansible.builtin.set_fact:
-        __sap_hana_install_fact_selected_sapcar_filename: "{{ sap_hana_install_sapcar_filename }}"
+        __sap_hana_install_fact_selected_sapcar_filename: "{{ sap_hana_install_sapcar_filename | basename }}"
 
   when: sap_hana_install_sapcar_filename is defined
 

--- a/roles/sap_swpm/tasks/pre_install/update_etchosts.yml
+++ b/roles/sap_swpm/tasks/pre_install/update_etchosts.yml
@@ -1,8 +1,7 @@
 # Update etc hosts for NW
 
 - name: SAP SWPM Pre Install - Update etc hosts for NW
-  block:
-
+  block:        
   - name: SAP SWPM Pre Install - Deduplicate values from /etc/hosts
     lineinfile:
       path: /etc/hosts
@@ -22,7 +21,6 @@
 
 - name: SAP SWPM Pre Install - Update etc hosts for HANA
   block:
-
   - name: SAP SWPM Pre Install - Deduplicate values from /etc/hosts
     lineinfile:
       path: /etc/hosts


### PR DESCRIPTION
if sapcar is in a different directory than the IMDB* file, it cannot be used. 
Hence I added "| basename" to the variable where the exact filename is needed. This doesn't change the behavior, but enables me to specify sap_hana_install_sapcar_filename relative to the HANA software directory. 
EXAMPLE:
```
# sap_hana_install
#------------------
sap_hana_install_software_directory: /software/HANA_installation
sap_hana_install_sapcar_filename: ../SAPCAR/SAPCAR_1311-80000935.EXE
sap_hana_install_common_master_password: "R3dh4t$123"
sap_hana_install_sid: 'RHE'
sap_hana_install_instance_number: "00"

```
It is tested and works
