### PR TITLE
Dev: sap_ha_install_hana_hsr: Doesn't work with multiple interfaces #181

### DIFF
--- a/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
@@ -26,7 +26,7 @@
   register: enablesr
   changed_when: "'successfully enabled system as system replication source site' in enablesr.stdout"
   when:
-    - ansible_hostname == item.node_name
+    - __sap_ha_install_hana_hsr_node_name == item.node_name.split('.')[0]
     - item.node_role is defined and item.node_role == 'primary'
     - "'is source system' not in __sap_ha_install_hana_hsr_srstate.stdout"
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
@@ -49,9 +49,9 @@
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   register: registersr
   when:
-    - ansible_hostname == item.node_name
+    - __sap_ha_install_hana_hsr_node_name == item.node_name.split('.')[0]
     - item.node_role is not defined or item.node_role == 'secondary'
-    - ansible_hostname not in __sap_ha_install_hana_hsr_srstate.stdout
+    - __sap_ha_install_hana_hsr_node_name not in __sap_ha_install_hana_hsr_srstate.stdout
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
@@ -67,5 +67,5 @@
   register: startinstance
   changed_when: "'StartSystem' in startinstance.stdout"
   when:
-    - ansible_hostname != __sap_ha_install_hana_hsr_primary_node_name
-    - ansible_hostname not in __sap_ha_install_hana_hsr_srstate.stdout
+    - __sap_ha_install_hana_hsr_node_name != __sap_ha_install_hana_hsr_primary_node_name
+    - __sap_ha_install_hana_hsr_node_name not in __sap_ha_install_hana_hsr_srstate.stdout

--- a/roles/sap_ha_install_hana_hsr/tasks/hdbuserstore.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/hdbuserstore.yml
@@ -10,6 +10,7 @@
   failed_when: false
   changed_when: false
 
+# CHECK: if ansible_hostname should be replaced by the connection interface name ?
 - name: "SAP HSR - Create and Store Connection Info in hdbuserstore"
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell: |

--- a/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
@@ -9,6 +9,7 @@
   failed_when: false
   changed_when: false
 
+# CHECK, if ansible_hostname needs to be replaced with interface name 
 - name: "SAP HSR - Set log_mode to normal"
   tags: hsr_logmode
   become: true

--- a/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
@@ -9,7 +9,7 @@
   failed_when: false
   changed_when: false
 
-# CHECK, if ansible_hostname needs to be replaced with interface name 
+# CHECK, if ansible_hostname needs to be replaced with interface name
 - name: "SAP HSR - Set log_mode to normal"
   tags: hsr_logmode
   become: true

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -8,6 +8,34 @@
   ansible.builtin.set_fact:
           __sap_ha_install_hana_hsr_node_name: "{{ ansible_hostname }}"
 
+## The following variables can be used to simplify the role
+
+- name: "SAP - HSR create information on HSR connection interface"
+  ansible.builtin.set_fact:
+    __sap_ha_install_hana_hsr_connection:
+            node_name: "{{ item.node_name.split('.')[0] }}"
+            node_domain: "{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}"
+            node_ip: "{{ item.node_ip }}"
+            node_role: "{{ item.node_role }}"
+            hana_site: "{{ item.hana_site }}"
+  when:
+    - item.node_ip in ansible_all_ipv4_addresses
+  loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
+  loop_control:
+    label: "{{ item.node_name }}"
+          
+- name: SAP HSR -  Connection Info of this host
+  debug:
+          var: __sap_ha_install_hana_hsr_connection
+
+- name: SAP HSR - Check that hsr interface is configured on host
+  ansible.builtin.assert:
+     that:
+          - __sap_ha_install_hana_hsr_connection.node_ip is defined
+          - __sap_ha_install_hana_hsr_connection.node_ip != ""
+     fail_msg: "The IP adress configured for HSR does not exist on this host"
+     success_msg: "The IP adress for HSR is configured on this host"
+
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:
     __sap_ha_install_hana_hsr_primary_node: "{{ item.node_name }}"

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -23,18 +23,18 @@
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
-          
+
 - name: SAP HSR -  Connection Info of this host
   debug:
-          var: __sap_ha_install_hana_hsr_connection
+    var: __sap_ha_install_hana_hsr_connection
 
 - name: SAP HSR - Check that hsr interface is configured on host
   ansible.builtin.assert:
-     that:
+    that:
           - __sap_ha_install_hana_hsr_connection.node_ip is defined
           - __sap_ha_install_hana_hsr_connection.node_ip != ""
-     fail_msg: "The IP adress configured for HSR does not exist on this host"
-     success_msg: "The IP adress for HSR is configured on this host"
+    fail_msg: "The IP adress configured for HSR does not exist on this host"
+    success_msg: "The IP adress for HSR is configured on this host"
 
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -21,6 +21,8 @@
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
+  when:
+    - item.node_ip in ansible_all_ipv4_addresses
 
 - name: SAP HSR -  Connection Info of this host
   debug:
