### PR TITLE
sap_hana_preconfigure: Add missing repo vars for rhel-9.x

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -25,6 +25,76 @@ __sap_hana_preconfigure_req_repos_redhat_9_1_ppc64le:
   - "rhel-9-for-ppc64le-appstream-rpms"
   - "rhel-9-for-ppc64le-sap-solutions-rpms"
 
+__sap_hana_preconfigure_req_repos_redhat_9_2_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms" 
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_2_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_3_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_3_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_4_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_4_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_5_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_5_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_6_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_6_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_7_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_7_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_8_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_8_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
 # required SAP notes for RHEL 9:
 __sap_hana_preconfigure_sapnotes_versions_x86_64:
   - { number: '2777782', version: '22' }


### PR DESCRIPTION
Add missing repo vars for rhel-9.x. It should resolve this issue  https://github.com/sap-linuxlab/community.sap_install/issues/265