### PR TITLE
HA roles: linter fixes + new checks

### DIFF
--- a/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
@@ -4,8 +4,6 @@
     source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.sapenv.sh && \
     /usr/sap/{{ sap_ha_install_hana_hsr_sid | upper }}/HDB{{ sap_ha_install_hana_hsr_instance_number }}/exe/hdbnsutil \
     -sr_state
-  args:
-    executable: /bin/bash
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   register: __sap_ha_install_hana_hsr_srstate
@@ -19,8 +17,6 @@
     source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.sapenv.sh && \
     /usr/sap/{{ sap_ha_install_hana_hsr_sid | upper }}/HDB{{ sap_ha_install_hana_hsr_instance_number }}/exe/hdbnsutil \
     -sr_enable --name="{{ item.hana_site }}"
-  args:
-    executable: /bin/bash
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   register: enablesr
@@ -43,8 +39,6 @@
     --remoteHost={{ __sap_ha_install_hana_hsr_primary_node_name }} --remoteInstance={{ sap_ha_install_hana_hsr_instance_number }} \
     --replicationMode={{ sap_ha_install_hana_hsr_rep_mode }} --operationMode={{ sap_ha_install_hana_hsr_oper_mode }} \
     --online
-  args:
-    executable: /bin/bash
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   register: registersr
@@ -60,8 +54,6 @@
   ansible.builtin.shell: |
     /usr/sap/{{ sap_ha_install_hana_hsr_sid | upper }}/HDB{{ sap_ha_install_hana_hsr_instance_number }}/exe/sapcontrol \
     -nr {{ sap_ha_install_hana_hsr_instance_number }} -function StartSystem
-  args:
-    executable: /bin/bash
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   register: startinstance

--- a/roles/sap_ha_install_hana_hsr/tasks/hdbuserstore.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/hdbuserstore.yml
@@ -1,23 +1,24 @@
 ---
+# ansible-lint:
+# become_user string is deduced from a variable + suffix with no spaces
 - name: "SAP HSR - Check if hdbuserstore exists"
-  become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
-  ansible.builtin.shell: |
+  become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm" # noqa var-spacing
+  ansible.builtin.command: |
     /usr/sap/{{ sap_ha_install_hana_hsr_sid}}/SYS/exe/hdb/hdbuserstore \
     List {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }}
-  args:
-    executable: /bin/bash
   register: sap_ha_install_hana_hsr_hdbuserstore
   failed_when: false
   changed_when: false
 
 # CHECK: if ansible_hostname should be replaced by the connection interface name ?
+#
+# ansible-lint:
+# become_user string is deduced from a variable + suffix with no spaces
 - name: "SAP HSR - Create and Store Connection Info in hdbuserstore"
