### PR TITLE
Fix invalid collection version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,5 +2,5 @@
 
 collections:
   - name: fedora.linux_system_roles
-    version: latest
+    version: '>=1.13.0'
     type: galaxy

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -6,7 +6,7 @@
 # Do NOT USE ANSIBLE FACTS for defaults to be compatible with
 # playbooks that disable generic fact gathering!
 
-sap_ha_pacemaker_cluster_cluster_name: my-cluster
+sap_ha_pacemaker_cluster_cluster_name: "{{ ha_cluster_cluster_name | default('my-cluster') }}"
 
 sap_ha_pacemaker_cluster_create_config_varfile: false
 sap_ha_pacemaker_cluster_create_config_dest: "{{ sap_ha_pacemaker_cluster_cluster_name }}_resource_config.yml"

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -171,7 +171,9 @@
 # their user provided variables?
 
 - name: "SAP HA Install Pacemaker - Create cluster configuration parameters file"
-  when: sap_ha_pacemaker_cluster_create_config_dest is defined
+  when: 
+    - sap_ha_pacemaker_cluster_create_config_dest | length
+    - sap_ha_pacemaker_cluster_create_config_varfile
   ansible.builtin.template:
     backup: true
     dest: "{{ sap_ha_pacemaker_cluster_create_config_dest }}"
@@ -185,7 +187,9 @@
   check_mode: false
 
 - name: "SAP HA Install Pacemaker - Display configuration parameters SAVE FILE location"
-  when: sap_ha_pacemaker_cluster_create_config_varfile
+  when: 
+    - sap_ha_pacemaker_cluster_create_config_varfile
+    - sap_ha_pacemaker_cluster_create_config_dest | length
   ansible.builtin.debug:
     msg: |
       The cluster resource configuration parameters have been saved here:

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -172,8 +172,8 @@
 
 - name: "SAP HA Install Pacemaker - Create cluster configuration parameters file"
   when: 
-    - sap_ha_pacemaker_cluster_create_config_dest | length
     - sap_ha_pacemaker_cluster_create_config_varfile
+    - sap_ha_pacemaker_cluster_create_config_dest | length
   ansible.builtin.template:
     backup: true
     dest: "{{ sap_ha_pacemaker_cluster_create_config_dest }}"


### PR DESCRIPTION
'latest' is not a valid version key for galaxy collections and causes dependency resolutions to fail during checks.
Version syntax reference: https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#collections-older-version

Added a valid minimum version. This minimum is required for the ha_cluster role.