### PR TITLE
Issue 246: removed all "warn" arguments

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -104,8 +104,6 @@
       ansible.builtin.shell: "{{ __sap_general_preconfigure_fact_yum_group_list_installed_command_assert }}"
       register: __sap_general_preconfigure_register_yum_group_assert
       changed_when: no
-      args:
-        warn: false
 
     - name: Assert that all required RHEL 7 package groups are installed
       ansible.builtin.assert:
@@ -135,8 +133,6 @@
       ansible.builtin.shell: "{{ __sap_general_preconfigure_fact_yum_envgroup_list_installed_command_assert }}"
       register: __sap_general_preconfigure_register_yum_envgroup_assert
       changed_when: no
-      args:
-        warn: false
 
     - name: Assert that all required RHEL 8 environment groups are installed
       ansible.builtin.assert:

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -105,8 +105,6 @@
 
 - name: Ensure that the required package groups are installed, RHEL 7
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} -y"
-  args:
-    warn: false
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '7'
 
@@ -118,8 +116,6 @@
 - name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9
 # Note: We want to avoid unwanted package upgrades, see bug 1983749.
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
-  args:
-    warn: false
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
 
@@ -228,8 +224,6 @@
   register: __sap_general_preconfigure_register_needs_restarting
   ignore_errors: true
   changed_when: false
-  args:
-    warn: false
   check_mode: false
 
 - name: Display the output of the reboot requirement check

--- a/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
@@ -134,8 +134,6 @@
   ansible.builtin.shell: "{{ __sap_general_preconfigure_fact_needs_restarting_command_assert }}"
   register: __sap_general_preconfigure_register_needs_restarting_assert
   changed_when: false
-  args:
-    warn: false
   check_mode: false
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 

--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -76,8 +76,6 @@
   register: __sap_general_preconfigure_register_needs_restarting
   ignore_errors: true
   changed_when: false
-  args:
-    warn: false
   check_mode: false
 
 - name: Display the output of the reboot requirement check

--- a/roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml
@@ -85,8 +85,6 @@
   ansible.builtin.shell: set -o pipefail && yum info installed {{ __sap_hana_preconfigure_required_ppc64le | map('quote') | join(' ') }} | awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
   register: __sap_hana_preconfigure_register_required_ppc64le_packages_assert
   changed_when: no
-  args:
-    warn: false
 
 - name: Assert that all required IBM packages are installed
   ansible.builtin.assert:
@@ -223,8 +221,6 @@
   ansible.builtin.shell: "{{ __sap_hana_preconfigure_fact_needs_restarting_command_assert }}"
   register: __sap_hana_preconfigure_register_needs_restarting_assert
   changed_when: false
-  args:
-    warn: false
   check_mode: false
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
 

--- a/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
@@ -209,8 +209,6 @@
   register: __sap_hana_preconfigure_register_needs_restarting
   ignore_errors: true
   changed_when: false
-  args:
-    warn: false
   check_mode: false
 
 - name: Display the output of the reboot requirement check

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2292690/10-assert-ibm-energyscale.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2292690/10-assert-ibm-energyscale.yml
@@ -14,8 +14,6 @@
       register: __sap_hana_preconfigure_register_yum_pseries_energy_assert
       changed_when: no
       ignore_errors: yes
-      args:
-        warn: false
 
     - name: Assert that package pseries-energy is not installed
       ansible.builtin.assert:

--- a/roles/sap_netweaver_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/RedHat/assert-installation.yml
@@ -16,8 +16,6 @@
   ansible.builtin.shell: rpm -q --qf "%{NAME}.%{ARCH}\n" {{ __sap_netweaver_preconfigure_adobe_doc_services_packages | map('quote') | join(' ') }}
   register: __sap_netweaver_preconfigure_register_rpm_q_ads_packages
   changed_when: no
-  args:
-    warn: false
   when: sap_netweaver_preconfigure_use_adobe_doc_services | d(false)
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 


### PR DESCRIPTION
Since I had to adjust some of these for a test with ansible 2.14, I just quickly fixed them all. :)

This should solve all lines related to issue https://github.com/sap-linuxlab/community.sap_install/issues/246.

**Before**
```
→ grep 'args:' -A5 * -r | grep warn
roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml-        warn: false
roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml-        warn: false
roles/sap_general_preconfigure/tasks/RedHat/installation.yml-    warn: false
roles/sap_general_preconfigure/tasks/RedHat/installation.yml-    warn: false
roles/sap_general_preconfigure/tasks/RedHat/installation.yml-    warn: false
roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml-    warn: false
roles/sap_general_preconfigure/tasks/SLES/installation.yml-    warn: false
roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml-    warn: false
roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml-    warn: false
roles/sap_hana_preconfigure/tasks/RedHat/installation.yml-    warn: false
roles/sap_hana_preconfigure/tasks/sapnote/2292690/10-assert-ibm-energyscale.yml-        warn: false
roles/sap_netweaver_preconfigure/tasks/RedHat/assert-installation.yml-    warn: false
```

**After**
- no findings of `args:` `warn` anymore