### PR TITLE
sap_ha_pacemaker_cluster: docs and playbook updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# community.sap_install Ansible Collection ![Ansible Lint](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint.yml/badge.svg?branch=main)
+# community.sap_install Ansible Collection
+
+![Ansible Lint](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint.yml/badge.svg?branch=main)
 
 This Ansible Collection executes various SAP Software installations and configuration tasks for running SAP software on Linux operating systems; with handlers for SAP HANA database lifecycle manager (HDBLCM) and SAP Software Provisioning Manager (SWPM) for programmatic deployment of any SAP solution scenario.
 
@@ -49,9 +51,7 @@ Within this Ansible Collection, there are various Ansible Roles and no custom An
 | [sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_install)                     | install SAP HANA via HDBLCM                                            |
 | [sap_swpm](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_swpm)                                     | install SAP Software via SWPM                                          |
 | [sap_ha_install_hana_hsr](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_install_hana_hsr)       | install SAP HANA System Replication                                    |
-| [sap_ha_prepare_pacemaker](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_prepare_pacemaker)     | prepare for Linux Pacemaker installation                               |
-| [sap_ha_install_pacemaker](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_install_pacemaker)     | install and configure Linux Pacemaker                                  |
-| [sap_ha_set_hana](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_set_hana)                       | configure HA/DR for SAP HANA                                           |
+| [sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_pacemaker_cluster)     | install and configure pacemaker and SAP resources |
 | [sap_ha_set_netweaver](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_set_netweaver)             | configure HA/DR for SAP NetWeaver                                      |
 | [sap_hostagent](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hostagent)                           | install SAP Host Agent                                                 |
 | [sap_storage_setup](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_storage_setup)                               | configure storage for SAP HANA, with LVM partitions and XFS filesystem |