@@ -33,8 +35,6 @@
           - __sap_ha_install_hana_hsr_connection.node_ip != ""
     fail_msg: "The IP adress configured for HSR does not exist on this host"
     success_msg: "The IP adress for HSR is configured on this host"
-  when:
-    - item.node_ip in ansible_all_ipv4_addresses
 
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -1,8 +1,18 @@
 ---
+
+# CHECK: we need to define variables, when the Hana Replication interface != ansible_hostname
+# for now I set the default to ansible_hostname, so I can update the rest of the role with that variable
+#  __sap_ha_install_hana_hsr_node_name
+#  __sap_ha_install_hana_hsr_node_domain
+- name: "SAP HSR - Pick up interface node name from definition"
+  ansible.builtin.set_fact:
+          __sap_ha_install_hana_hsr_node_name: "{{ ansible_hostname }}"
+
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:
     __sap_ha_install_hana_hsr_primary_node: "{{ item.node_name }}"
-    __sap_ha_install_hana_hsr_primary_node_name: "{{ item.node_name }}"
+    __sap_ha_install_hana_hsr_primary_node_name: "{{ item.node_name.split('.')[0] }}"
+    __sap_ha_install_hana_hsr_primary_node_domain: "{{ item.node_name.split('.')[1:]|join('.') }}"
     __sap_ha_install_hana_hsr_primary_node_ip: "{{ item.node_ip }}"
   when:
     - item.node_role is defined
@@ -21,7 +31,7 @@
   delegate_to: "{{ __sap_ha_install_hana_hsr_primary_node_name }}"
   register: __sap_ha_install_hana_hsr_primary_node_name_check
   when:
-    - ansible_hostname != __sap_ha_install_hana_hsr_primary_node_name
+    - __sap_ha_install_hana_hsr_node_name != __sap_ha_install_hana_hsr_primary_node_name
   ignore_unreachable: true
   ignore_errors: true
   failed_when: false
@@ -62,7 +72,7 @@
 
   # block settings
   when:
-    - ansible_hostname != __sap_ha_install_hana_hsr_primary_node_name
+    - __sap_ha_install_hana_hsr_node_name != __sap_ha_install_hana_hsr_primary_node_name
     - __sap_ha_install_hana_hsr_primary_node_name_check.unreachable is defined
     - __sap_ha_install_hana_hsr_primary_node_name_check.unreachable
   become: false
@@ -106,7 +116,7 @@
       vars:
         __sap_ha_install_hana_hsr_secpath: "/usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/global/security/rsecssfs"
   when:
-    - ansible_hostname != __sap_ha_install_hana_hsr_primary_node_name
+    - __sap_ha_install_hana_hsr_node_name != __sap_ha_install_hana_hsr_primary_node_name
   tags:
     - hsr_pki
 
@@ -119,7 +129,7 @@
       become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
       tags: hsr_backup
   when:
-    - ansible_hostname == __sap_ha_install_hana_hsr_primary_node_name
+    - __sap_ha_install_hana_hsr_node_name == __sap_ha_install_hana_hsr_primary_node_name
   tags:
     - hsr_backup
 

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -18,8 +18,6 @@
             node_ip: "{{ item.node_ip }}"
             node_role: "{{ item.node_role }}"
             hana_site: "{{ item.hana_site }}"
-  when:
-    - item.node_ip in ansible_all_ipv4_addresses
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
@@ -35,6 +33,8 @@
           - __sap_ha_install_hana_hsr_connection.node_ip != ""
     fail_msg: "The IP adress configured for HSR does not exist on this host"
     success_msg: "The IP adress for HSR is configured on this host"
+  when:
+    - item.node_ip in ansible_all_ipv4_addresses
 
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -16,17 +16,13 @@
       node_name: "{{ item.node_name.split('.')[0] }}"
       node_domain: "{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}"
       node_ip: "{{ item.node_ip }}"
-      node_role: "{{ item.node_role }}"
+      node_role: "{{ item.node_role|default('secondary') }}"
       hana_site: "{{ item.hana_site }}"
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
   when:
     - item.node_ip in ansible_all_ipv4_addresses
-
-- name: SAP HSR -  Connection Info of this host
-  debug:
-    var: __sap_ha_install_hana_hsr_connection
 
 - name: SAP HSR - Check that hsr interface is configured on host
   ansible.builtin.assert:

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -6,18 +6,18 @@
 #  __sap_ha_install_hana_hsr_node_domain
 - name: "SAP HSR - Pick up interface node name from definition"
   ansible.builtin.set_fact:
-          __sap_ha_install_hana_hsr_node_name: "{{ ansible_hostname }}"
+    __sap_ha_install_hana_hsr_node_name: "{{ ansible_hostname }}"
 
 ## The following variables can be used to simplify the role
 
 - name: "SAP - HSR create information on HSR connection interface"
   ansible.builtin.set_fact:
     __sap_ha_install_hana_hsr_connection:
