### PR TITLE
sap_netweaver_preconfigure: Use meta/argument_specs.yml

### DIFF
--- a/roles/sap_netweaver_preconfigure/README.md
+++ b/roles/sap_netweaver_preconfigure/README.md
@@ -25,70 +25,97 @@ Please check the SAP NetWeaver installation guide for swap space requirements.
 Do not run this role against an SAP NetWeaver or other production system. The role will enforce a certain configuration on the managed
 node(s), which might not be intended.
 
-## Role Variables
+<!-- BEGIN: Role Input Parameters -->
+## Role Input Parameters
 
-### Execute only certain steps of SAP notes (RHEL only)
-If the following variable is set to `no`, only the installation or configuration steps of SAP notes will be executed or checked. If this variable is undefined or set to `yes`, all installation and configuration steps of applicable SAP notes will be executed.
-```yaml
-sap_netweaver_preconfigure_config_all
-```
+Minimum required parameters:
+This role does not require any parameter to be set in the playbook or inventory.
 
-### Perform installation or configuration steps, or both
-If you have set `sap_netweaver_preconfigure_config_all` (see above) to `no`, you can limit the scope of the role to only execute the installation or the configuration steps. For this purpose, set one of the following variables, or both, to `yes`. The default for both is `no`.
-```yaml
-sap_netweaver_preconfigure_installation
-sap_netweaver_preconfigure_configuration
-```
 
-### Install required packages for Adobe Document Services (RHEL Only)
-If the following variable is set to `yes`, required packages for Adobe Document Services according to SAP note 2135057 (RHEL 7) or 2920407 (RHEL 8) will be installed. Default is `no`.
-```yaml
-sap_netweaver_preconfigure_use_adobe_doc_services
-```
+### sap_netweaver_preconfigure_config_all
+- _Type:_ `bool`
+- _Default:_ `true`
 
-### Run the role in assert mode
-If the following variable is set to `yes`, the role will only check if the configuration of the managed node(s) is according to the applicable SAP notes. Default is `no`.
-```yaml
-sap_netweaver_preconfigure_assert
-```
+If set to `false`, the role will only execute or verify the installation or configuration steps of SAP notes.<br>
+Default is to perform installation and configuration steps.<br>
 
-### Behavior of the role in assert mode
-If the role is run in assert mode (see above) and the following variable is set to `yes`, assertion errors will not cause the role to fail. This can be useful for creating reports.
-Default is `no`, meaning that the role will fail for any assertion error which is discovered. This variable has no meaning if the role is not run in assert mode.
-```yaml
-sap_netweaver_preconfigure_assert_ignore_errors
-```
+### sap_netweaver_preconfigure_installation
+- _Type:_ `bool`
+- _Default:_ `false`
 
-### Swap space for SAP NetWeaver
-When installing SAP NetWeaver, the prerequisite checker verifies if enough swap space is configured. By default, the role checks is there is at least 20480 MB of swap space available.
-This variable can be used set to the swap space limit to any other value.
-```yaml
-sap_netweaver_preconfigure_min_swap_space_mb
-```
+If `sap_netweaver_preconfigure_config_all` is set to `false`, set this variable to `true` to perform only the<br>
+installation steps of SAP notes.<br>
 
-### Fail if there is less than 20480 MB of swap space configured
-If the following variable is set to `no`, the role will not fail if less than 20480 MB of swap space is configured. Default is `yes`.
-```yaml
-sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured
-```
+### sap_netweaver_preconfigure_configuration
+- _Type:_ `bool`
+- _Default:_ `false`
 
-## Select saptune solution (SLES only)
-You can specify the saptune solution you want to implement.  For Netweaver, there are a number of possible solutions depending on the deployment:
+If `sap_netweaver_preconfigure_config_all` is set to `false`, set this variable to `true` to perform only the<br>
+configuration steps of SAP notes.<br>
 
-* NETWEAVER
-* NETWEAVER+HANA 
-* S4HANA-APP+DB  
-* S4HANA-APPSERVER
-* S4HANA-DBSERVER
-The default vaule is NETWEAVER
+### sap_netweaver_preconfigure_assert
+- _Type:_ `bool`
+- _Default:_ `false`
 
-sap_netweaver_preconfigure_saptune_solution: NETWEAVER
+If set to `true`, the role will run in assertion mode instead of the default configuration mode.<br>
 
-The default is `NETWEAVER`
+### sap_netweaver_preconfigure_assert_ignore_errors
+- _Type:_ `bool`
+- _Default:_ `false`
 
