### PR TITLE
Solve issue 306 (avoid the `nobest` parameter in the `dnf` module)

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -110,6 +110,9 @@
   when: ansible_distribution_major_version == '7'
 
 # Note: We do not want package updates, see also Red Hat bug 1983749.
+#       Because the installation of an environment or package group is not guaranteed to avoid package updates,
+#       and because of bug 2011426 (for which the fix is not available in the RHEL 8.1 ISO image), a RHEL 8.1
+#       system might not boot after installing environment group Server.
 - name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9 # noqa command-instead-of-module
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
   register: __sap_general_preconfigure_register_yum_group_install

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -110,14 +110,18 @@
   when: ansible_distribution_major_version == '7'
 
 # Note: We do not want package updates, see Red Hat bug 1983749.
-- name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9
+- name: Ensure that the required package groups are installed, RHEL 8 # noqa command-instead-of-module
+  ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
+  register: __sap_general_preconfigure_register_yum_group_install
+  when: ansible_distribution_major_version == '8'
+
+- name: Ensure that the required package groups are installed, RHEL 9
   ansible.builtin.dnf:
     name: "{{ sap_general_preconfigure_packagegroups }}"
     state: present
-    exclude: kernel*
     nobest: true
   register: __sap_general_preconfigure_register_yum_group_install
-  when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
+  when: ansible_distribution_major_version == '9'
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -119,7 +119,7 @@
   ansible.builtin.dnf:
     name: "{{ sap_general_preconfigure_packagegroups }}"
     state: present
-    nobest: true
+#    nobest: true  # supported from Ansible 2.11
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '9'
 

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -110,7 +110,7 @@
   when: ansible_distribution_major_version == '7'
 
 # Note: We do not want package updates, see also Red Hat bug 1983749.
-- name: Ensure that the required package groups are installed, RHEL 8 # noqa command-instead-of-module
+- name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9 # noqa command-instead-of-module
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
@@ -122,7 +122,7 @@
 #    state: present
 #    nobest: true  # supported from Ansible 2.11
 #  register: __sap_general_preconfigure_register_yum_group_install
-#  when: ansible_distribution_major_version == '9'
+#  when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -120,7 +120,7 @@
 
 # possible replacement once we no longer need Ansible 2.9 compatibility:
 #- name: Ensure that the required package groups are installed, RHEL 8 and 9
-#  ansible.builtin.dnf:
+#  ansible.builtin.package:
 #    name: "{{ sap_general_preconfigure_packagegroups }}"
 #    state: present
 #    nobest: true  # supported from Ansible 2.11

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -109,19 +109,20 @@
     state: present
   when: ansible_distribution_major_version == '7'
 
-# Note: We do not want package updates, see Red Hat bug 1983749.
+# Note: We do not want package updates, see also Red Hat bug 1983749.
 - name: Ensure that the required package groups are installed, RHEL 8 # noqa command-instead-of-module
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
   register: __sap_general_preconfigure_register_yum_group_install
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
 
-- name: Ensure that the required package groups are installed, RHEL 9
-  ansible.builtin.dnf:
-    name: "{{ sap_general_preconfigure_packagegroups }}"
-    state: present
+# possible replacement once we no longer need Ansible 2.9 compatibility:
+#- name: Ensure that the required package groups are installed, RHEL 8 and 9
+#  ansible.builtin.dnf:
+#    name: "{{ sap_general_preconfigure_packagegroups }}"
+#    state: present
 #    nobest: true  # supported from Ansible 2.11
-  register: __sap_general_preconfigure_register_yum_group_install
-  when: ansible_distribution_major_version == '9'
+#  register: __sap_general_preconfigure_register_yum_group_install
+#  when: ansible_distribution_major_version == '9'
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:


### PR DESCRIPTION
Tested with several RHEL 8.1...9.1 versions, on x86_64, ppc64le, and s390x. All systems booted successfully and had the Server software environment group installed afterwards.