### PR TITLE
sap_hana_install: installation media handling actions when using NFS share

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -81,9 +81,6 @@ If this role is executed on more than one host in parallel and the software extr
 the role will only extract the files on the first host on which the extraction has started. The role will proceed on the other hosts
 after the extraction of SAR files has completed.
 
-If NFS is used for sharing the SAP HANA installation media between the nodes, then it is required to define `sap_hana_install_configfile_directory`. The default for `sap_hana_install_configfile_directory` is  "{{ sap_hana_install_software_extract_directory }}/configfiles". This variable should point to a non nfs path. After installation, if a cleanup of configfile is required, then set `sap_hana_install_cleanup_configfile_directory` as true. If a cleanup of software extract directory is required then set sap_hana_install_cleanup_extract_directory as true. The default value for both these cleanup actins are false
-
-
 - Sample directory `sap_hana_install_software_extract_directory` containing extracted SAP HANA software installation files
     ```console
     [root@hanahost extracted]# ll -lrt

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -81,11 +81,11 @@ If this role is executed on more than one host in parallel and the software extr
 the role will only extract the files on the first host on which the extraction has started. The role will proceed on the other hosts
 after the extraction of SAR files has completed.
 
-If NFS is used for sharing the SAP HANA installation media between the nodes, then it is required to define 
-`sap_hana_install_configfile_directory`. The default for `sap_hana_install_configfile_directory` is 
+If NFS is used for sharing the SAP HANA installation media between the nodes, then it is required to define
+`sap_hana_install_configfile_directory`. The default for `sap_hana_install_configfile_directory` is
 "{{ sap_hana_install_software_extract_directory }}/configfiles". This variable should point to a non nfs path. After installation,
 if a cleanup of configfile is required, then set `sap_hana_install_cleanup_configfile_directory` as true. If a cleanup of
-software extract directory is required then set `sap_hana_install_cleanup_extract_directory` as true. The default value for both 
+software extract directory is required then set `sap_hana_install_cleanup_extract_directory` as true. The default value for both
 these cleanup actions are false.
 
 

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -81,6 +81,14 @@ If this role is executed on more than one host in parallel and the software extr
 the role will only extract the files on the first host on which the extraction has started. The role will proceed on the other hosts
 after the extraction of SAR files has completed.
 
+If NFS is used for sharing the SAP HANA installation media between the nodes, then it is required to define 
+`sap_hana_install_configfile_directory`. The default for `sap_hana_install_configfile_directory` is 
+"{{ sap_hana_install_software_extract_directory }}/configfiles". This variable should point to a non nfs path. After installation,
+if a cleanup of configfile is required, then set `sap_hana_install_cleanup_configfile_directory` as true. If a cleanup of
+software extract directory is required then set `sap_hana_install_cleanup_extract_directory` as true. The default value for both 
+these cleanup actions are false.
+
+
 - Sample directory `sap_hana_install_software_extract_directory` containing extracted SAP HANA software installation files
     ```console
     [root@hanahost extracted]# ll -lrt

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -81,6 +81,9 @@ If this role is executed on more than one host in parallel and the software extr
 the role will only extract the files on the first host on which the extraction has started. The role will proceed on the other hosts
 after the extraction of SAR files has completed.
 