-```yaml
-sap_hana_preconfigure_saptune_solution
-```
+In assertion mode, the role will abort when encountering any assertion error.<br>
+If this parameter is set to `false`, the role will *not* abort when encountering an assertion error.<br>
+This is useful if the role is used for reporting a system's SAP notes compliance.<br>
+
+### sap_netweaver_preconfigure_min_swap_space_mb
+- _Type:_ `str`
+- _Default:_ `20480`
+
+Specifies the minimum amount of swap space on the system required by SAP NetWeaver.<br>
+If this requirement is not met, the role will abort.<br>
+Set your own value to override the default of `20480`.<br>
+
+### sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured
+- _Type:_ `bool`
+- _Default:_ `true`
+
+If the system does not have the minimum amount of swap space configured as defined<br>
+in parameter `sap_netweaver_preconfigure_min_swap_space_mb`, the role will abort.<br>
+By setting this parameter to `false`, the role will not abort in such cases.<br>
+
+### sap_netweaver_preconfigure_rpath
+- _Type:_ `str`
+- _Default:_ `/usr/sap/lib`
+
+Specifies the SAP kernel's `RPATH`. This is where the SAP kernel is searching for libraries, and where the role<br>
+is creating a link named `libstdc++.so.6` pointing to `/opt/rh/SAP/lib64/compat-sap-c++-10.so`,<br>
+so that newer SAP kernels which are built with GCC10 can find the required symbols.<br>
+
+### sap_netweaver_preconfigure_use_adobe_doc_services
+- _Type:_ `bool`
+- _Default:_ `false`
+
+Set this parameter to `true` when using Adobe Document Services, to ensure all required packages are installed.<br>
+
+### sap_netweaver_preconfigure_saptune_version
+- _Type:_ `str`
+- _Default:_ `3.0.2`
+
+On SLES systems, specifies the saptune version<br>
+
+### sap_netweaver_preconfigure_saptune_solution
+- _Type:_ `str`
+- _Default:_ `NETWEAVER`
+- _Possible Values:_<br>
+  - `NETWEAVER`
+  - `NETWEAVER+HANA`
+  - `S4HANA-APP+DB`
+  - `S4HANA-APPSERVER`
+  - `S4HANA-DBSERVER`
+
+On SLES systems, specifies the saptune solution to apply.<br>
+
+<!-- END: Role Input Parameters -->
 
 ## Example Playbook
 

--- a/roles/sap_netweaver_preconfigure/defaults/main.yml
+++ b/roles/sap_netweaver_preconfigure/defaults/main.yml
@@ -7,7 +7,7 @@ sap_netweaver_preconfigure_assert: no
 # In case of an assertion run, if set to "yes", the role will abort for any assertion error:
 sap_netweaver_preconfigure_assert_ignore_errors: no
 
-sap_netweaver_preconfigure_min_swap_space_mb: "{{ __sap_netweaver_preconfigure_min_swap_space_mb }}"
+sap_netweaver_preconfigure_min_swap_space_mb: '20480'
 
 sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: yes
 
@@ -16,7 +16,7 @@ sap_netweaver_preconfigure_rpath: '/usr/sap/lib'
 sap_netweaver_preconfigure_use_adobe_doc_services: no
 
 #SLES Only
-sap_netweaver_preconfigure_saptune_version: 3.0.2
+sap_netweaver_preconfigure_saptune_version: '3.0.2'
 
 ## The following variables control aspects of saptune and are only relevant for SLES for SAP Application
 
@@ -28,4 +28,4 @@ sap_netweaver_preconfigure_saptune_version: 3.0.2
 #S4HANA-DBSERVER
 # The default vaule is NETWEAVER
 