-  become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
-  ansible.builtin.shell: |
+  become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm" # noqa var-spacing
+  ansible.builtin.command: |
     /usr/sap/{{ sap_ha_install_hana_hsr_sid}}/SYS/exe/hdb/hdbuserstore \
     SET {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
     {{ ansible_hostname }}:3{{ sap_ha_install_hana_hsr_instance_number }}13 \
     SYSTEM '{{ sap_ha_install_hana_hsr_db_system_password }}'
-  args:
-    executable: /bin/bash
   when: sap_ha_install_hana_hsr_hdbuserstore.rc != '0'

--- a/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
@@ -4,10 +4,8 @@
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell: |
-    set -e -o pipefail
+    set -o pipefail &&
     grep "log_mode" /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/global/hdb/custom/config/global.ini | grep normal
-  args:
-    executable: /usr/bin/bash
   register: sap_ha_install_hana_hsr_log_mode
   failed_when: false
   changed_when: false
@@ -24,7 +22,5 @@
     ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'normal' WITH RECONFIGURE;
     ALTER SYSTEM ALTER CONFIGURATION('global.ini','HOST','{{ ansible_hostname }}') SET ('persistence','log_mode') = 'normal' WITH RECONFIGURE;
     EOF
-  args:
-    executable: /bin/bash
   ignore_errors: true
   when: sap_ha_install_hana_hsr_log_mode.rc != '0'

--- a/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
@@ -4,7 +4,10 @@
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell: |
+    set -e -o pipefail
     grep "log_mode" /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/global/hdb/custom/config/global.ini | grep normal
+  args:
+    executable: /usr/bin/bash
   register: sap_ha_install_hana_hsr_log_mode
   failed_when: false
   changed_when: false

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -14,9 +14,9 @@
   ansible.builtin.set_fact:
     __sap_ha_install_hana_hsr_connection:
       node_name: "{{ item.node_name.split('.')[0] }}"
-      node_domain: "{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}"
+      node_domain: "{{ item.node_name.split('.')[1:] | join('.') or sap_ha_install_hana_hsr_fqdn }}"
       node_ip: "{{ item.node_ip }}"
-      node_role: "{{ item.node_role|default('secondary') }}"
+      node_role: "{{ item.node_role | default('secondary') }}"
       hana_site: "{{ item.hana_site }}"
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
@@ -36,7 +36,7 @@
   ansible.builtin.set_fact:
     __sap_ha_install_hana_hsr_primary_node: "{{ item.node_name }}"
     __sap_ha_install_hana_hsr_primary_node_name: "{{ item.node_name.split('.')[0] }}"
-    __sap_ha_install_hana_hsr_primary_node_domain: "{{ item.node_name.split('.')[1:]|join('.') }}"
+    __sap_ha_install_hana_hsr_primary_node_domain: "{{ item.node_name.split('.')[1:] | join('.') }}"
     __sap_ha_install_hana_hsr_primary_node_ip: "{{ item.node_ip }}"
   when:
     - item.node_role is defined

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: "SAP HSR - Pick up interface node name from definition"
   ansible.builtin.set_fact:
     __sap_ha_install_hana_hsr_node_name: "{{ ansible_hostname }}"
+  tags: always
 
 ## The following variables can be used to simplify the role
 
@@ -23,6 +24,7 @@
     label: "{{ item.node_name }}"
   when:
     - item.node_ip in ansible_all_ipv4_addresses
+  tags: always
 
 - name: SAP HSR - Check that hsr interface is configured on host
   ansible.builtin.assert:
@@ -31,6 +33,7 @@
       - __sap_ha_install_hana_hsr_connection.node_ip != ""
     fail_msg: "The IP adress configured for HSR does not exist on this host"
     success_msg: "The IP adress for HSR is configured on this host"
+  tags: always
 
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:
@@ -44,10 +47,7 @@
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ item.node_name }}"
-  tags:
-    - hsr_hdbuserstore
-    - hsr_pki
-    - hsr_register
+  tags: always
 
 - name: "SAP HSR - Verify that Ansible can connect to the defined primary node by name"
   ansible.builtin.command: |

--- a/roles/sap_ha_install_hana_hsr/tasks/pki_files.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pki_files.yml
@@ -20,6 +20,8 @@
           cat ~/.ssh/hsr_temp.pub || \
           (ssh-keygen -t rsa -f ~/.ssh/hsr_temp -N "" -q && \
           cat ~/.ssh/hsr_temp.pub)
+      args:
+        creates: ~/.ssh/hsr_temp.pub
       register: __sap_ha_install_hana_hsr_pubkey
       failed_when: false
 
@@ -41,8 +43,10 @@
       register: __sap_ha_install_hana_hsr_addauth
       delegate_to: "{{ __sap_ha_install_hana_hsr_primary_node }}"
 
-    - name: "SAP HSR - Copy PKI files from primary node"
-      ansible.builtin.shell:
+    # ansible-lint:
+    # The synchronize module is not part of ansible-core collections.
+    - name: "SAP HSR - Copy PKI files from primary node" # noqa command-instead-of-module
+      ansible.builtin.command:
         rsync --checksum -vv \
         {{ __sap_ha_install_hana_hsr_primary_node }}:{{ item }} {{ item }} \
         -e "ssh -o StrictHostKeyChecking=no -i ~/.ssh/hsr_temp"
@@ -105,6 +109,7 @@
         dest: ~/.ssh/authorized_keys
         remote_src: true
         src: "{{ __sap_ha_install_hana_hsr_addauth.backup }}"
