### PR TITLE
sap_swpm: Add some tags (issue 281)

### DIFF
--- a/roles/sap_swpm/tasks/main.yml
+++ b/roles/sap_swpm/tasks/main.yml
@@ -2,9 +2,14 @@
 
 - name: SAP SWPM - run pre_install tasks
   ansible.builtin.import_tasks: pre_install.yml
+  tags:
+    - sap_swpm_pre_install
+    - sap_swpm_install
 
 - name: SAP SWPM - run swpm
   ansible.builtin.import_tasks: swpm.yml
+  tags:
+    - sap_swpm_install
 
 - name: SAP SWPM - run postinstall task
   ansible.builtin.import_tasks: post_install.yml

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -6,7 +6,9 @@
 
 - name: SAP SWPM Pre Install - Run Preinstallation Steps
   ansible.builtin.include_tasks: swpm/swpm_pre_install.yml
-
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
 
 ################
 # Set sapinst command
@@ -20,6 +22,7 @@
     # IF SWPM is running a HA installation, Ansible Variable sap_swpm_swpm_command_virtual_hostname is set and contains "SAPINST_USE_HOSTNAME={{ sap_swpm_virtual_hostname }}"
     # If SWPM is running a MP Stack XML installation, Ansible Variable sap_swpm_swpm_command_mp_stack is set and contains "SAPINST_STACK_XML={{ sap_swpm_mp_stack_path }}/{{ sap_swpm_mp_stack_file_name }}"
     sap_swpm_swpm_command_extra_args: "SAPINST_SKIP_DIALOGS=true SAPINST_START_GUISERVER=false {{ sap_swpm_swpm_command_virtual_hostname }} {{ sap_swpm_swpm_command_mp_stack }}"
+  tags: sap_swpm_sapinst_commandline
 
 ################
 # Pre Install Optional Tasks
@@ -29,15 +32,13 @@
 
 - name: SAP SWPM Pre Install - Firewall Setup
   ansible.builtin.include_tasks: pre_install/firewall.yml
-  when:
-    - "sap_swpm_setup_firewall | bool"
+  when: "sap_swpm_setup_firewall | bool"
 
 # /etc/hosts
 
 - name: SAP SWPM Pre Install - Update /etc/hosts
   ansible.builtin.include_tasks: pre_install/update_etchosts.yml
-  when:
-    - "sap_swpm_update_etchosts | bool"
+  when: "sap_swpm_update_etchosts | bool"
 
 ################
 # Display Parameters

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -31,14 +31,22 @@
 # Firewall
 
 - name: SAP SWPM Pre Install - Firewall Setup
-  ansible.builtin.include_tasks: pre_install/firewall.yml
+  ansible.builtin.include_tasks:
+    file: pre_install/firewall.yml
+    apply:
+      tags: sap_swpm_setup_firewall
   when: "sap_swpm_setup_firewall | bool"
+  tags: sap_swpm_setup_firewall
 
 # /etc/hosts
 
 - name: SAP SWPM Pre Install - Update /etc/hosts
-  ansible.builtin.include_tasks: pre_install/update_etchosts.yml
+  ansible.builtin.include_tasks:
+    file: pre_install/update_etchosts.yml
+    apply:
+      tags: sap_swpm_update_etchosts
   when: "sap_swpm_update_etchosts | bool"
+  tags: sap_swpm_update_etchosts
 
 ################
 # Display Parameters

--- a/roles/sap_swpm/tasks/pre_install/install_type.yml
+++ b/roles/sap_swpm/tasks/pre_install/install_type.yml
@@ -7,7 +7,6 @@
     sap_swpm_swpm_command_virtual_hostname: ""
     sap_swpm_swpm_command_mp_stack: ""
 
-
 ################
 # Determine Installation Type
 ################
@@ -47,7 +46,10 @@
 # Run Installation Type Steps
 ################
 
+- name: SAP SWPM Pre Install - Display the Installation Type
+  ansible.builtin.debug:
+    var: sap_swpm_swpm_installation_type
+
 - name: SAP SWPM Pre Install - Run Installation Type Steps
   ansible.builtin.include_tasks: "install_type/{{ sap_swpm_swpm_installation_type }}_install.yml"
-  when:
-    - "sap_swpm_swpm_installation_type | length > 0"
+  when: "sap_swpm_swpm_installation_type | length > 0"

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced.yml
@@ -1,11 +1,12 @@
 ---
 
 # Remove Existing inifile.params
