### PR TITLE
Check sapconf active and force saptune to takeover

### DIFF
--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -7,13 +7,17 @@
 - name: Get service facts
   ansible.builtin.service_facts:
 
+- name: Output information of sapconf.service
+  ansible.builtin.debug:
+    var: ansible_facts.services["sapconf.service"]
+
 - name: saptune should takeover service
-  ansible.builtin.shell: 
+  ansible.builtin.shell:
     cmd: "saptune service takeover"
-  when: 
-    - ansible_facts.services["sapconf.service"] is defined
-    - ansible_facts.services["sapconf.service"]["state"] == "active"
-    
+  when:
+    - ansible_facts.services["sapconf.service"]["status"] == "enabled"
+    - ansible_facts.services["sapconf.service"]["state"] == "stopped"
+
 - name: Ensure saptune is running and enabled
   ansible.builtin.systemd:
     name: saptune

--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -4,6 +4,16 @@
 #  debug:
 #    verbosity: "{{ debuglevel }}"
 #
+- name: Get service facts
+  ansible.builtin.service_facts:
+
+- name: saptune should takeover service
+  ansible.builtin.shell: 
+    cmd: "saptune service takeover"
+  when: 
+    - ansible_facts.services["sapconf.service"] is defined
+    - ansible_facts.services["sapconf.service"]["state"] == "active"
+    
 - name: Ensure saptune is running and enabled
   ansible.builtin.systemd:
     name: saptune

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -1,4 +1,14 @@
 ---
+- name: Get service facts
+  ansible.builtin.service_facts:
+
+- name: saptune should takeover service
+  ansible.builtin.shell: 
+    cmd: "saptune service takeover"
+  when: 
+    - ansible_facts.services["sapconf.service"] is defined
+    - ansible_facts.services["sapconf.service"]["state"] == "active"
+    
 - name: Ensure saptune is running and enabled
   ansible.builtin.systemd:
     name: saptune

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -2,13 +2,17 @@
 - name: Get service facts
   ansible.builtin.service_facts:
 
+- name: Output information of sapconf.service
+  ansible.builtin.debug:
+    var: ansible_facts.services["sapconf.service"]
+
 - name: saptune should takeover service
-  ansible.builtin.shell: 
+  ansible.builtin.shell:
     cmd: "saptune service takeover"
-  when: 
-    - ansible_facts.services["sapconf.service"] is defined
-    - ansible_facts.services["sapconf.service"]["state"] == "active"
-    
+  when:
+    - ansible_facts.services["sapconf.service"]["status"] == "enabled"
+    - ansible_facts.services["sapconf.service"]["state"] == "stopped"
+
 - name: Ensure saptune is running and enabled
   ansible.builtin.systemd:
     name: saptune


### PR DESCRIPTION
Hello,
I have a fresh installation of SLES4SAP SP15 SP4 and there is the sapconfig service active and enabled. This leads that saptune cannot be enabled and started.

## Problem

```
andsse1d01:~ # saptune_check

This is saptune_check v0.2.2.

It verifies if saptune is set up correctly.
Please keep in mind:
 - This tool does not check, if the tuning itself works correctly.
 - Follow the hints from top to down to minimize side effects.


Checking saptune
================
[NOTE] saptune package has version 3.0.2
[WARN] System is in status "degraded". Failed services are: saptune.service     -> Check the cause and reset the state with 'systemctl reset-failed'!
[ OK ] configured saptune version is 3
[FAIL] sapconf.service is active        -> Run 'systemctl stop sapconf.service' or 'saptune service takeover'.
[FAIL] sapconf.service is enabled       -> Run 'systemctl disable sapconf.service' or 'saptune service takeover'.
[FAIL] saptune.service is failed        -> Run 'systemctl start saptune.service', 'saptune service start' or 'saptune service takeover'.
[ OK ] saptune.service is enabled

1 warning(s) have been found.
3 error(s) have been found.
Saptune will not work properly!
```

I have had this problem also on another machine, where I did the following:
```
systemctl stop sapconfig.service
systemctl disable sapconf.service
```
But nevertheless saptune_check was showing same output like above. I have then restarted the saptune service. Same output again. Only a reboot from the whole machine worked.

But the command `saptune service takeover` did the trick without restarting anything.

## Idea
It should be checked if sapconf.service is active and enabled, if yes, do the `saptune service takeover` and then proceed with the tasks like they are.