### PR TITLE
sap_ha_pacemaker_cluster: updated 2-node cluster sample playbook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: '^$'
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       - id: end-of-file-fixer
       - id: check-merge-conflict

--- a/docs/getting_started/sample-playbook_deploy-2-node-sap-hana-cluster.yml
+++ b/docs/getting_started/sample-playbook_deploy-2-node-sap-hana-cluster.yml
@@ -48,7 +48,7 @@
         hana_site: DC02
 
     sap_hana_vip:
-      primary: 192.168.5.64
+      primary: 192.168.1.100
 
     ha_cluster_fence_agent_packages:
       - fence-agents-rhevm

--- a/docs/getting_started/sample-playbook_deploy-2-node-sap-hana-cluster.yml
+++ b/docs/getting_started/sample-playbook_deploy-2-node-sap-hana-cluster.yml
@@ -28,15 +28,13 @@
     sap_hana_preconfigure_reboot_ok: yes
     sap_hana_preconfigure_fail_if_reboot_required: no
 
-    sap_hana_update_etchosts: yes
-
     sap_hana_sid: "DB1"
     sap_hana_instance_number: "00"
     sap_hana_install_master_password: "my-hana-password"
 
     ### Cluster Definition
-    sap_hana_cluster_name: cluster1
-    sap_hana_hacluster_password: "my_hacluster-password"
+    ha_cluster_cluster_name: cluster1
+    ha_cluster_hacluster_password: "my_hacluster-password"
 
     sap_hana_cluster_nodes:
       - node_name: node1
@@ -49,18 +47,25 @@
         node_role: secondary
         hana_site: DC02
 
-    sap_hana_vip1: 192.168.1.100
+    sap_hana_vip:
+      primary: 192.168.5.64
 
-    sap_pacemaker_stonith_devices:
-      - name: "rhevm_fence1"
-        agent: "fence_rhevm"
-        parameters: >
-          ip=rhevm-manager.example.com
-          username=rhevm-user@internal
-          password=rhevm-secret
-          pcmk_host_list='node1,node2'
-          power_wait=3
-          ssl=1 ssl_insecure=1 disable_http_filter=1
+    ha_cluster_fence_agent_packages:
+      - fence-agents-rhevm
+
+    sap_ha_pacemaker_cluster_stonith_custom:
+      - name: rhevm-fencing
+        agent: 'stonith:fence_rhevm'
+        options:
+          ip: rhevm-manager.example.com
+          username: rhevm-user@internal
+          password: rhevm-secret
+          pcmk_host_list: "{{ ansible_play_hosts_all | join(',') }}"
+          power_wait: 3
+          ssl: 1
+          ssl_insecure: 1
+          disable_http_filter: 1
+
 
   roles:
     # SAP Hana preparation and installation
@@ -71,9 +76,5 @@
     # SAP Hana System Replication setup between 2 nodes
     - name: sap_ha_install_hana_hsr
 
-    # 2-node Pacemaker Cluster Configuration
-    - name: sap_ha_prepare_pacemaker
-    - name: sap_ha_install_pacemaker
-
-    # SAP Hana Cluster Resources Configuration
-    - name: sap_ha_set_hana
+    # Pacemaker cluster installation and configuration for SAP HANA nodes
+    - name: sap_ha_pacemaker_cluster

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -171,7 +171,7 @@
 # their user provided variables?
 
 - name: "SAP HA Install Pacemaker - Create cluster configuration parameters file"
-  when: 
+  when:
     - sap_ha_pacemaker_cluster_create_config_varfile
     - sap_ha_pacemaker_cluster_create_config_dest | length
   ansible.builtin.template:
@@ -187,7 +187,7 @@
   check_mode: false
 
 - name: "SAP HA Install Pacemaker - Display configuration parameters SAVE FILE location"
-  when: 
+  when:
     - sap_ha_pacemaker_cluster_create_config_varfile
     - sap_ha_pacemaker_cluster_create_config_dest | length
   ansible.builtin.debug:


### PR DESCRIPTION
**Cluster role and sample playbook**
The sample playbook for a 2-node SAP HANA cluster has been updated to use the new `sap_ha_pacemaker_cluster` role and the adjusted input variables.

**pre-commit**
Updated version v4.0.1 -> v4.3.0.