### PR TITLE
sap_general_preconfigure: recognize tabs in /etc/hosts

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-etc-hosts.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-etc-hosts.yml
@@ -58,9 +58,9 @@
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: Check for duplicate or missing entries of {{ sap_hostname }}.{{ sap_domain }} in /etc/hosts
-  ansible.builtin.command: awk '/^{{ sap_hostname }}.{{ sap_domain }} /||
-                / {{ sap_hostname }}.{{ sap_domain }} /||
-                / {{ sap_hostname }}.{{ sap_domain }}$/{a++}END{print a}' /etc/hosts
+  ansible.builtin.command: awk 'BEGIN{a=0}/^{{ sap_hostname }}.{{ sap_domain }}\s/||
+                /\s{{ sap_hostname }}.{{ sap_domain }}\s/||
+                /\s{{ sap_hostname }}.{{ sap_domain }}$/{a++}END{print a}' /etc/hosts
   register: __sap_general_preconfigure_register_fqdn_once_assert
   ignore_errors: yes
   changed_when: no
@@ -73,9 +73,9 @@
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: Check for duplicate or missing entries of {{ sap_hostname }} in /etc/hosts
-  ansible.builtin.command: awk '/^{{ sap_hostname }} /||
-                / {{ sap_hostname }} /||
-                / {{ sap_hostname }}$/{a++}END{print a}' /etc/hosts
+  ansible.builtin.command: awk 'BEGIN{a=0}/^{{ sap_hostname }}\s/||
+                /\s{{ sap_hostname }}\s/||
+                /\s{{ sap_hostname }}$/{a++}END{print a}' /etc/hosts
   register: __sap_general_preconfigure_register_sap_hostname_once_assert
   ignore_errors: yes
   changed_when: no


### PR DESCRIPTION
Solves issue #332.

Proof:
```
# cat hosts.test
192.168.0.1 space.domain host
192.168.0.2     tab.domain      tab
# od -c hosts.test
0000000   1   9   2   .   1   6   8   .   0   .   1       s   p   a   c
0000020   e   .   d   o   m   a   i   n       h   o   s   t  \n   1   9
0000040   2   .   1   6   8   .   0   .   2  \t   t   a   b   .   d   o
0000060   m   a   i   n  \t   t   a   b  \n
0000071
# awk '/^space.domain\s/||/\sspace.domain\s/||/\sspace.domain$/{print; a++}END{print a}' hosts.test
192.168.0.1 space.domain host
1
# awk '/^tab.domain\s/||/\stab.domain\s/||/\stab.domain$/{print; a++}END{print a}' hosts.test
192.168.0.2     tab.domain      tab
1
```
The original code only checked for spaces whereas the new code checks for white spaces.

As per `man awk` in RHEL 8:
```
       \s         Matches any whitespace character.
```
An alternative solution would be to specify the character class `[[:space:]]`:
```
# awk '/^space.domain[[:space:]]/||/[[:space:]]space.domain[[:space:]]/||/[[:space:]]space.domain$/{print; a++}END{print a}' hosts.test
192.168.0.1 space.domain host
1
# awk '/^tab.domain[[:space:]]/||/[[:space:]]tab.domain[[:space:]]/||/[[:space:]]tab.domain$/{print; a++}END{print a}' hosts.test
192.168.0.2     tab.domain      tab
1
```
but this should not be necessary here.