### PR TITLE
Generation of HDBLCM config file

### DIFF
--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
@@ -31,7 +31,7 @@
   block:
 
     - name: SAP HANA Pre Install - Create the hdblcm configfile template '{{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.cfg'
-      ansible.builtin.command: "{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm --dump_configfile_template={{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.cfg"
+      ansible.builtin.command: "{{ __sap_hana_install_fact_hdblcm_path }}/hdblcm --dump_configfile_template={{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}-{{ ansible_hostname }}.cfg"
       register: __sap_hana_install_register_hdblcm_output
       changed_when: no
 
@@ -44,17 +44,17 @@
         set -o pipefail &&
         awk 'BEGIN{FS="="; printf ("\{\{ ansible_managed | comment \}\}\n# File created on: \{\{ template_host \}\}\n# Template file:   \{\{ template_path \}\}\n#\n")}
           !/^[a-z]/{print}
-          /^[a-z]/{printf ("%s=\{\{ sap_hana_install_%s|d(\047%s\047) \}\}\n", $1, $1, $2)}' {{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.cfg > {{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.j2
+          /^[a-z]/{printf ("%s=\{\{ sap_hana_install_%s|d(\047%s\047) \}\}\n", $1, $1, $2)}' {{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}-{{ ansible_hostname }}.cfg > {{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}-{{ ansible_hostname }}.j2
       register: __sap_hana_install_create_jinja2_template
       changed_when: no
 
     - name: SAP HANA Pre Install - Display the location of the remote Jinja2 template
       ansible.builtin.debug:
-        msg: "The Jinja2 template for creating the hdblcm configfile has been saved to '{{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.j2'."
+        msg: "The Jinja2 template for creating the hdblcm configfile has been saved to '{{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}-{{ ansible_hostname }}.j2'."
 
     - name: SAP HANA Pre Install - Download the Jinja2 template
       ansible.builtin.fetch:
-        src: "{{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.j2"
+        src: "{{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}-{{ ansible_hostname }}.j2"
         dest: "{{ sap_hana_install_local_configfile_directory }}"
       register: __sap_hana_install_register_fetch_hdblcm_configfile_jinja2_template
 


### PR DESCRIPTION
Two node install of SAP HANA using RHEL for SAP Collections fails because the config for node 2 uses the hostname of node 1

Error message
```
fatal: [dhcp200-237.redhat.com]: FAILED! =>
{
  "changed": true,
  "cmd": [
    "./hdblcm",
    "--ignore=check_diskspace,check_min_mem",
    "--hdbinst_server_xs_engine=off",
    "--hdbinst_server_import_content=off",
    "--configfile=/tmp/ansible.ia7cu4lchanaconfig/configfile.cfg",
    "-b"
  ],
  "delta": "0:00:04.955358",
  "end": "2022-07-21 12:25:10.811444",
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2022-07-21 12:25:05.856086",
  "stderr_lines": [
    "Running in batch mode",
    "  IP address '10.65.200.241' (host 'dhcp200-241.redhat.com') is not assigned to a local network interface"
  ],
  "stdout_lines": [
    "",
    "",
    "SAP HANA Lifecycle Management - SAP HANA Database 2.00.063.00.1655123455",
    "************************************************************************",
    "",
    "",
    "Scanning software locations...",
    "Detected components:",
    "    SAP HANA Database (2.00.063.00.1655123455) in /software/hana/extracted/SAP_HANA_DATABASE/server",
    "Log file written to '/var/tmp/hdb_DB1_hdblcm_install_2022-07-21_12.25.06/hdblcm.log' on host 'dhcp200-237'."
  ]
}
```