### PR TITLE
sap_ha_pacemaker_cluster: update argument def ha_cluster

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -45,20 +45,9 @@ On cloud platforms additional parameters are required:
 ### ha_cluster
 - _Type:_ `dict`
 
-Optional _**host_vars**_ parameter, if defined it must be set for each node.<br>
-Definition of node name and IP addresses to be used for the pacemaker cluster.<br>
-Required for resilient node communication by providing more than one corosync IP.<br>
-See https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses<br>
-
-  - **corosync_addresses**<br>
-        _Default:_ `<primary ip>`<br>
-        List of one or more IP addresses to be used for Corosync.<br>All nodes must have the same number of addresses.<br>The order of the listed addresses matters.
-  - **node_name**<br>
-        _Default:_ `<play host name>`<br>
-        The name of the node in the cluster.
-  - **pcs_address**<br>
-        _Default:_ `<play host primary address>`<br>
-        An address used by pcs to communicate with the node.<br>Can be a name, FQDN or IP address and can contain a port.
+Optional _**host_vars**_ parameter - if defined it must be set for each node.<br>
+Dictionary that can contain various node options for the pacemaker cluster configuration.<br>
+{'Supported options can be reviewed in the `ha_cluster` Linux System Role': 'https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses'}<br>
 
 Example:
 ```yaml
@@ -68,6 +57,10 @@ ha_cluster:
   - 192.168.2.10
   node_name: nodeA
   pcs_address: nodeA
+  sbd_devices:
+  - /dev/vdw
+  - /dev/vdz
+  sbd_watchdog: /dev/watchdog1
 ```
 
 ### ha_cluster_cluster_name

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -47,7 +47,7 @@ On cloud platforms additional parameters are required:
 
 Optional _**host_vars**_ parameter - if defined it must be set for each node.<br>
 Dictionary that can contain various node options for the pacemaker cluster configuration.<br>
-Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses).<br>
+Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md).<br>
 
 Example:
 ```yaml

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -47,7 +47,7 @@ On cloud platforms additional parameters are required:
 
 Optional _**host_vars**_ parameter - if defined it must be set for each node.<br>
 Dictionary that can contain various node options for the pacemaker cluster configuration.<br>
-{'Supported options can be reviewed in the `ha_cluster` Linux System Role': 'https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses'}<br>
+Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses).<br>
 
 Example:
 ```yaml

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -56,11 +56,6 @@ ha_cluster:
   - 192.168.1.10
   - 192.168.2.10
   node_name: nodeA
-  pcs_address: nodeA
-  sbd_devices:
-  - /dev/vdw
-  - /dev/vdz
-  sbd_watchdog: /dev/watchdog1
 ```
 
 ### ha_cluster_cluster_name

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -31,7 +31,7 @@ argument_specs:
         description:
           - Optional _**host_vars**_ parameter - if defined it must be set for each node.
           - Dictionary that can contain various node options for the pacemaker cluster configuration.
-          - Supported options can be reviewed in the `ha_cluster` Linux System Role: https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses
+          - Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses).
         example:
           ha_cluster:
             corosync_addresses:

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -29,10 +29,9 @@ argument_specs:
 
       ha_cluster:
         description:
-          - Optional _**host_vars**_ parameter, if defined it must be set for each node.
-          - Definition of node name and IP addresses to be used for the pacemaker cluster.
-          - Required for resilient node communication by providing more than one corosync IP.
-          - See https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses
+          - Optional _**host_vars**_ parameter - if defined it must be set for each node.
+          - Dictionary that can contain various node options for the pacemaker cluster configuration.
+          - Supported options can be reviewed in the `ha_cluster` Linux System Role: https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses
         example:
           ha_cluster:
             corosync_addresses:
@@ -40,28 +39,13 @@ argument_specs:
               - 192.168.2.10
             node_name: nodeA
             pcs_address: nodeA
+            sbd_watchdog: /dev/watchdog1
+            sbd_devices:
+              - /dev/vdw
+              - /dev/vdz
 
         required: false
         type: dict
-        options:
-          corosync_addresses:
-            default: <primary ip>
-            description:
-              - List of one or more IP addresses to be used for Corosync.
-              - All nodes must have the same number of addresses.
-              - The order of the listed addresses matters.
-            type: list
-          node_name:
-            default: <play host name>
-            description:
-              - The name of the node in the cluster.
-            type: str
-          pcs_address:
-            default: <play host primary address>
-            description:
-              - An address used by pcs to communicate with the node.
-              - Can be a name, FQDN or IP address and can contain a port.
-            type: str
 
       ha_cluster_cluster_name:
         default: my-cluster

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -38,11 +38,6 @@ argument_specs:
               - 192.168.1.10
               - 192.168.2.10
             node_name: nodeA
-            pcs_address: nodeA
-            sbd_watchdog: /dev/watchdog1
-            sbd_devices:
-              - /dev/vdw
-              - /dev/vdz
 
         required: false
         type: dict

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -31,7 +31,7 @@ argument_specs:
         description:
           - Optional _**host_vars**_ parameter - if defined it must be set for each node.
           - Dictionary that can contain various node options for the pacemaker cluster configuration.
-          - Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md#nodes-names-and-addresses).
+          - Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md).
         example:
           ha_cluster:
             corosync_addresses:


### PR DESCRIPTION
Tiny adjustment to the `ha_cluster` argument definition (native `ha_cluster` role parameter) to  allow any option instead of a limited set.