+        mode: "0600"
       delegate_to: "{{ __sap_ha_install_hana_hsr_primary_node }}"
       when:
         - __sap_ha_install_hana_hsr_addauth.backup is defined

--- a/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
@@ -1,21 +1,34 @@
 ---
 - name: "SAP HSR - Run backup for SYSTEMDB"
   ansible.builtin.shell: |
-    /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+    /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql -quiet \
     -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
     -m <<EOF
     BACKUP DATA FOR SYSTEMDB USING FILE ('data_bck');
     EOF
   args:
-    executable: /bin/bash
+    executable: /usr/bin/bash
+  changed_when: true
 
 - name: "SAP HSR - Run backup in TENANTDB {{ sap_ha_install_hana_hsr_sid }}"
   ansible.builtin.shell: |
-    /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+    /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql -quiet \
     -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
     -m <<EOF
     BACKUP DATA FOR {{ sap_ha_install_hana_hsr_sid }} USING FILE ('data_bck');
     EOF
   args:
-    executable: /bin/bash
-  failed_when: false
+    executable: /usr/bin/bash
+  changed_when: true
+
+- name: "SAP HSR - Verify backup files"
+  ansible.builtin.shell: |
+    source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.sapenv.sh && \
+    find /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/HDB{{ sap_ha_install_hana_hsr_instance_number }}/backup/data/ \
+    -type f -name data_bck* \
+    -exec /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbbackupcheck {} \;
+  register: __sap_ha_install_hana_hsr_verify_backup
+  failed_when:
+    - __sap_ha_install_hana_hsr_verify_backup.rc == '1' or
+      __sap_ha_install_hana_hsr_verify_backup.stderr != ""
+  changed_when: false

--- a/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
@@ -6,8 +6,6 @@
     -m <<EOF
     BACKUP DATA FOR SYSTEMDB USING FILE ('data_bck');
     EOF
-  args:
-    executable: /usr/bin/bash
   changed_when: true
 
 - name: "SAP HSR - Run backup in TENANTDB {{ sap_ha_install_hana_hsr_sid }}"
@@ -17,8 +15,6 @@
     -m <<EOF
     BACKUP DATA FOR {{ sap_ha_install_hana_hsr_sid }} USING FILE ('data_bck');
     EOF
-  args:
-    executable: /usr/bin/bash
   changed_when: true
 
 - name: "SAP HSR - Verify backup files"

--- a/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
@@ -9,15 +9,17 @@
   loop_control:
     label: "Check if {{ item.node_ip }} exists for hosts other than {{ item.node_name }}"
 
-- name: "SAP HSR - Add Cluster Nodes to /etc/hosts"
+# ansible-lint:
+# no-tabs exception for standard aligned /etc/hosts entries
+- name: "SAP HSR - Add Cluster Nodes to /etc/hosts" # noqa no-tabs
   ansible.builtin.lineinfile:
     path: /etc/hosts
     create: true
     mode: '0644'
     state: present
     backup: yes
-    line: "{{ item.node_ip }}\t{{ item.node_name.split('.')[0] }}.{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name.split('.')[0] }}"
+    line: "{{ item.node_ip }}\t{{ item.node_name.split('.')[0] }}.{{ item.node_name.split('.')[1:] | join('.') or sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name.split('.')[0] }}"
     regexp: (?i)^\s*{{ item.node_ip }}\s+{{ item.node_name.split('.')[0] }}
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
-    label: "{{ item.node_ip }}\t{{ item.node_name.split('.')[0] }}.{{ item.node_name.split('.')[1:]|join('.') or sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name.split('.')[0] }}"
+    label: "{{ item.node_ip }}\t{{ item.node_name.split('.')[0] }}.{{ item.node_name.split('.')[1:] | join('.') or sap_ha_install_hana_hsr_fqdn }}\t{{ item.node_name.split('.')[0] }}"

--- a/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
@@ -2,19 +2,29 @@
 # The following tasks are only included on the primary node!
 
 - name: "SAP Pacemaker Setup - Setup Pacemaker cluster"
-  ansible.builtin.shell: |
+  ansible.builtin.command: |
     pcs cluster setup \
     {{ sap_ha_install_pacemaker_cluster_name }} {% for node in sap_ha_install_pacemaker_cluster_nodes %}{{ node.node_name }}{{ " " if not loop.last else "" }}{% endfor %} \
