### PR TITLE
sap_ha_pacemaker_cluster: 2 small logic fixes

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -6,7 +6,7 @@
 # Do NOT USE ANSIBLE FACTS for defaults to be compatible with
 # playbooks that disable generic fact gathering!
 
-sap_ha_pacemaker_cluster_cluster_name: my-cluster
+sap_ha_pacemaker_cluster_cluster_name: "{{ ha_cluster_cluster_name | default('my-cluster') }}"
 
 sap_ha_pacemaker_cluster_create_config_varfile: false
 sap_ha_pacemaker_cluster_create_config_dest: "{{ sap_ha_pacemaker_cluster_cluster_name }}_resource_config.yml"

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -171,7 +171,9 @@
 # their user provided variables?
 
 - name: "SAP HA Install Pacemaker - Create cluster configuration parameters file"
-  when: sap_ha_pacemaker_cluster_create_config_dest is defined
+  when: 
+    - sap_ha_pacemaker_cluster_create_config_dest | length
+    - sap_ha_pacemaker_cluster_create_config_varfile
   ansible.builtin.template:
     backup: true
     dest: "{{ sap_ha_pacemaker_cluster_create_config_dest }}"
@@ -185,7 +187,9 @@
   check_mode: false
 
 - name: "SAP HA Install Pacemaker - Display configuration parameters SAVE FILE location"
-  when: sap_ha_pacemaker_cluster_create_config_varfile
+  when: 
+    - sap_ha_pacemaker_cluster_create_config_varfile
+    - sap_ha_pacemaker_cluster_create_config_dest | length
   ansible.builtin.debug:
     msg: |
       The cluster resource configuration parameters have been saved here:

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -172,8 +172,8 @@
 
 - name: "SAP HA Install Pacemaker - Create cluster configuration parameters file"
   when: 
-    - sap_ha_pacemaker_cluster_create_config_dest | length
     - sap_ha_pacemaker_cluster_create_config_varfile
+    - sap_ha_pacemaker_cluster_create_config_dest | length
   ansible.builtin.template:
     backup: true
     dest: "{{ sap_ha_pacemaker_cluster_create_config_dest }}"


### PR DESCRIPTION
**Fix 1**
The task creating the ha_cluster role compatible config vars file (for config review or re-use) is now only created when the user enables this var file creation. It was disabled by default for security reasons, but the conditional in the file creation task was missing.

**Fix 2**
The cluster name role variable now inherits the `ha_cluster` role variable for setting the cluster name, and only applies a default string if none of the 2 possible cluster name parameters is defined by the user.