### PR TITLE
sap*preconfigure: flush handlers at the end

### DIFF
--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -86,3 +86,6 @@
     - '{{ ansible_distribution.split("_")[0] }}'
     - '{{ ansible_distribution }}'
     - '{{ ansible_os_family }}.yml'
+
+# allow a reboot at the end of the preconfigure role
+- ansible.builtin.meta: flush_handlers

--- a/roles/sap_hana_preconfigure/tasks/main.yml
+++ b/roles/sap_hana_preconfigure/tasks/main.yml
@@ -46,3 +46,6 @@
   with_first_found:
     - '{{ ansible_distribution.split("_")[0] }}'
     - '{{ ansible_distribution }}'
+
+# allow a reboot at the end of the preconfigure role
+- ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Notes:
- We flush the handlers at the end of roles sap_general_preconfigure and sap_hana_preconfigure, for maximum flexibility.
- We do not flush the handlers at the end of role sap_netweaver_preconfigure because the handlers/main.yml file is empty.

Solves issue #145.

Note: With the following parameter settings, only one reboot will be performed, at the end of role sap_hana_preconfigure:
```
    sap_general_preconfigure_reboot_ok: no
    sap_general_preconfigure_fail_if_reboot_required: no
    sap_hana_preconfigure_reboot_ok: yes
    sap_hana_preconfigure_fail_if_reboot_required: no
```