### PR TITLE
sap_hana_preconfigure - Fixes fatal looping error, reboot logic

### DIFF
--- a/roles/sap_hana_preconfigure/handlers/main.yml
+++ b/roles/sap_hana_preconfigure/handlers/main.yml
@@ -60,7 +60,7 @@
 - name: "Debug grub-mkconfig UEFI"
   ansible.builtin.debug:
     var: __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines,
-         __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines
+      __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines
   listen: __sap_hana_preconfigure_regenerate_grub2_conf_handler
   when:
     - __sap_hana_preconfigure_register_stat_sys_firmware_efi.stat.exists
@@ -77,7 +77,7 @@
     test_command: /bin/true
   listen: __sap_hana_preconfigure_reboot_handler
   when:
-    - sap_hana_preconfigure_reboot_ok|d(false)
+    - not sap_hana_preconfigure_reboot_ok|d(false)
 
 - name: Let the role fail if a reboot is required
   ansible.builtin.fail:

--- a/roles/sap_hana_preconfigure/tasks/sapnote/1944799/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/1944799/installation.yml
@@ -5,39 +5,37 @@
 # show zypper patterns
 - name: "1944799 - PDF 8.1 Package List Pattern Also 3.5 Software selection"
   community.general.zypper:
-    name: "{{ pattern }}"
+    name: "{{ item }}"
     type: pattern
-  vars:
-    pattern:
-      - gnome_basic
-      - base
-      - enhanced_base
-      - apparmor
-      - 32bit
-      - yast2_basis
-      - sw_management
-      - fonts
-      - x11
-      - sap-hana
-      - sap_server
+  with_items:
+    - gnome_basic
+    - base
+    - enhanced_base
+    - apparmor
+    - 32bit
+    - yast2_basis
+    - sw_management
+    - fonts
+    - x11
+    - sap-hana
+    - sap_server
 
 # Requires SLE-Module-Legacy15 Module
 - name: "1944799 - PDF 8.1 Package List Packages (SLE-Module-Legacy15)"
   community.general.zypper:
-    name: "{{ packages }}"
+    name: "{{ items }}"
     type: package
-  vars:
-    packages:
-      - libssh2-1
-      - libopenssl1_1
-      - libstdc++6
-      - libatomic1
-      - libgcc_s1
-      - libltdl7
-      - insserv
-      - numactl
-      - system-user-uuidd
-      - unzip
+  with_items:
+    - libssh2-1
+    - libopenssl1_1
+    - libstdc++6
+    - libatomic1
+    - libgcc_s1
+    - libltdl7
+    - insserv
+    - numactl
+    - system-user-uuidd
+    - unzip
 
 - name: 1944799 - Install recommended packages
   community.general.zypper:

--- a/roles/sap_hana_preconfigure/tasks/sapnote/1944799/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/1944799/installation.yml
@@ -5,7 +5,7 @@
 # show zypper patterns
 - name: "1944799 - PDF 8.1 Package List Pattern Also 3.5 Software selection"
   community.general.zypper:
-    name: "{{ item }}"
+    name: "{{ package }}"
     type: pattern
   with_items:
     - gnome_basic
@@ -19,11 +19,13 @@
     - x11
     - sap-hana
     - sap_server
+  loop_control:
+    loop_var: package
 
 # Requires SLE-Module-Legacy15 Module
 - name: "1944799 - PDF 8.1 Package List Packages (SLE-Module-Legacy15)"
   community.general.zypper:
-    name: "{{ items }}"
+    name: "{{ package }}"
     type: package
   with_items:
     - libssh2-1
@@ -36,11 +38,15 @@
     - numactl
     - system-user-uuidd
     - unzip
+  loop_control:
+    loop_var: package
 
 - name: 1944799 - Install recommended packages
   community.general.zypper:
     type: package
     state: latest
-    name: "{{ item }}"
+    name: "{{ package }}"
   with_items:
     - tcsh
+  loop_control:
+    loop_var: package

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2578899/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2578899/installation.yml
@@ -2,11 +2,13 @@
 # Requires SLE-Module-Legacy15 Module
 - name: "2578899 - SAP HANA database"
   ansible.builtin.zypper:
