### PR TITLE
preconfigure: Add package_facts after the installation phase

### DIFF
--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -80,6 +80,9 @@
     - '{{ ansible_distribution }}'
     - '{{ ansible_os_family }}.yml'
 
+- name: Gather package facts again after the installation
+  ansible.builtin.package_facts:
+
 - name: Include tasks from 'configuration.yml'
   ansible.builtin.include_tasks: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}configuration.yml'
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_configuration | d(false)

--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -80,7 +80,7 @@
     - '{{ ansible_distribution }}'
     - '{{ ansible_os_family }}.yml'
 
-- name: Gather package facts again after the installation
+- name: Gather package facts again after the installation phase
   ansible.builtin.package_facts:
 
 - name: Include tasks from 'configuration.yml'

--- a/roles/sap_hana_preconfigure/tasks/main.yml
+++ b/roles/sap_hana_preconfigure/tasks/main.yml
@@ -41,6 +41,9 @@
     - '{{ ansible_distribution.split("_")[0] }}'
     - '{{ ansible_distribution }}'
 
+- name: Gather package facts again after the installation phase
+  ansible.builtin.package_facts:
+
 - include_tasks: '{{ item }}/{{ assert_prefix }}configuration.yml'
   when: sap_hana_preconfigure_config_all|d(true) or sap_hana_preconfigure_configuration|d(false)
   with_first_found:


### PR DESCRIPTION
so that we have the correct status before we start the configuration. Solves issue https://github.com/sap-linuxlab/community.sap_install/issues/176 .