### PR TITLE
[HSR] PKI filersync fix and [HA roles] linter config symlinks

### DIFF
--- a/roles/sap_ha_install_hana_hsr/.ansible-lint
+++ b/roles/sap_ha_install_hana_hsr/.ansible-lint
@@ -1,0 +1,1 @@
+../../.ansible-lint

--- a/roles/sap_ha_install_hana_hsr/.yamllint.yml
+++ b/roles/sap_ha_install_hana_hsr/.yamllint.yml
@@ -1,0 +1,1 @@
+../../.yamllint.yml

--- a/roles/sap_ha_install_hana_hsr/tasks/hdbuserstore.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/hdbuserstore.yml
@@ -14,7 +14,9 @@
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell: |
     /usr/sap/{{ sap_ha_install_hana_hsr_sid}}/SYS/exe/hdb/hdbuserstore \
-    SET {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} {{ ansible_hostname }}:3{{ sap_ha_install_hana_hsr_instance_number }}13 SYSTEM '{{ sap_ha_install_hana_hsr_db_system_password }}'
+    SET {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+    {{ ansible_hostname }}:3{{ sap_ha_install_hana_hsr_instance_number }}13 \
+    SYSTEM '{{ sap_ha_install_hana_hsr_db_system_password }}'
   args:
     executable: /bin/bash
   when: sap_ha_install_hana_hsr_hdbuserstore.rc != '0'

--- a/roles/sap_ha_install_hana_hsr/tasks/pki_files.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pki_files.yml
@@ -43,12 +43,15 @@
 
     - name: "SAP HSR - Copy PKI files from primary node"
       ansible.builtin.shell:
-        rsync -av {{ __sap_ha_install_hana_hsr_primary_node }}:{{ item }} {{ item }} \
+        rsync --checksum -vv \
+        {{ __sap_ha_install_hana_hsr_primary_node }}:{{ item }} {{ item }} \
         -e "ssh -o StrictHostKeyChecking=no -i ~/.ssh/hsr_temp"
       loop:
         - "{{ __sap_ha_install_hana_hsr_secpath }}/data/SSFS_{{ sap_ha_install_hana_hsr_sid }}.DAT"
         - "{{ __sap_ha_install_hana_hsr_secpath }}/key/SSFS_{{ sap_ha_install_hana_hsr_sid }}.KEY"
       register: __sap_ha_install_hana_hsr_fetch_pki
+      changed_when:
+        - '"is uptodate" not in __sap_ha_install_hana_hsr_fetch_pki.stdout'
 
     - name: "SAP HSR - Update PKI files permissions"
       ansible.builtin.file:

--- a/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
@@ -13,6 +13,7 @@
   ansible.builtin.lineinfile:
     path: /etc/hosts
     create: true
+    mode: '0644'
     state: present
     backup: yes
     line: "{{ item.node_ip }}\t{{ item.node_name }}.{{ sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name }}"

--- a/roles/sap_ha_install_pacemaker/.ansible-lint
+++ b/roles/sap_ha_install_pacemaker/.ansible-lint
@@ -1,0 +1,1 @@
+../../.ansible-lint

--- a/roles/sap_ha_install_pacemaker/.yamllint.yml
+++ b/roles/sap_ha_install_pacemaker/.yamllint.yml
@@ -1,0 +1,1 @@
+../../.yamllint.yml

--- a/roles/sap_ha_prepare_pacemaker/.ansible-lint
+++ b/roles/sap_ha_prepare_pacemaker/.ansible-lint
@@ -1,0 +1,1 @@
+../../.ansible-lint

--- a/roles/sap_ha_prepare_pacemaker/.yamllint.yml
+++ b/roles/sap_ha_prepare_pacemaker/.yamllint.yml
@@ -1,0 +1,1 @@
+../../.yamllint.yml

--- a/roles/sap_ha_set_hana/.ansible-lint
+++ b/roles/sap_ha_set_hana/.ansible-lint
@@ -1,0 +1,1 @@
+../../.ansible-lint

--- a/roles/sap_ha_set_hana/.yamllint.yml
+++ b/roles/sap_ha_set_hana/.yamllint.yml
@@ -1,0 +1,1 @@
+../../.yamllint.yml


### PR DESCRIPTION
**sap_ha_install_hana_hsr**
- PKI file copy via rsync not working when size and mtime of source and destination are identical
-> added `--checksum` for more reliable file comparison
-> added `-vv` for more output and parsing as `changed_when` indicator

**HA roles**
- missing role based ansible-lint and yamllint config files leads to more errors/warnings based on linter defaults
-> symlinks to repo parent created for a consistent linter config in all roles