### PR TITLE
sap_swpm: revert to pids module

### DIFF
--- a/roles/sap_swpm/requirements.yml
+++ b/roles/sap_swpm/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/ansible-collections/community.general
+    type: git
+    version: main

--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -47,9 +47,12 @@
 
 # Monitor sapinst process (i.e. ps aux | grep sapinst) and wait for exit
 - name: SAP SWPM - Wait for sapinst process to exit, poll every 60 seconds
-  shell: ps -ef | awk '/sapinst/&&!/awk/&&!/ansible/{print}'
+  community.general.pids:
+    name: sapinst
+#  shell: ps -ef | awk '/sapinst/&&!/awk/&&!/ansible/{print}'
   register: pids_sapinst
-  until: "pids_sapinst.stdout | length == 0"
+  until: "pids_sapinst.pids | length == 0"
+#  until: "pids_sapinst.stdout | length == 0"
   retries: 1000
   delay: 60
 


### PR DESCRIPTION
But use the FQCN

Reason for going back to the pids module: Tests with calling the role from Terraform lead to a failed sapinst exit detection.