@@ -66,12 +66,15 @@ The logic has been separated to support a flexible execution of the different st
 
 | Role Name                                                                                                                      | Ansible Lint Status                                                                                                                                                                                                                                                                                      |
 | :----------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)     | [![Ansible Lint for sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_general_preconfigure.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_general_preconfigure.yml)       |
-| [sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_netweaver_preconfigure) | [![Ansible Lint for sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_netweaver_preconfigure.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_netweaver_preconfigure.yml) |
-| [sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_preconfigure)           | [![Ansible Lint for sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_hana_preconfigure.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_hana_preconfigure.yml)                |
-| [sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_install)                     | [![Ansible Lint for sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_hana_install.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint%20sap_hana_install.yml)                               |
+| [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)     | [![Ansible Lint for sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_general_preconfigure.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_general_preconfigure.yml)       |
+| [sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_netweaver_preconfigure) | [![Ansible Lint for sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_netweaver_preconfigure.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_netweaver_preconfigure.yml) |
+| [sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_preconfigure)           | [![Ansible Lint for sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_hana_preconfigure.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lintsap_hana_preconfigure.yml)                |
+| [sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_install)                     | [![Ansible Lint for sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_hana_install.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_hana_install.yml)                               |
+| [sap_ha_install_hana_hsr](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_install_hana_hsr)       | [![Ansible Lint for sap_ha_install_hana_hsr](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_ha_install_hana_hsr.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_ha_install_hana_hsr.yml)                               |
+| [sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_pacemaker_cluster)                     | [![Ansible Lint for sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_ha_pacemaker_cluster.yml/badge.svg)](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_ha_pacemaker_cluster.yml)                               |
 
 **_Notes:_**
+
 - Ansible Playbook localhost executions may have limitations on SAP Software installations
 - Ansible Roles for HA/DR are all designed for execution with Terraform
 
@@ -144,5 +147,3 @@ SAP SWPM Catalog Products which have been tested:
 ## Contributors
 
 Contributors to the Ansible Roles within this Ansible Collection, are shown within [/docs/contributors](./docs/CONTRIBUTORS.md).
-
-[^rhel]: [Overview of the Red Hat Enterprise Linux for SAP Solutions subscription](https://access.redhat.com/solutions/3082481)

--- a/docs/getting_started/secure-your-passwords.md
+++ b/docs/getting_started/secure-your-passwords.md
@@ -23,13 +23,14 @@ Enter your secret password as single string in a file and save it. Make sure the
 vi passfile
 ```
 
-Use ansible-vault to encrypt the string, which it reads from the file. Adding the variable name will using `-n` will give you the full variable definition that can be copied directly into your `vars:` section of the playbook or the desired place of your variable definition (group_vars, host_vars, etc.).
+Use ansible-vault to encrypt the string, which it reads from the file. Adding the variable name using `-n` will give you the full variable definition that can be copied directly into your `vars:` section of the playbook or the desired place of your variable definition (group_vars, host_vars, etc.).
 
 ```bash
 ansible-vault encrypt_string $(cat passfile) -n my_secret_var
 ```
 
-Ansible-vault will ask to enter a password which is required to automatically encrypt the value during ansible runtime afterwards.
+Ansible-vault will ask to enter a vault password, which is required to decrypt the value during ansible runtime afterwards.  
+Consider this the "master key" for your vault-encrypted credentials.
 
 ```text
 New Vault password:
@@ -44,15 +45,11 @@ my_secret_var: !vault |
 Encryption successful
 ```
 
-Save the `my_secret_var` and encrypted value in your variable definitions and include the definition file as usual.
+Save the `my_secret_var` and encrypted multi-line value in your variable definitions and include the definition file as usual.  
 The variable can as well be referenced and used by other variables for more flexibility.
 
 ```yaml
 playbook1_secret_var: "{{ my_secret_var }}"
-```
-
-```yaml
-playbook5_secret_var: "{{ my_secret_var }}"
 ```
 
 This way the value is only present and managed in one place and can be used by different playbooks.
@@ -65,7 +62,8 @@ rm passfile
 
 ## Run playbook which uses vault-encrypted content
 
-For the encryption to work during ansible / ansible-playbook execution you have to tell ansible to prompt for the vault password.
+As soon as a vault-encrypted value is present in your playbook, ansible will require the vault password to be entered for playbook execution.  
+Add `--ask-vault` to your `ansible-playbook` command to prompt for this "master key" password and allow secure decryption.
 
 ```bash
 ansible-playbook tasks_with_secrets.yml [...] --ask-vault
@@ -77,10 +75,10 @@ _When encrypting multiple values that will be used together, you have to make su
 
 You can also encrypt an entire file, e.g. containing multiple secrets.
 
-However, if variables are defined in the file it will encrypt the variable names as well and makes it harder to identify the source definition of a referenced variable.
+However, if variables are defined in the file it will encrypt the variable names as well and makes it harder to identify the source definition of a referenced variable.  
 Also, encrypting the entire file will require ansible-vault commands to view or edit the contents of the file. A file containing individually encrypted values can be viewed and edited as any other file without uncovering the actual secret value.
 
-It will prompt for the vault password - either to be created, or to be used for decrypting the existing content.
+`ansible-vault` will prompt for the vault password - either to be created for a new encrypted file, or to be used for decrypting existing content (for view or edit operations).
 
 ```bash
 ansible-vault encrypt file_containing_secrets.yml
@@ -89,11 +87,13 @@ ansible-vault view file_containing_secrets.yml
 ansible-vault edit file_containing_secrets.yml
 ```
 
-Including this file and using it works the same way as any other included file, as long as the vault password is provided to ansible during execution.
+This file can be included into a playbook similar to any other file include.  
+The playbook will only be usable when the correct vault password is provided to `ansible-playbook` for the runtime, see above.
 
 ## More features and information
 
 Vault encryption can also be done through password-files, scripts or automation software which provides secure ways to manage vault credentials.
 For more complex ways to use ansible vault encryption/decryption please refer to the documentation.
-https://docs.ansible.com/ansible/latest/user_guide/vault.html
-https://docs.ansible.com/ansible/latest/cli/ansible-vault.html
+
+- [Ansible Vault User Guide](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
+- [Ansible Vault CLI Guide](https://docs.ansible.com/ansible/latest/cli/ansible-vault.html)

--- a/playbooks/sample-deploy-2-node-sap-hana-pacemaker-cluster.yml
+++ b/playbooks/sample-deploy-2-node-sap-hana-pacemaker-cluster.yml
@@ -9,10 +9,11 @@
 # please update the "vars" parameters with values
 # corresponding to your individual naming standards
 # and infrastructure (e.g. IP definitions matching your network).
-
-# Prerequisite:
-# - target nodes are registered with subscription-manager and
-#   subscribed to "RHEL for SAP Solutions"
+#
+# NOTE:
+# For simplicity the sample password values are plain text. Please make sure to
+# apply security measures to any credentials, for instance using ansible-vault
+# encryption.
 
 - name: "Install SAP HANA and configure it in a 2-node pacemaker cluster"
   hosts: node1, node2

--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -1,6 +1,11 @@
 # sap_ha_install_hana_hsr Ansible Role
 
-Ansible role for SAP HANA System Replication Setup on 2 nodes with the same OS and SAP HANA release.
+Ansible role for SAP HANA System Replication Setup on 2 nodes.
+
+## Prerequisites
+
+- target nodes are on the same OS level
+- target nodes are using the same SAP HANA release
 
 ## Overview
 
@@ -11,10 +16,8 @@ The **sap_ha_install_hana_hsr** role is part of this system role sequence:
 |    1.    | sap_general_preconfigure | System Preparation for SAP                                   |
 |    2.    | sap_hana_preconfigure    | System Preparation for SAP HANA                              |
 |    3.    | sap_hana_install         | Installation of SAP HANA Database                            |
-|    4.    | sap_ha_install_hana_hsr  | Configuration of SAP HANA System Replication                 |
-|    5.    | sap_ha_prepare_pacemaker | Authentication and Preparation of Nodes for Cluster Creation |
-|    6.    | sap_ha_install_pacemaker | Initialization of the Pacemaker Cluster                      |
-|    7.    | sap_ha_set_hana          | Configuration of SAP HANA Resources for SAP Solutions        |
+|  _4._    | _sap_ha_install_hana_hsr_ | _Configuration of SAP HANA System Replication_              |
+|    5.    | sap_ha_pacemaker_cluster | Linux Pacemaker cluster setup and SAP resources configuration |
 
 The **sap_ha_install_hana_hsr** roles configures a HANA system replication relationship which is used by the pacemaker cluster to automate SAP HANA System Replication (HSR). Prerequisite is the SAP HANA installation on the nodes.
 
@@ -22,8 +25,8 @@ The **sap_ha_install_hana_hsr** roles configures a HANA system replication relat
 
 | Task                   | Description                                                                         |
 | ---------------------- | ----------------------------------------------------------------------------------- |
-| update_etchosts.yml    | all nodes of the cluster will be entered into the /etc/hosts, if not already exists |
-| configure_firewall.yml | this will configure the firewall für HANA system replication (opional)              |
+| update_etchosts.yml    | ensures that all nodes of the cluster are configured in all nodes' /etc/hosts       |
+| configure_firewall.yml | this will configure the firewall für HANA system replication (disabled)        |
 | hdbuserstore.yml       | create a user in the hdbuserstore                                                   |
 | log_mode.yml           | check/set database logmode                                                          |
 | pki_files.yml          | copy pki file from primary to secondary database                                    |
@@ -32,11 +35,11 @@ The **sap_ha_install_hana_hsr** roles configures a HANA system replication relat
 
 ## Common Variables/Parameters Used
 
-| Name                             | Description                     | Value            |
-| -------------------------------- | ------------------------------- | ---------------- |
-| sap_domain                       | Domain Name                     | e.g. example.com |
-| sap_hana_sid                     | SAP ID                          | e.g. RH1         |
-| sap_hana_instance_number         | Instance Number                 | e.g. 00          |
+| Name                             | Description                     | Value                  |
+| -------------------------------- | ------------------------------- | ---------------------- |
+| sap_domain                       | Domain Name                     | example: `example.com` |
+| sap_hana_sid                     | SAP ID                          | example: `RH1`         |
+| sap_hana_instance_number         | Instance Number                 | example: `"00"`        |
 | sap_hana_install_master_password | DB System Password              |
 | sap_hana_cluster_nodes           | Parameter list of cluster nodes |
 | sap_hana_hacluster_password      | Pacemaker hacluster Password    |
@@ -47,14 +50,6 @@ The **sap_ha_install_hana_hsr** roles configures a HANA system replication relat
 | --------------------------------- | ---------------- | -------------------- |
 | sap_ha_install_hana_hsr_rep_mode  | replication mode | default is sync      |
 | sap_ha_install_hana_hsr_oper_mode | operation mode   | default is logreplay |
-
-In most cases you need to specify these variables only, if you want to use different values than the default values.
-
-## Requirements, Dependencies and Testing
-
-Tests are performed with other Ansible Roles in the sequence. Please refer to tests performed with final Ansible Roles:
-- [sap_ha_set_hana Ansible Role - Requirements, Dependencies and Testing](../sap_ha_set_hana/README.md#requirements-dependencies-and-testing)
-- [sap_ha_set_netweaver Ansible Role - Requirements, Dependencies and Testing](../sap_ha_set_netweaver/README.md#requirements-dependencies-and-testing)
 
 ## Example Parameter File
 

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -1,33 +1,53 @@
 <!-- BEGIN: Role Introduction -->
 # sap_ha_pacemaker_cluster Ansible Role
 
-This role installs pacemaker cluster packages and configures the cluster and SAP cluster resources.
-The cluster setup is managed through the `ha_cluster` Linux System Role.<br>
-`sap_ha_pacemaker_cluster` is acting as a wrapper that takes care of the SAP environment parameter definitions, platform specific variables and additional steps to complete the SAP HA Cluster setup after pacemaker configuration.
+![Ansible Lint for sap_ha_pacemaker_cluster](https://github.com/sap-linuxlab/community.sap_install/actions/workflows/ansible-lint-sap_ha_pacemaker_cluster.yml/badge.svg)
 
-<!-- END: Role Introduction -->
+This role installs pacemaker cluster packages and configures the cluster and SAP cluster resources in a new pacemaker cluster.  
+The pacemaker installation and cluster setup is done through the `ha_cluster` Linux System Role.  
+Ansible role `sap_ha_pacemaker_cluster` is acting as a wrapper and takes care of the SAP environment parameter definitions, platform specific variables and additional steps to complete the SAP HA configuration in the pacemaker cluster.
 
-<!-- BEGIN: Requirements -->
+:warning: Do **not** execute this role against already configured cluster nodes,  
+:warning: unless you know what you are doing and have prepared the role input variables accordingly!
+
 ## Requirements
 
 Target Systems:
+
 - Supported OS: RHEL 8.3+
-- RHEL registration and access to High-Availability repository
-- SAP Hana installed and configured, for instance using the provided `sap_hana_*` Ansible roles in this repository
+- access to High-Availability repository
+- SAP HANA is installed and configured, for instance using the provided `sap_hana_*` Ansible roles in this repository
 
 Ansible Control System:
-- Ansible 2.9+
-- `Linux System Roles` collection from either source and minimum version:
-  - RHEL package: _rhel-system-roles-1.13.0-1_ or later
-  - Red Hat Automation Hub: _rhel_system_roles 1.12.1_ or later
-  - Ansible Galaxy: _fedora.linux_system_roles:1.13.0_ or later
 
-<!-- END: Requirements -->
+- Ansible 2.9+
+- **Linux System Roles** collection from either source and minimum version:
+  - RHEL package: `rhel-system-roles-1.13.0-1` or later
+  - Red Hat Automation Hub: `rhel_system_roles 1.12.1` or later
+  - Ansible Galaxy: `fedora.linux_system_roles:1.13.0` or later
+
+## Functionality
+
+_All of the following functionality is provided as **Technology Preview**._
+
+:warning: Platforms not explicitly listed may not work as expected.  
+
+### 2-node pacemaker cluster with SAP HANA System Replication
+
+| Platform | Usability |
+| -------- | --------- |
+| :heavy_check_mark: physical server | expected to work with any fencing method that is supported by the `ha_cluster` Linux System Role |
+| :heavy_check_mark: OVirt VM | tested and working |
+| :heavy_check_mark: AWS EC2 | platform detection and awscli setup included, tested and expected to work |
+| IBM Cloud VPC | platform detection included, tested and working (unsupported at this point in time) |
+
+<!-- END: Role Introduction -->
 
 <!-- BEGIN: Role Input Parameters -->
 ## Role Input Parameters
 
 Minimum required parameters:
+
 - [ha_cluster_hacluster_password](#ha_cluster_hacluster_password)
 - [sap_hana_cluster_nodes](#sap_hana_cluster_nodes)
 - [sap_hana_instance_number](#sap_hana_instance_number)
@@ -43,13 +63,15 @@ On cloud platforms additional parameters are required:
 ---
 
 ### ha_cluster
+
 - _Type:_ `dict`
 
 Optional _**host_vars**_ parameter - if defined it must be set for each node.<br>
 Dictionary that can contain various node options for the pacemaker cluster configuration.<br>
-Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md).<br>
+Supported options can be reviewed in the `ha_cluster` Linux System Role [https://github.com/linux-system-roles/ha_cluster/blob/master/README.md].<br>
 
 Example:
+
 ```yaml
 ha_cluster:
   corosync_addresses:
@@ -59,41 +81,48 @@ ha_cluster:
 ```
 
 ### ha_cluster_cluster_name
+
 - _Type:_ `str`
 - _Default:_ `my-cluster`
 
 The name of the pacemaker cluster.<br>
 
 ### ha_cluster_hacluster_password <sup>required</sup>
+
 - _Type:_ `str`
 
 The password of the `hacluster` user which is created during pacemaker installation.<br>
 
 ### sap_ha_pacemaker_cluster_aws_access_key_id
+
 - _Type:_ `str`
 
 AWS access key to allow control of instances (for example for fencing operations).<br>
 Required for cluster nodes setup on Amazon cloud.<br>
 
 ### sap_ha_pacemaker_cluster_aws_region
+
 - _Type:_ `str`
 
 The AWS region in which the instances to be used for the cluster setup are located.<br>
 Required for cluster nodes setup on Amazon cloud.<br>
 
 ### sap_ha_pacemaker_cluster_aws_secret_access_key
+
 - _Type:_ `str`
 
 AWS secret key, paired with the access key for instance control.<br>
 Required for cluster nodes setup on Amazon cloud.<br>
 
 ### sap_ha_pacemaker_cluster_cluster_properties
+
 - _Type:_ `dict`
 - _Default:_ `See example`
 
 Standard pacemaker cluster properties are configured with recommended settings for cluster node fencing.<br>
 
 Example:
+
 ```yaml
 sap_ha_pacemaker_cluster_cluster_properties:
   concurrent-fencing: true
@@ -102,6 +131,7 @@ sap_ha_pacemaker_cluster_cluster_properties:
 ```
 
 ### sap_ha_pacemaker_cluster_create_config_dest
+
 - _Type:_ `str`
 - _Default:_ `<cluster-name>_resource_config.yml`
 
@@ -111,6 +141,7 @@ Specify a path/filename to save the file in a custom location.<br>
 The file can be used as input vars file for an Ansible playbook running the 'ha_cluster' Linux System Role.<br>
 
 ### sap_ha_pacemaker_cluster_create_config_varfile
+
 - _Type:_ `bool`
 - _Default:_ `False`
 
@@ -120,6 +151,7 @@ When enabled this parameters file is also created when the playbook is run in ch
 WARNING! This report may include sensitive details like secrets required for certain cluster resources!<br>
 
 ### sap_ha_pacemaker_cluster_fence_options
+
 - _Type:_ `dict`
 
 STONITH resource common parameters that apply to most fencing agents.<br>
@@ -127,17 +159,18 @@ These options are applied to fencing resources this role uses automatically for 
 The listed options are set by default.<br>
 Additional options can be added by defining this parameter in dictionary format and adding the defaults plus any valid stonith resource key-value pair.<br>
 
-  - **pcmk_reboot_retries**<br>
-        _Default:_ `4`<br>
-        STONITH resource parameter to define how often it retries to restart a node.
-  - **pcmk_reboot_timeout**<br>
-        _Default:_ `400`<br>
-        STONITH resource parameter to define after which timeout a node restart is returned as failed.
-  - **power_timeout**<br>
-        _Default:_ `240`<br>
-        STONITH resource parameter to test X seconds for status change after ON/OFF.
+- **pcmk_reboot_retries**<br>
+    _Default:_ `4`<br>
+    STONITH resource parameter to define how often it retries to restart a node.
+- **pcmk_reboot_timeout**<br>
+    _Default:_ `400`<br>
+    STONITH resource parameter to define after which timeout a node restart is returned as failed.
+- **power_timeout**<br>
+    _Default:_ `240`<br>
+    STONITH resource parameter to test X seconds for status change after ON/OFF.
 
 Example:
+
 ```yaml
 sap_ha_pacemaker_cluster_fence_options:
   pcmk_reboot_retries: 4
@@ -146,6 +179,7 @@ sap_ha_pacemaker_cluster_fence_options:
 ```
 
 ### sap_ha_pacemaker_cluster_hana_automated_register
+
 - _Type:_ `bool`
 - _Default:_ `True`
 
@@ -153,6 +187,7 @@ Parameter for the 'SAPHana' cluster resource.<br>
 Define if a former primary should be re-registered automatically as secondary.<br>
 
 ### sap_ha_pacemaker_cluster_hana_duplicate_primary_timeout
+
 - _Type:_ `int`
 - _Default:_ `900`
 
@@ -162,6 +197,7 @@ If the time difference is less than the time gap, then the cluster holds one or 
 This is to give an admin a chance to react on a failover. A failed former primary will be registered after the time difference is passed.<br>
 
 ### sap_ha_pacemaker_cluster_hana_prefer_site_takeover
+
 - _Type:_ `bool`
 - _Default:_ `True`
 
@@ -170,30 +206,35 @@ Set to "false" if the cluster should first attempt to restart the instance on th
 When set to "true" (default) a failover to secondary will be initiated on resource failure.<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_name
+
 - _Type:_ `str`
 - _Default:_ `SAPHana_<SID>_<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA DB resource.<br>
 
 ### sap_ha_pacemaker_cluster_hana_topology_resource_name
+
 - _Type:_ `str`
 - _Default:_ `SAPHanaTopology_<SID>_<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Topology resource.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_api_key
+
 - _Type:_ `str`
 
 The API key is required to allow control of instances (for example for fencing operations).<br>
 Required for cluster nodes setup in IBM Cloud VPC.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_region
+
 - _Type:_ `str`
 
 The cloud region key in which the instances are running.<br>
 Required for cluster nodes setup in IBM Cloud VPC.<br>
 
 ### sap_ha_pacemaker_cluster_replication_type
+
 - _Type:_ `str`
 - _Default:_ `none`
 
@@ -201,12 +242,14 @@ The type of SAP HANA site replication across multiple hosts.<br>
 _Not yet supported_<br>
 
 ### sap_ha_pacemaker_cluster_resource_defaults
+
 - _Type:_ `dict`
 - _Default:_ `See example`
 
 Set default parameters that will be valid for all pacemaker resources.<br>
 
 Example:
+
 ```yaml
 sap_ha_pacemaker_cluster_resource_defaults:
   migration-threshold: 5000
@@ -214,6 +257,7 @@ sap_ha_pacemaker_cluster_resource_defaults:
 ```
 
 ### sap_ha_pacemaker_cluster_sap_type
+
 - _Type:_ `str`
 - _Default:_ `scaleup`
 
@@ -221,6 +265,7 @@ The SAP landscape to be installed.<br>
 _Currently only scale-up is supported_<br>
 
 ### sap_ha_pacemaker_cluster_vip_client_interface
+
 - _Type:_ `str`
 - _Default:_ `eth0`
 
@@ -228,33 +273,37 @@ OS device name of the network interface to use for the Virtual IP configuration.
 This is used for VIP agents that require an interface name, for example in cloud platform environments.<br>
 
 ### sap_ha_pacemaker_cluster_vip_resource_name
+
 - _Type:_ `str`
 - _Default:_ `vip_<SID>_<Instance Number>`
 
 Customize the name of the resource managing the Virtual IP.<br>
 
 ### sap_ha_pacemaker_cluster_vip_update_rt
+
 - _Type:_ `list`
 
 List one more routing table IDs for managing Virtual IP failover through routing table changes.<br>
 Required for VIP configuration in AWS EC2 environments.<br>
 
 ### sap_hana_cluster_nodes <sup>required</sup>
+
 - _Type:_ `list`
 
 List of cluster nodes and associated attributes to describe the target SAP HA environment.<br>
 This is required for the HANA System Replication configuration.<br>
 
-  - **hana_site**<br>
-        Site of the cluster and/or SAP HANA System Replication node (for example 'DC01').<br>This is required for HANA System Replication configuration.
-  - **node_ip**<br>
-        IP address of the node used for HANA System Replication.
-  - **node_name**<br>
-        Name of the cluster node, should match the remote systems' hostnames.<br>This is needed by the cluster members to know all their partner nodes.
-  - **node_role**<br>
-        Role of this node in the SAP cluster setup.<br>There must be only *one* primary, but there can be multiple secondary nodes.
+- **hana_site**<br>
+    Site of the cluster and/or SAP HANA System Replication node (for example 'DC01').<br>This is required for HANA System Replication configuration.
+- **node_ip**<br>
+    IP address of the node used for HANA System Replication.
+- **node_name**<br>
+    Name of the cluster node, should match the remote systems' hostnames.<br>This is needed by the cluster members to know all their partner nodes.
+- **node_role**<br>
+    Role of this node in the SAP cluster setup.<br>There must be only **one** primary, but there can be multiple secondary nodes.
 
 Example:
+
 ```yaml
 sap_hana_cluster_nodes:
 - hana_site: DC01
@@ -268,23 +317,27 @@ sap_hana_cluster_nodes:
 ```
 
 ### sap_hana_instance_number <sup>required</sup>
+
 - _Type:_ `str`
 
 The instance number of the SAP HANA database which is role will configure in the cluster.<br>
 
 ### sap_hana_sid <sup>required</sup>
+
 - _Type:_ `str`
 
 The SAP System ID of the instance that will be configured in the cluster.<br>
 The SAP SID must follow SAP specifications - see SAP Note 1979280.<br>
 
 ### sap_hana_vip <sup>required</sup>
+
 - _Type:_ `dict`
 
 One floating IP is required for SAP HANA DB connection by clients.<br>
 This main VIP will always run on the promoted HANA node and be moved with it during a failover.<br>
 
 Example:
+
 ```yaml
 sap_hana_vip:
   primary: 192.168.10.100

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -31,7 +31,7 @@ argument_specs:
         description:
           - Optional _**host_vars**_ parameter - if defined it must be set for each node.
           - Dictionary that can contain various node options for the pacemaker cluster configuration.
-          - Supported options can be reviewed in the `ha_cluster` Linux System Role (https://github.com/linux-system-roles/ha_cluster/blob/master/README.md).
+          - Supported options can be reviewed in the `ha_cluster` Linux System Role [https://github.com/linux-system-roles/ha_cluster/blob/master/README.md].
         example:
           ha_cluster:
             corosync_addresses:
@@ -298,7 +298,7 @@ argument_specs:
               - secondary
             description:
               - Role of this node in the SAP cluster setup.
-              - There must be only *one* primary, but there can be multiple secondary nodes.
+              - There must be only **one** primary, but there can be multiple secondary nodes.
             required: true
           hana_site:
             description:


### PR DESCRIPTION
**Global README.md**
- replaced deprecated and deleted roles with new sap_ha_pacemaker_cluster role context
- minor syntax/markdownlint fixes
- fixed ansible-lint status links to newer workflows

**docs / playbooks**
- renamed and moved the full 2-node sample playbook to the playbooks folder
- a few improvements in the vault doc

**Cluster and HSR role READMEs**
- README.md enhancements and adjustments in syntax