-    totem token=30000 --force
+    totem token=30000 \
+    --enable --start --wait=30
+  register: __sap_ha_install_pacemaker_cluster_create
+  changed_when: __sap_ha_install_pacemaker_cluster_create.rc == 0
 
-- name: "SAP Pacemaker Setup - Start Pacemaker cluster"
+- name: "SAP Pacemaker Setup - Check cluster nodes are online"
   ansible.builtin.shell: |
-    pcs cluster start --all
-    pcs cluster enable --all
+    set -e -o pipefail
+    pcs status nodes corosync | awk -F ':' '/Offline/{print $2}'
+  args:
+    executable: /usr/bin/bash
+  register: __sap_ha_install_pacemaker_cluster_online
+  failed_when:
+    - __sap_ha_install_pacemaker_cluster_online.stderr|length != '0'
+    - __sap_ha_install_pacemaker_cluster_online.stdout|length != '0'
+  changed_when: false
 
-- name: "SAP Pacemaker Setup - Set Expected Votes = {{ sap_ha_install_pacemaker_cluster_nodes | length }}"
-  ansible.builtin.shell: |
-    pcs quorum expected-votes {{ sap_ha_install_pacemaker_cluster_nodes | length }}
+#- name: "SAP Pacemaker Setup - Set Expected Votes = {{ sap_ha_install_pacemaker_cluster_nodes | length }}"
+#  ansible.builtin.shell: |
+#    pcs quorum expected-votes {{ sap_ha_install_pacemaker_cluster_nodes | length }}
 
 - name: "SAP Pacemaker Setup - Check pcs properties"
   include_tasks: check_properties.yml

--- a/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
@@ -10,17 +10,25 @@
   register: __sap_ha_install_pacemaker_cluster_create
   changed_when: __sap_ha_install_pacemaker_cluster_create.rc == 0
 
-- name: "SAP Pacemaker Setup - Check cluster nodes are online"
+- name: "SAP Pacemaker Setup - Get cluster node corosync status"
   ansible.builtin.shell: |
     set -e -o pipefail
-    pcs status nodes corosync | awk -F ':' '/Offline/{print $2}'
+    pcs status nodes corosync | grep "Online"
   args:
     executable: /usr/bin/bash
   register: __sap_ha_install_pacemaker_cluster_online
-  failed_when:
-    - __sap_ha_install_pacemaker_cluster_online.stderr|length != '0'
-    - __sap_ha_install_pacemaker_cluster_online.stdout|length != '0'
+  failed_when: false
   changed_when: false
+
+- name: "SAP PAcemaker Setup - Verify that all nodes are online"
+  ansible.builtin.assert:
+    that:
+      - item.node_name.split('.')[0] in __sap_ha_install_pacemaker_cluster_online.stdout
+    quiet: true
+    fail_msg: "Node not found in 'Online' status!"
+  loop: "{{ sap_ha_install_pacemaker_cluster_nodes }}"
+  loop_control:
+    label: "Is online: {{ item.node_name.split('.')[0] }}"
 
 #- name: "SAP Pacemaker Setup - Set Expected Votes = {{ sap_ha_install_pacemaker_cluster_nodes | length }}"
 #  ansible.builtin.shell: |

--- a/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
@@ -12,10 +12,8 @@
 
 - name: "SAP Pacemaker Setup - Get cluster node corosync status"
   ansible.builtin.shell: |
-    set -e -o pipefail
+    set -o pipefail &&
     pcs status nodes corosync | grep "Online"
-  args:
-    executable: /usr/bin/bash
   register: __sap_ha_install_pacemaker_cluster_online
   failed_when: false
   changed_when: false

--- a/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
@@ -1,7 +1,7 @@
 ---
 # The following tasks are only included on the primary node!
 
-- name: "SAP Pacemaker Setup - Setup Pacemaker cluster"
+- name: "SAP Pacemaker Setup - Setup and enable/start Pacemaker cluster"
   ansible.builtin.command: |
     pcs cluster setup \
     {{ sap_ha_install_pacemaker_cluster_name }} {% for node in sap_ha_install_pacemaker_cluster_nodes %}{{ node.node_name }}{{ " " if not loop.last else "" }}{% endfor %} \