-- name: SAP SWPM advanced mode - Create inifile.params
+- name: SAP SWPM advanced mode - Ensure 'inifile.params' exists
   ansible.builtin.file:
     path: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     state: touch
     mode: '0640'
+  tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM advanced mode - Loop over the dictionary and output to file
   ansible.builtin.lineinfile:
@@ -13,13 +14,17 @@
     state: present
     line: "{{ item.key }} = {{ item.value }}"
   with_dict: "{{ sap_swpm_inifile_custom_values_dictionary }}"
+  tags: sap_swpm_generate_inifile
 
 # NOTE: Values in Dictionary Keys for instance numbers must be string using '01' single quote, otherwise SAP SWPM will crash
 
-
 # Detect variables from generated inifile
 - name: SAP SWPM advanced mode - Detect Variables
-  ansible.builtin.include_tasks: detect_variables.yml
+  ansible.builtin.include_tasks:
+    file: detect_variables.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Prepare Software
 - name: SAP SWPM advanced mode - Prepare Software

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced_templates.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced_templates.yml
@@ -4,19 +4,22 @@
 - name: SAP SWPM advanced_templates mode - Set product_catalog_id
   ansible.builtin.set_fact:
     sap_swpm_product_catalog_id: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_product_catalog_id'] }}"
+  tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM advanced_templates mode - Create temporary directory
   ansible.builtin.tempfile:
     state: directory
     suffix: swpmconfig
   register: sap_swpm_tmpdir
+  tags: sap_swpm_generate_inifile
 
 # Remove Existing inifile.params
-- name: SAP SWPM advanced_templates mode - Ensure inifile.params
+- name: SAP SWPM advanced_templates mode - Ensure 'inifile.params' exists
   ansible.builtin.file:
     path: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     state: touch
     mode: '0640'
+  tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM advanced_templates mode - Loop over the dictionary and output to file
   ansible.builtin.lineinfile:
@@ -25,18 +28,22 @@
     insertafter: EOF
     line: "{{ item.key }}={{ item.value }}"
   with_dict: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_custom_values_dictionary'] }}"
+  tags: sap_swpm_generate_inifile
 
 # NOTE: Values in Dictionary Keys for instance numbers must be string using '01' single quote, otherwise SAP SWPM will crash
 
 
 # Detect variables from generated inifile
 - name: SAP SWPM advanced_templates mode - Detect Variables
-  ansible.builtin.include_tasks: detect_variables.yml
+  ansible.builtin.include_tasks:
+    file: detect_variables.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Prepare Software
 - name: SAP SWPM advanced_templates mode - Prepare Software
   ansible.builtin.include_tasks: prepare_software.yml
-
 
 # ALT: Generate complete inifile.params with all parameters from control.xml, for every SAP software product
 #- name: ALT: SAP SWPM advanced_templates mode - Generate complete inifile.params

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_default.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_default.yml
@@ -2,11 +2,19 @@
 
 # Determine Installation Type
 - name: SAP SWPM default mode - Determine Installation Type
-  ansible.builtin.include_tasks: "../pre_install/install_type.yml"
+  ansible.builtin.include_tasks:
+    file: ../pre_install/install_type.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Password Facts
 - name: SAP SWPM default mode - Password Facts
-  ansible.builtin.include_tasks: ../pre_install/password_facts.yml
+  ansible.builtin.include_tasks:
+    file: ../pre_install/password_facts.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Prepare Software
 - name: SAP SWPM default mode - Prepare Software
@@ -19,3 +27,4 @@
     dest: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     mode: '0640'
   register: sap_swpm_cftemplate
+  tags: sap_swpm_generate_inifile

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_default_templates.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_default_templates.yml
@@ -5,25 +5,35 @@
   ansible.builtin.set_fact:
     sap_swpm_product_catalog_id: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_product_catalog_id'] }}"
     sap_swpm_inifile_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_list'] }}"
+  tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM default_templates mode - Set product_catalog_id and inifile_list
   ansible.builtin.set_fact:
     sap_swpm_java_template_id_selected_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_java_template_id_selected_list'] }}"
   when: "'java' in sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_product_catalog_id'] | lower"
+  tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM default_templates mode - If not already defined, use the default variable for the template
   ansible.builtin.set_fact:
     "{{ item.key }}": "{{ item.value }}"
   with_dict: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_dictionary'] }}"