-sap_netweaver_preconfigure_saptune_solution: NETWEAVER
+sap_netweaver_preconfigure_saptune_solution: 'NETWEAVER'

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -1,4 +1,4 @@
-
+---
 # Requires: ansible 2.11
 # Argument specifications in this separate file maintain backwards compatibility.
 argument_specs:

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -1,0 +1,90 @@
+
+# Requires: ansible 2.11
+# Argument specifications in this separate file maintain backwards compatibility.
+argument_specs:
+
+  main:
+    short_description: Additional settings for SAP NetWeaver
+    options:
+
+#      sap_netweaver_preconfigure_...
+#        default:
+#        description:
+#           -
+#        example:
+#
+#        required: false
+#        type:
+#        options: # additional options for lists and dicts
+#          <param>:
+#            description:
+#            ...
+
+      sap_netweaver_preconfigure_assert:
+        default: false
+        description:
+          - If set to `true`, changes the role from configuration mode to assertion mode
+        required: false
+        type: bool
+
+      sap_netweaver_preconfigure_assert_ignore_errors:
+        default: false
+        description:
+          - In assertion mode, the role will not abort for any assertion error.
+          - If this parameter is set to `false`, the role will not abort when encountering an assertion error.
+          - This is useful if the role is used for reporting a system's SAP notes compliance.
+        required: false
+        type: bool
+
+      sap_netweaver_preconfigure_min_swap_space_mb:
+        default: "{{ __sap_netweaver_preconfigure_min_swap_space_mb }}"
+        description:
+          - Specifies the minimum amount of swap space on the system. If this requirement is not met, the role will abort.
+        required: false
+        type: str
+
+      sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured:
+        default: true
+        description:
+          - If the system does not have the minimum amount of swap space configured, the role will abort.
+          - By setting this parameter to `false`, the role will no abort in such cases.
+        required: false
+        type: bool
+
+      sap_netweaver_preconfigure_rpath:
+        default: '/usr/sap/lib'
+        description:
+          - RPATH for the SAP kernel. This is where the SAP kernel is searching for libraries, and where the role
+          - is creating a link named `libstdc++.so.6` pointing to `/opt/rh/SAP/lib64/compat-sap-c++-10.so`,
+          - so that newer SAP kernels which are built with GCC10 can find the required symbols.
+        required: false
+        type: str
+
+      sap_netweaver_preconfigure_use_adobe_doc_services:
+        default: false
+        description:
+          - Set this parameter to `true` when using Adobe Document Services, to ensure all required packages are installed.
+        required: false
+        type: bool
+
+# SLES Only
+      sap_netweaver_preconfigure_saptune_version:
+        default: '3.0.2'
+        description:
+          - For SLES only, specifies the saptune version
+        required: false
+        type: str
+
+# SLES Only
+      sap_netweaver_preconfigure_saptune_solution:
+        default: 'NETWEAVER'
+        description:
+          - For SLES only, specifies the saptune solution to apply.
+        choices:
+          - 'NETWEAVER'
+          - 'NETWEAVER+HANA'
+          - 'S4HANA-APP+DB'
+          - 'S4HANA-APPSERVER'
+          - 'S4HANA-DBSERVER'
+        required: false
+        type: str

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -37,9 +37,10 @@ argument_specs:
         type: bool
 
       sap_netweaver_preconfigure_min_swap_space_mb:
-        default: "{{ __sap_netweaver_preconfigure_min_swap_space_mb }}"
+        default: '20480'
         description:
           - Specifies the minimum amount of swap space on the system. If this requirement is not met, the role will abort.
+          - The default is the value of internal variable __sap_netweaver_preconfigure_min_swap_space_mb
         required: false
         type: str
 

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -4,7 +4,7 @@
 argument_specs:
 
   main:
-    short_description: Additional settings for SAP NetWeaver
+    short_description: Variables for SAP NetWeaver preconfiguration
     options:
 
 #      sap_netweaver_preconfigure_...
@@ -23,14 +23,14 @@ argument_specs:
       sap_netweaver_preconfigure_assert:
         default: false
         description:
-          - If set to `true`, changes the role from configuration mode to assertion mode
+          - If set to `true`, the role will run in assertion mode instead of the default configuration mode
         required: false
         type: bool
 
       sap_netweaver_preconfigure_assert_ignore_errors:
         default: false
         description:
-          - In assertion mode, the role will not abort for any assertion error.
+          - In assertion mode, the role will abort when encountering any assertion error.
           - If this parameter is set to `false`, the role will not abort when encountering an assertion error.
           - This is useful if the role is used for reporting a system's SAP notes compliance.
         required: false
@@ -39,8 +39,8 @@ argument_specs:
       sap_netweaver_preconfigure_min_swap_space_mb:
         default: '20480'
         description:
-          - Specifies the minimum amount of swap space on the system. If this requirement is not met, the role will abort.
-          - The default is the value of internal variable __sap_netweaver_preconfigure_min_swap_space_mb
+          - Specifies the minimum amount of swap space on the system required by SAP NetWeaver.
+          - If this requirement is not met, the role will abort.
         required: false
         type: str
 

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -20,10 +20,34 @@ argument_specs:
 #            description:
 #            ...
 