--- a/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/cluster_setup.yml
@@ -18,7 +18,7 @@
   failed_when: false
   changed_when: false
 
-- name: "SAP PAcemaker Setup - Verify that all nodes are online"
+- name: "SAP Pacemaker Setup - Verify that all nodes are online"
   ansible.builtin.assert:
     that:
       - item.node_name.split('.')[0] in __sap_ha_install_pacemaker_cluster_online.stdout

--- a/roles/sap_ha_install_pacemaker/tasks/main.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/main.yml
@@ -16,8 +16,6 @@
 - name: "SAP Install Pacemaker - Check Cluster"
   ansible.builtin.shell: |
     pcs cluster status
-  args:
-    executable: /bin/bash
   become: true
   become_user: root
   register: sap_ha_install_pacemaker_check_cluster

--- a/roles/sap_ha_install_pacemaker/tasks/stonith_config.yml
+++ b/roles/sap_ha_install_pacemaker/tasks/stonith_config.yml
@@ -24,8 +24,11 @@
   loop: "{{ sap_ha_install_pacemaker_stonith_devices }}"
   loop_control:
     label: "{{ item.agent }} as {{ item.name }}"
+  register: __sap_ha_install_pacemaker_configure_fence_device
   when:
     - item.name not in __sap_ha_install_pacemaker_stonith_check.stdout
+  failed_when:
+    - __sap_ha_install_pacemaker_configure_fence_device.stderr != ""
 
 - name: "SAP Pacemaker Setup - Enable the STONITH devices"
   ansible.builtin.shell: |

--- a/roles/sap_ha_prepare_pacemaker/tasks/main.yml
+++ b/roles/sap_ha_prepare_pacemaker/tasks/main.yml
@@ -115,8 +115,6 @@
 - name: "SAP Prepare Pacemaker - Check Cluster Status"
   ansible.builtin.shell: |
     pcs cluster status
-  args:
-    executable: /bin/bash
   become: true
   become_user: root
   register: sap_ha_prepare_pacemaker_check_cluster

--- a/roles/sap_ha_prepare_pacemaker/tasks/software_setup.yml
+++ b/roles/sap_ha_prepare_pacemaker/tasks/software_setup.yml
@@ -3,7 +3,6 @@
   ansible.builtin.shell: |
     yum repolist
   args:
-    executable: /bin/bash
     warn: no
   become: true
   become_user: root

--- a/roles/sap_ha_set_hana/tasks/cluster_constraint.yml
+++ b/roles/sap_ha_set_hana/tasks/cluster_constraint.yml
@@ -3,25 +3,32 @@
 
 - name: "SAP Pacemaker Hana - check constraint order HANA TOPOLOGY"
   ansible.builtin.shell: |
+    set -e -o pipefail
     pcs constraint order --full | grep "id:"| awk -F "id:" '{ print $2 }' | \
     grep order-SAPHanaTopology_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}-clone-SAPHana
-  register: sap_ha_set_hana_check_constraint_order_topology
+  args:
+    executable: /usr/bin/bash
+  register: __sap_ha_set_hana_check_constraint_order_topology
   failed_when: false
   changed_when: false
 
 - name: "SAP Pacemaker Hana - set ORDER Constraints"
-  ansible.builtin.shell: |
+  ansible.builtin.command: |
     pcs constraint order \
     SAPHanaTopology_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}-clone then \
     SAPHana_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}-clone symmetrical=false
+  register: __sap_ha_set_hana_order_constraint
   when:
-    - sap_ha_set_hana_check_constraint_order_topology.rc == 1
+    - __sap_ha_set_hana_check_constraint_order_topology.rc == 1
 
 - name: "SAP Pacemaker Hana - check constraint colocation VIP with MASTER HANA"
   ansible.builtin.shell: |
+    set -e -o pipefail
     pcs constraint colocation --full | \
     grep colocation-vip_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}_MASTER-SAPHana