-    name: "{{ item }}"
+    name: "{{ package }}"
     type: package
   with_items:
     - libssh2-1
     - libopenssl1_1
+  loop_control:
+    loop_var: package
 
 
 - name: 2578899 - sysstat - monitoring data

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2578899/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2578899/installation.yml
@@ -2,12 +2,11 @@
 # Requires SLE-Module-Legacy15 Module
 - name: "2578899 - SAP HANA database"
   ansible.builtin.zypper:
-    name: "{{ packages }}"
+    name: "{{ item }}"
     type: package
-  vars:
-    packages:
-      - libssh2-1
-      - libopenssl1_1
+  with_items:
+    - libssh2-1
+    - libopenssl1_1
 
 
 - name: 2578899 - sysstat - monitoring data

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/installation.yml
@@ -2,8 +2,7 @@
 # Additional notes for the installation of HANA 1.0 SPS12 and HANA 2.0 SPS03
 - name: 2777782 - Additional notes for the installation of HANA 1.0 SPS12 and HANA 2.0 SPS03
   ansible.builtin.package:
-    name: "{{ packages }}"
-  vars:
-    packages:
-      - libopenssl1_1
-      - libssh2-1
+    name: "{{ item }}"
+  with_items:
+    - libopenssl1_1
+    - libssh2-1

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/installation.yml
@@ -2,7 +2,9 @@
 # Additional notes for the installation of HANA 1.0 SPS12 and HANA 2.0 SPS03
 - name: 2777782 - Additional notes for the installation of HANA 1.0 SPS12 and HANA 2.0 SPS03
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ package }}"
   with_items:
     - libopenssl1_1
     - libssh2-1
+  loop_control:
+    loop_var: package


### PR DESCRIPTION
A `dict` is being passed into a `string` field. This is not supported. Running the role as-is from main produces this error for every step that uses the `name: "{{ packages }}"` syntax:

```
TASK [sap_hana_preconfigure : 1944799 - PDF 8.1 Package List Packages (SLE-Module-Legacy15)] ***
fatal: [heiq1hhdb05]: FAILED! => {"changed": false, "msg": "argument 'name' is of type <class 'dict'> and we were unable to convert to list: <class 'dict'> cannot be converted to a list"}
```

```
TASK [sap_hana_preconfigure : 2578899 - SAP HANA database] *********************
fatal: [heiq1hhdb05]: FAILED! => {"changed": false, "msg": "argument 'name' is of type <class 'dict'> and we were unable to convert to list: <class 'dict'> cannot be converted to a list"}
```

I have converted all package installs to a `with_items` list that is fed to the `name:` field using the `{{ item }}` variable. This allows the role to execute correctly.

Additionally, the reboot logic handler is incorrect. The handler asserts that no reboot is required when the "Reboot the managed node" step is played, but then asserts a reboot is required during the "Let the role fail if a reboot is required" step. This has been repaired by adding the same checks to the reboot step as the playbook failure handler. It will now reboot the server correctly if a reboot is required. See for the current logic error:

```
RUNNING HANDLER [sap_hana_preconfigure : Reboot the managed node] **************
skipping: [myvm] => {"changed": false, "skip_reason": "Conditional result was False"}

RUNNING HANDLER [sap_hana_preconfigure : Let the role fail if a reboot is required] ***
fatal: [myvm]: FAILED! => {"changed": false, "msg": "Reboot is required!"}

RUNNING HANDLER [sap_hana_preconfigure : Show a warning message if a reboot is required] ***
```

The loop variable `{{ item }}` is already in use and generates warnings:

```
TASK [sap_hana_preconfigure : 2588899 - I/O scheduler] *************************
[WARNING]: TASK: sap_hana_preconfigure : 2588899 - I/O scheduler: The loop
variable 'item' is already in use. You should set the `loop_var` value in the
`loop_control` option for the task to something else to avoid variable
collisions and unexpected behavior.
```

I have fixed this with a `loop_control` block.