### PR TITLE
sap_hana_install: back out changes of PR #90

### DIFF
--- a/roles/sap_hana_install/tasks/pre_install/prepare_sapcar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/prepare_sapcar.yml
@@ -20,7 +20,7 @@
     - name: SAP HANA hdblcm prepare - SAPCAR defined - Copy the SAPCAR executable to '{{ sap_hana_install_software_extract_directory }}/sapcar'
       ansible.builtin.copy:
         src: "{{ sap_hana_install_software_directory }}/{{ sap_hana_install_sapcar_filename }}"
-        dest: "{{ sap_hana_install_software_extract_directory }}/sapcar/{{ sap_hana_install_sapcar_filename | basename }}"
+        dest: "{{ sap_hana_install_software_extract_directory }}/sapcar/{{ sap_hana_install_sapcar_filename }}"
         remote_src: true
         owner: 'root'
         group: 'root'
@@ -30,7 +30,7 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_dict_tmp: {
           dir: "{{ sap_hana_install_software_extract_directory }}/sapcar",
-          file: "{{ sap_hana_install_sapcar_filename | basename }}",
+          file: "{{ sap_hana_install_sapcar_filename }}",
           checksum_file: "{{ sap_hana_install_global_checksum_file }}",
         }
       when: sap_hana_install_global_checksum_file is defined
@@ -39,7 +39,7 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_dict_tmp: {
             dir: "{{ sap_hana_install_software_extract_directory }}/sapcar",
-            file: "{{ sap_hana_install_sapcar_filename | basename }}",
+            file: "{{ sap_hana_install_sapcar_filename }}",
             checksum_file: "{{ sap_hana_install_software_directory }}/{{ sap_hana_install_sapcar_filename }}.sha256",
         }
       when: sap_hana_install_global_checksum_file is not defined
@@ -59,7 +59,7 @@
 
     - name: SAP HANA hdblcm prepare - SAPCAR defined - Set fact for the SAPCAR executable from variable
       ansible.builtin.set_fact:
-        __sap_hana_install_fact_selected_sapcar_filename: "{{ sap_hana_install_sapcar_filename | basename }}"
+        __sap_hana_install_fact_selected_sapcar_filename: "{{ sap_hana_install_sapcar_filename }}"
 
   when: sap_hana_install_sapcar_filename is defined
 

--- a/roles/sap_swpm/tasks/pre_install/update_etchosts.yml
+++ b/roles/sap_swpm/tasks/pre_install/update_etchosts.yml
@@ -1,7 +1,8 @@
 # Update etc hosts for NW
 
 - name: SAP SWPM Pre Install - Update etc hosts for NW
-  block:        
+  block:
+
   - name: SAP SWPM Pre Install - Deduplicate values from /etc/hosts
     lineinfile:
       path: /etc/hosts
@@ -21,6 +22,7 @@
 
 - name: SAP SWPM Pre Install - Update etc hosts for HANA
   block:
+
   - name: SAP SWPM Pre Install - Deduplicate values from /etc/hosts
     lineinfile:
       path: /etc/hosts


### PR DESCRIPTION
Note: ansible-lint 5.4.0 using ansible 2.12.2 completed manually for the sap*preconfigure and sap_hana_install roles.