-  register: sap_ha_set_hana_check_constraint_collocation_vip_master
+  args:
+    executable: /usr/bin/bash
+  register: __sap_ha_set_hana_check_constraint_collocation_vip_master
   failed_when: false
   changed_when: false
   when: sap_ha_set_hana_vip1 is defined
@@ -37,5 +44,5 @@
     then start \
     vip_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}_MASTER
   when:
-    - sap_ha_set_hana_check_constraint_collocation_vip_master.rc == 1
+    - __sap_ha_set_hana_check_constraint_collocation_vip_master.rc == 1
     - sap_ha_set_hana_vip1 is defined

--- a/roles/sap_ha_set_hana/tasks/cluster_constraint.yml
+++ b/roles/sap_ha_set_hana/tasks/cluster_constraint.yml
@@ -3,11 +3,9 @@
 
 - name: "SAP Pacemaker Hana - check constraint order HANA TOPOLOGY"
   ansible.builtin.shell: |
-    set -e -o pipefail
+    set -o pipefail &&
     pcs constraint order --full | grep "id:"| awk -F "id:" '{ print $2 }' | \
     grep order-SAPHanaTopology_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}-clone-SAPHana
-  args:
-    executable: /usr/bin/bash
   register: __sap_ha_set_hana_check_constraint_order_topology
   failed_when: false
   changed_when: false
@@ -23,11 +21,9 @@
 
 - name: "SAP Pacemaker Hana - check constraint colocation VIP with MASTER HANA"
   ansible.builtin.shell: |
-    set -e -o pipefail
+    set -o pipefail &&
     pcs constraint colocation --full | \
     grep colocation-vip_{{ sap_ha_set_hana_sid }}_{{ sap_ha_set_hana_instance_number }}_MASTER-SAPHana
-  args:
-    executable: /usr/bin/bash
   register: __sap_ha_set_hana_check_constraint_collocation_vip_master
   failed_when: false
   changed_when: false

--- a/roles/sap_ha_set_hana/tasks/cluster_resources.yml
+++ b/roles/sap_ha_set_hana/tasks/cluster_resources.yml
@@ -1,7 +1,7 @@
 ---
 # The following tasks are only included on the primary node!
 
-- name: "SAP Pacemaker Hana - Resource default update"
+- name: "SAP Pacemaker Hana - Resource defaults update command on RHEL8.2"
   ansible.builtin.set_fact:
     sap_ha_set_hana_resource_defaults: ""
   when: ansible_distribution_version == "8.2"
@@ -10,6 +10,7 @@
   ansible.builtin.shell: |
     pcs resource defaults {{ sap_ha_set_hana_resource_defaults }} resource-stickiness=1000
     pcs resource defaults {{ sap_ha_set_hana_resource_defaults }} migration-threshold=5000
+  changed_when: true
 
 - name: "SAP Pacemaker Hana - Check SAP HANA Resources Topology"
   ansible.builtin.shell: |

--- a/roles/sap_ha_set_hana/tasks/cluster_srhook.yml
+++ b/roles/sap_ha_set_hana/tasks/cluster_srhook.yml
@@ -19,8 +19,6 @@
 - name: "SAP Pacemaker Hana - check global.ini"
   ansible.builtin.shell: |
     grep ha_dr_saphanasr /usr/sap/{{ sap_ha_set_hana_sid | upper }}/SYS/global/hdb/custom/config/global.ini
-  args:
-    executable: /bin/bash
   register: trace_global
   failed_when: false
   changed_when: false


### PR DESCRIPTION
### sap_ha_install_hana_hsr
- adjustments to fix ansible-lint issues
- new: backup files are verified via `hdbbackupcheck`
- https://github.com/sap-linuxlab/community.sap_install/issues/162

### sap_ha_install_pacemaker
- adjustments to fix ansible-lint issues
- added `--enable --start --wait=30` to cluster setup command and removed separate start task
- disabled task for live update of quorum `expected-votes` - questioning/clarifying the actual need for this during provisioning
- new: check if all defined nodes are shown online after cluster setup
- new: failure conditional for stonith resource, because the command actually returns rc=0 even when it failed (e.g. for missing resource parameters)

### sap_ha_set_hana
- adjustments to fix ansible-lint issues
- added `__` prefix to internal role variable