+      sap_netweaver_preconfigure_config_all:
+        default: true
+        description:
+          - If set to `false`, the role will only execute or verify the installation or configuration steps of SAP notes.
+          - Default is to perform installation and configuration steps.
+        required: false
+        type: bool
+
+      sap_netweaver_preconfigure_installation:
+        default: false
+        description:
+          - If `sap_netweaver_preconfigure_config_all` is set to `false`, set this variable to `true` to perform only the
+          - installation steps of SAP notes.
+        required: false
+        type: bool
+
+      sap_netweaver_preconfigure_configuration:
+        default: false
+        description:
+          - If `sap_netweaver_preconfigure_config_all` is set to `false`, set this variable to `true` to perform only the
+          - configuration steps of SAP notes.
+        required: false
+        type: bool
+
       sap_netweaver_preconfigure_assert:
         default: false
         description:
-          - If set to `true`, the role will run in assertion mode instead of the default configuration mode
+          - If set to `true`, the role will run in assertion mode instead of the default configuration mode.
         required: false
         type: bool
 
@@ -31,7 +55,7 @@ argument_specs:
         default: false
         description:
           - In assertion mode, the role will abort when encountering any assertion error.
-          - If this parameter is set to `false`, the role will not abort when encountering an assertion error.
+          - If this parameter is set to `false`, the role will *not* abort when encountering an assertion error.
           - This is useful if the role is used for reporting a system's SAP notes compliance.
         required: false
         type: bool
@@ -41,21 +65,23 @@ argument_specs:
         description:
           - Specifies the minimum amount of swap space on the system required by SAP NetWeaver.
           - If this requirement is not met, the role will abort.
+          - Set your own value to override the default of `20480`.
         required: false
         type: str
 
       sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured:
         default: true
         description:
-          - If the system does not have the minimum amount of swap space configured, the role will abort.
-          - By setting this parameter to `false`, the role will no abort in such cases.
+          - If the system does not have the minimum amount of swap space configured as defined
+          - in parameter `sap_netweaver_preconfigure_min_swap_space_mb`, the role will abort.
+          - By setting this parameter to `false`, the role will not abort in such cases.
         required: false
         type: bool
 
       sap_netweaver_preconfigure_rpath:
         default: '/usr/sap/lib'
         description:
-          - RPATH for the SAP kernel. This is where the SAP kernel is searching for libraries, and where the role
+          - Specifies the SAP kernel's `RPATH`. This is where the SAP kernel is searching for libraries, and where the role
           - is creating a link named `libstdc++.so.6` pointing to `/opt/rh/SAP/lib64/compat-sap-c++-10.so`,
           - so that newer SAP kernels which are built with GCC10 can find the required symbols.
         required: false
@@ -68,19 +94,17 @@ argument_specs:
         required: false
         type: bool
 
-# SLES Only
       sap_netweaver_preconfigure_saptune_version:
         default: '3.0.2'
         description:
-          - For SLES only, specifies the saptune version
+          - On SLES systems, specifies the saptune version
         required: false
         type: str
 
-# SLES Only
       sap_netweaver_preconfigure_saptune_solution:
         default: 'NETWEAVER'
         description:
-          - For SLES only, specifies the saptune solution to apply.
+          - On SLES systems, specifies the saptune solution to apply.
         choices:
           - 'NETWEAVER'
           - 'NETWEAVER+HANA'

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_7.yml
@@ -11,8 +11,6 @@ __sap_netweaver_preconfigure_sapnotes_versions:
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap
 
-__sap_netweaver_preconfigure_min_swap_space_mb: '20480'
-
 __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - autoconf.noarch
   - automake.noarch

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_8.yml
@@ -13,8 +13,6 @@ __sap_netweaver_preconfigure_sapnotes_versions:
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap
 
-__sap_netweaver_preconfigure_min_swap_space_mb: '20480'
-
 __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - autoconf.noarch
   - automake.noarch

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_9.yml
@@ -11,8 +11,6 @@ __sap_netweaver_preconfigure_sapnotes_versions:
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap
 
-__sap_netweaver_preconfigure_min_swap_space_mb: '20480'
-
 __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - autoconf.noarch
   - automake.noarch

--- a/roles/sap_netweaver_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_netweaver_preconfigure/vars/SLES_15.yml
@@ -27,5 +27,3 @@ __sap_netweaver_preconfigure_packages:
   - yast2-vpn
   - tcsh
   - acl
-
-__sap_netweaver_preconfigure_min_swap_space_mb: "20480"


### PR DESCRIPTION
At the same time, remove OS dependent vars where possible (`sap_netweaver_preconfigure_min_swap_space_mb` in this case).

Solves issue https://github.com/sap-linuxlab/community.sap_install/issues/321.

The role's file README.md will be updated as the next step.