### PR TITLE
sap_hana_install: Revert to empty sid and number vars in defaults/main.yml

### DIFF
--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -90,8 +90,8 @@ sap_hana_install_components: 'all'
 #sap_hana_install_hdblcm_extraargs: '--ignore=check_diskspace,check_min_mem'
 
 # Instance details
-sap_hana_install_sid: "{{ sap_hana_sid }}"
-sap_hana_install_number: "{{ sap_hana_instance_number }}"
+sap_hana_install_sid:
+sap_hana_install_number:
 sap_hana_install_install_path: '/hana/shared'
 
 # Adjust these accordingly for your installation type


### PR DESCRIPTION
Reasons:
- "global variables" sap_hana_sid and sap_hana_install_number are already used for setting the corresponding role variables which start with `sap_hana_install_` , in tasks/main.yml.

- If the variable sap_hana_instance_number is not set, the role aborts in task "Rename some variables used by hdblcm configfile" but not in task "Fail if necessary variable 'sap_hana_install_number' is not configured" . The role even would abort in tasks/main.yml if just a debug task is attempting to display the variable `sap_hana_install_number` right at the beginning.