-
+  tags: sap_swpm_generate_inifile
 
 # Determine Installation Type
 - name: SAP SWPM default_templates mode - Determine Installation Type
-  ansible.builtin.include_tasks: "../pre_install/install_type.yml"
+  ansible.builtin.include_tasks:
+    file: ../pre_install/install_type.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Password Facts
 - name: SAP SWPM default_templates mode - Password Facts
-  ansible.builtin.include_tasks: ../pre_install/password_facts.yml
+  ansible.builtin.include_tasks:
+    file: ../pre_install/password_facts.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Prepare Software
 - name: SAP SWPM default_templates mode - Prepare Software
@@ -36,3 +46,4 @@
     dest: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     mode: '0640'
   register: sap_swpm_cftemplate
+  tags: sap_swpm_generate_inifile

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_inifile_reuse.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_inifile_reuse.yml
@@ -6,22 +6,29 @@
     src: "{{ sap_swpm_inifile_reuse_source }}"
     dest: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     mode: '0640'
+  tags: sap_swpm_generate_inifile
 
 # Check inifile for des25
 - name: SAP SWPM inifile_reuse mode - Check inifile for des25
   ansible.builtin.shell: set -o pipefail && cat "{{ sap_swpm_tmpdir.path }}/inifile.params" | grep des25 | wc -l
   register: sap_swpm_inifile_read_file
   changed_when: false
+  tags: sap_swpm_generate_inifile
 
 # Check if inifile is reusable
 - name: SAP SWPM inifile_reuse mode - Check if inifile is reusable
   ansible.builtin.fail:
     msg: "{{ sap_swpm_inifile_reuse_source }} is not reusable"
   when: sap_swpm_inifile_read_file.stdout != '0'
+  tags: sap_swpm_generate_inifile
 
 # Detect variables from generated inifile
 - name: SAP SWPM inifile_reuse mode - Detect Variables
-  ansible.builtin.include_tasks: detect_variables.yml
+  ansible.builtin.include_tasks:
+    file: detect_variables.yml
+    apply:
+      tags: sap_swpm_generate_inifile
+  tags: sap_swpm_generate_inifile
 
 # Prepare Software
 - name: SAP SWPM inifile_reuse mode - Prepare Software

--- a/roles/sap_swpm/tasks/swpm/swpm_pre_install.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_pre_install.yml
@@ -6,6 +6,9 @@
     state: directory
     suffix: swpmconfig
   register: sap_swpm_tmpdir
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
 
 # Copy password file to the same location as inifile.params
 - name: SAP SWPM Pre Install - Copy password file to the same location as inifile.params
@@ -15,17 +18,24 @@
     remote_src: yes
     mode: '0640'
   when: sap_swpm_use_password_file == "y"
+  tags: sap_swpm_generate_inifile
 
 # Run SWPM inifile generation based on ansible role mode
-- name: SAP SWPM - generate swpm inifile
+- name: SAP SWPM Pre Install - generate swpm inifile
   ansible.builtin.include_tasks: "swpm_inifile_generate_{{ sap_swpm_ansible_role_mode }}.yml"
+  tags: sap_swpm_generate_inifile
+
+- name: SAP SWPM Pre Install - Display the location of file 'inifile.params'
+  ansible.builtin.debug:
+    msg: "{{ sap_swpm_tmpdir.path }}/inifile.params"
+  tags: sap_swpm_generate_inifile
 
 # Set fact for SWPM path
 - name: SAP SWPM Pre Install - Set fact for SWPM path
   ansible.builtin.set_fact:
     sap_swpm_sapinst_path: "{{ sap_swpm_swpm_path }}/sap_swpm_extracted"
 
-- name: Create directories if does not exist
+- name: SAP SWPM Pre Install - Ensure directory '{{ sap_swpm_sapinst_path }}' exists
   ansible.builtin.file:
     path: "{{ sap_swpm_sapinst_path }}"
     state: directory


### PR DESCRIPTION
Add some tags to allow for easily executing only certain steps of the role:
- sap_swpm_pre_install: Only run all preinstallation steps
- sap_swpm_generate_inifile: Only generate the SWPM inifile
- sap_swpm_sapinst_commandline: Only display the full sapinst command line
- sap_swpm_install: Run all preinstallation and installation steps but omit the postinstallation steps