-            node_name: "{{ item.node_name.split('.')[0] }}"
-            node_domain: "{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}"
-            node_ip: "{{ item.node_ip }}"
-            node_role: "{{ item.node_role }}"
-            hana_site: "{{ item.hana_site }}"
+      node_name: "{{ item.node_name.split('.')[0] }}"
+      node_domain: "{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}"
+      node_ip: "{{ item.node_ip }}"
+      node_role: "{{ item.node_role }}"
+      hana_site: "{{ item.hana_site }}"
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
@@ -31,8 +31,8 @@
 - name: SAP HSR - Check that hsr interface is configured on host
   ansible.builtin.assert:
     that:
-          - __sap_ha_install_hana_hsr_connection.node_ip is defined
-          - __sap_ha_install_hana_hsr_connection.node_ip != ""
+      - __sap_ha_install_hana_hsr_connection.node_ip is defined
+      - __sap_ha_install_hana_hsr_connection.node_ip != ""
     fail_msg: "The IP adress configured for HSR does not exist on this host"
     success_msg: "The IP adress for HSR is configured on this host"
 

--- a/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
@@ -1,7 +1,7 @@
 ---
 - name: "SAP HSR - Check /etc/hosts for conflicting entries"
   ansible.builtin.shell: |
-    awk '(/{{ item.node_name }}/ && !/^{{ item.node_ip }}/) || (/^{{ item.node_ip }}/ && !/{{ item.node_name }}/)' /etc/hosts
+    awk '(/{{ item.node_name }} / && !/^{{ item.node_ip }}/) || (/^{{ item.node_ip }}/ && !/{{ item.node_name }} /)' /etc/hosts
   register: etchosts_conflict
   changed_when: false
   failed_when: etchosts_conflict.stdout != ''
@@ -16,8 +16,8 @@
     mode: '0644'
     state: present
     backup: yes
-    line: "{{ item.node_ip }}\t{{ item.node_name }}.{{ sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name }}"
-    regexp: (?i)^\s*{{ item.node_ip }}\s+{{ item.node_name }}
+    line: "{{ item.node_ip }}\t{{ item.node_name.split('.')[0] }}.{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name.split('.')[0] }}"
+    regexp: (?i)^\s*{{ item.node_ip }}\s+{{ item.node_name.split('.')[0] }}
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
-    label: "{{ item.node_ip }} {{ item.node_name }}.{{ sap_ha_install_hana_hsr_fqdn }} {{ item.node_name }}"
+    label: "{{ item.node_ip }}\t{{ item.node_name.split('.')[0] }}.{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name.split('.')[0] }}"

--- a/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
@@ -1,7 +1,7 @@
 ---
 - name: "SAP HSR - Check /etc/hosts for conflicting entries"
   ansible.builtin.shell: |
-    awk '(/{{ item.node_name+" " }}/ && !/^{{ item.node_ip }}/) || (/^{{ item.node_ip }}/ && !/{{ item.node_name }}/)' /etc/hosts
+    awk '(/{{ "( |\t)"+item.node_name+"($| |\t)" }}/ && !/^{{ item.node_ip+"( |\t)" }}/) || (/^{{ item.node_ip+"( |\t)" }}/ && !/{{ "( |\t)"+item.node_name+"($| |\t)" }}/)' /etc/hosts
   register: etchosts_conflict
   changed_when: false
   failed_when: etchosts_conflict.stdout != ''

--- a/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
@@ -1,7 +1,7 @@
 ---
 - name: "SAP HSR - Check /etc/hosts for conflicting entries"
   ansible.builtin.shell: |
-    awk '(/{{ item.node_name }} / && !/^{{ item.node_ip }}/) || (/^{{ item.node_ip }}/ && !/{{ item.node_name }} /)' /etc/hosts
+    awk '(/{{ item.node_name+" " }}/ && !/^{{ item.node_ip }}/) || (/^{{ item.node_ip }}/ && !/{{ item.node_name }}/)' /etc/hosts
   register: etchosts_conflict
   changed_when: false
   failed_when: etchosts_conflict.stdout != ''


### PR DESCRIPTION
I started to implement the first fixes for sap_ha_install_hana_hsr to work in the lab environment
The most important fixes are:
- accepts now fqdn instead of short name for hsr interface
- proper check if full qualified domain name is given instead of short
- proper check if short name exists as substring in other names (not fully tested)
- check if hsr interface is configured
- creates internal variable with proper part of sap_hana_cluster_nodes dict

Not fixed:
- can't define HSR interface on an interface that has the same short name like the primary. This will make a wrong entry to /etc/hosts. Identical short hostnames with different domains on different interfaces will create duplicate host entry for short name

Role tested against RH445 environment