+If NFS is used for sharing the SAP HANA installation media between the nodes, then it is required to define `sap_hana_install_configfile_directory`. The default for `sap_hana_install_configfile_directory` is  "{{ sap_hana_install_software_extract_directory }}/configfiles". This variable should point to a non nfs path. After installation, if a cleanup of configfile is required, then set `sap_hana_install_cleanup_configfile_directory` as true. If a cleanup of software extract directory is required then set sap_hana_install_cleanup_extract_directory as true. The default value for both these cleanup actins are false
+
+
 - Sample directory `sap_hana_install_software_extract_directory` containing extracted SAP HANA software installation files
     ```console
     [root@hanahost extracted]# ll -lrt

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -11,8 +11,8 @@ sap_hana_install_software_directory: '/software/hana'
 # created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
-# If there is a requirement to cleanup "sap_hana_install_software_extract_directory" after SAP HANA Installation, then 
-# set the value to true. By default, this directory will not be removed 
+# If there is a requirement to cleanup "sap_hana_install_software_extract_directory" after SAP HANA Installation, then
+# set the value to true. By default, this directory will not be removed
 sap_hana_install_cleanup_extract_directory: false
 
 # Set this variabe to `yes` if you want to copy the SAR files from `sap_hana_install_software_directory`
@@ -54,7 +54,7 @@ sap_hana_install_verify_signature: no
 sap_hana_install_configfile_directory: "{{ sap_hana_install_software_extract_directory }}/configfiles"
 
 # If a custom path for sap_hana_install_configfile_directory was defined and if there is a requirement to cleanup this directory,
-# then set "sap_hana_install_cleanup_configfile_directory" as true. Incase if a custom path was not defined and 
+# then set "sap_hana_install_cleanup_configfile_directory" as true. Incase if a custom path was not defined and
 # "sap_hana_install_cleanup_extract_directory" was set as true, then the configfiles will be removed.
 sap_hana_install_cleanup_configfile_directory: false
 

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -11,9 +11,6 @@ sap_hana_install_software_directory: '/software/hana'
 # created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
-# If there is a requirement to cleanup "sap_hana_install_software_extract_directory" after SAP HANA Installation, then set the value to true. By default, this directory will not be removed
-sap_hana_install_cleanup_extract_directory: false
-
 # Set this variabe to `yes` if you want to copy the SAR files from `sap_hana_install_software_directory`
 # to `sap_hana_install_software_extract_directory/sarfiles` before extracting.
 # This might be useful if the SAR files are on a slow fileshare.
@@ -51,9 +48,6 @@ sap_hana_install_verify_signature: no
 # hdblcm configfile related variables:
 # Directory where to store the hdblcm configfile template and the Jinja2 template:
 sap_hana_install_configfile_directory: "{{ sap_hana_install_software_extract_directory }}/configfiles"
-
-# If a custom path for sap_hana_install_configfile_directory was defined and if there is a requirement to cleanup this directory, then set "sap_hana_install_cleanup_configfile_directory" as true. Incase if a custom path was not defined and "sap_hana_install_cleanup_extract_directory" was set as true, then the configfiles will be removed.
-sap_hana_install_cleanup_configfile_directory: false
 
 # File name prefix for the hdblcm configfile template and the Jinja2 template:
 sap_hana_install_configfile_template_prefix: "hdblcm_configfile_template"
@@ -184,4 +178,3 @@ sap_hana_install_create_initial_tenant: 'y'
 # The hostname is set by 'hdblcm --dump_configfile_template' during the preinstall phase but can also
 # be set to a different value in your playbook or hostvars:
 # sap_hana_install_hostname:
-

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -11,6 +11,9 @@ sap_hana_install_software_directory: '/software/hana'
 # created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
+# If there is a requirement to cleanup "sap_hana_install_software_extract_directory" after SAP HANA Installation, then set the value to true. By default, this directory will not be removed
+sap_hana_install_cleanup_extract_directory: false
+
 # Set this variabe to `yes` if you want to copy the SAR files from `sap_hana_install_software_directory`
 # to `sap_hana_install_software_extract_directory/sarfiles` before extracting.
 # This might be useful if the SAR files are on a slow fileshare.
@@ -48,6 +51,9 @@ sap_hana_install_verify_signature: no
 # hdblcm configfile related variables:
 # Directory where to store the hdblcm configfile template and the Jinja2 template:
 sap_hana_install_configfile_directory: "{{ sap_hana_install_software_extract_directory }}/configfiles"
+
+# If a custom path for sap_hana_install_configfile_directory was defined and if there is a requirement to cleanup this directory, then set "sap_hana_install_cleanup_configfile_directory" as true. Incase if a custom path was not defined and "sap_hana_install_cleanup_extract_directory" was set as true, then the configfiles will be removed.
+sap_hana_install_cleanup_configfile_directory: false
 
 # File name prefix for the hdblcm configfile template and the Jinja2 template:
 sap_hana_install_configfile_template_prefix: "hdblcm_configfile_template"
@@ -178,3 +184,4 @@ sap_hana_install_create_initial_tenant: 'y'
 # The hostname is set by 'hdblcm --dump_configfile_template' during the preinstall phase but can also
 # be set to a different value in your playbook or hostvars:
 # sap_hana_install_hostname:
+

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -11,6 +11,10 @@ sap_hana_install_software_directory: '/software/hana'
 # created again before the extraction starts.
 sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_directory }}/extracted"
 
+# If there is a requirement to cleanup "sap_hana_install_software_extract_directory" after SAP HANA Installation, then 
+# set the value to true. By default, this directory will not be removed 
+sap_hana_install_cleanup_extract_directory: false
+
 # Set this variabe to `yes` if you want to copy the SAR files from `sap_hana_install_software_directory`
 # to `sap_hana_install_software_extract_directory/sarfiles` before extracting.
 # This might be useful if the SAR files are on a slow fileshare.
@@ -48,6 +52,11 @@ sap_hana_install_verify_signature: no
 # hdblcm configfile related variables:
 # Directory where to store the hdblcm configfile template and the Jinja2 template:
 sap_hana_install_configfile_directory: "{{ sap_hana_install_software_extract_directory }}/configfiles"
+
+# If a custom path for sap_hana_install_configfile_directory was defined and if there is a requirement to cleanup this directory,
+# then set "sap_hana_install_cleanup_configfile_directory" as true. Incase if a custom path was not defined and 
+# "sap_hana_install_cleanup_extract_directory" was set as true, then the configfiles will be removed.
+sap_hana_install_cleanup_configfile_directory: false
 
 # File name prefix for the hdblcm configfile template and the Jinja2 template:
 sap_hana_install_configfile_template_prefix: "hdblcm_configfile_template"

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -160,6 +160,18 @@
     __sap_hana_install_fact_hana_version: "{{ __sap_hana_install_register_install_result.stdout.split(';')[0] }}"
   when: not ansible_check_mode
 
+- name: SAP HANA Post Install - Deleting software extract directory '{{ sap_hana_install_software_extract_directory }}'
+  ansible.builtin.file:
+    path: "{{ sap_hana_install_software_extract_directory }}" 
+    state: absent
+  when: sap_hana_install_cleanup_extract_directory 
+
+- name: SAP HANA Post Install - Deleting Configfile Directory '{{ sap_hana_install_configfile_directory }}'
+  ansible.builtin.file:
+    path: "{{ sap_hana_install_configfile_directory }}"
+    state: absent
+  when: sap_hana_install_cleanup_configfile_directory
+
 - name: Set fact - HANA hosts
   ansible.builtin.set_fact:
     __sap_hana_install_fact_hana_hosts: "{{ __sap_hana_install_register_install_result.stdout.split(';')[1] }}"

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -162,9 +162,9 @@
 
 - name: SAP HANA Post Install - Deleting software extract directory '{{ sap_hana_install_software_extract_directory }}'
   ansible.builtin.file:
-    path: "{{ sap_hana_install_software_extract_directory }}" 
+    path: "{{ sap_hana_install_software_extract_directory }}"
     state: absent
-  when: sap_hana_install_cleanup_extract_directory 
+  when: sap_hana_install_cleanup_extract_directory
 
 - name: SAP HANA Post Install - Deleting Configfile Directory '{{ sap_hana_install_configfile_directory }}'
   ansible.builtin.file:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -160,19 +160,6 @@
     __sap_hana_install_fact_hana_version: "{{ __sap_hana_install_register_install_result.stdout.split(';')[0] }}"
   when: not ansible_check_mode
 
-
-- name: SAP HANA Post Install - Deleting software extract directory '{{ sap_hana_install_software_extract_directory }}'
-  ansible.builtin.file:
-       path: "{{ sap_hana_install_software_extract_directory }}"
-       state: absent
-  when: sap_hana_install_cleanup_extract_directory 
-
-- name: SAP HANA Post Install - Deleting Configfile Directory '{{ sap_hana_install_configfile_directory }}'
-  ansible.builtin.file:
-       path: "{{ sap_hana_install_configfile_directory }}"
-       state: absent
-  when: sap_hana_install_cleanup_configfile_directory
-
 - name: Set fact - HANA hosts
   ansible.builtin.set_fact:
     __sap_hana_install_fact_hana_hosts: "{{ __sap_hana_install_register_install_result.stdout.split(';')[1] }}"

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -160,6 +160,19 @@
     __sap_hana_install_fact_hana_version: "{{ __sap_hana_install_register_install_result.stdout.split(';')[0] }}"
   when: not ansible_check_mode
 
+
+- name: SAP HANA Post Install - Deleting software extract directory '{{ sap_hana_install_software_extract_directory }}'
+  ansible.builtin.file:
+       path: "{{ sap_hana_install_software_extract_directory }}"
+       state: absent
+  when: sap_hana_install_cleanup_extract_directory 
+
+- name: SAP HANA Post Install - Deleting Configfile Directory '{{ sap_hana_install_configfile_directory }}'
+  ansible.builtin.file:
+       path: "{{ sap_hana_install_configfile_directory }}"
+       state: absent
+  when: sap_hana_install_cleanup_configfile_directory
+
 - name: Set fact - HANA hosts
   ansible.builtin.set_fact:
     __sap_hana_install_fact_hana_hosts: "{{ __sap_hana_install_register_install_result.stdout.split(';')[1] }}"


### PR DESCRIPTION
Requesting review from Markus Koch. Discussed with him

This PR is required to remove the extracted left overs of the SAP Install media on the node. When using with NFS Install media, the installation fails due to issue #188 so we had to define sap_hana_install_software_extract_directory. Noticed that the extracted files were not getting cleared after the SAP HANA install