### PR TITLE
sap_ha_prepare_pacemaker: ignore_errors for connectivity checkers

### DIFF
--- a/roles/sap_ha_prepare_pacemaker/tasks/main.yml
+++ b/roles/sap_ha_prepare_pacemaker/tasks/main.yml
@@ -24,6 +24,7 @@
   when:
     - ansible_hostname != __sap_ha_prepare_pacemaker_primary_node_name
   ignore_unreachable: true
+  ignore_errors: true
   failed_when: false
   changed_when: false
   become: false
@@ -40,6 +41,7 @@
       delegate_to: "{{ __sap_ha_prepare_pacemaker_primary_node_ip }}"
       register: __sap_ha_prepare_pacemaker_primary_node_ip_check
       ignore_unreachable: true
+      ignore_errors: true
       failed_when: false
       changed_when: false
 


### PR DESCRIPTION
Same improvement as in role sap_ha_install_hana_hsr, merged yesterday:
https://github.com/sap-linuxlab/community.sap_install/commit/6fe126bc348efb9aff7794e7eaed7946b6d42ce0

The `ignore_errors` are required for correct error handling in combination with `any_errors_fatal`.