### PR TITLE
Fixed failing SLES15 preconfigure

### DIFF
--- a/roles/sap_general_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_15.yml
@@ -12,3 +12,6 @@ __sap_general_preconfigure_packages:
   - hostname
 
 __sap_general_preconfigure_min_pkgs:
+__sap_general_preconfigure_packagegroups:
+__sap_general_preconfigure_envgroups:
+__sap_general_preconfigure_kernel_parameters_default:


### PR DESCRIPTION
Fix for issue https://github.com/sap-linuxlab/community.sap_install/issues/218.

This defines the following empty variables in `roles/sap_general_preconfigure/vars/SLES_15.yml`

* __sap_general_preconfigure_packagegroups:
* __sap_general_preconfigure_envgroups:
* __sap_general_preconfigure_kernel_parameters_default: 

Without these variables defined the role fails.