### PR TITLE
sap_swpm: Add nw_config_webdisp_generic for WDP installation

### DIFF
--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -85,7 +85,7 @@ sap_swpm_inifile_list:
   - nw_config_ports
 #  - nw_config_java_ume
 #  - nw_config_java_feature_template_ids
-#  - nw_config_webdisp_generic
+  - nw_config_webdisp_generic
 #  - nw_config_webdisp_gateway
   - nw_config_host_agent
 #  - nw_config_post_load_abap_reports


### PR DESCRIPTION
This PR makes it possible to install the web dispatcher in default mode:

```
 - ansible.builtin.include_vars: ./vars/wdp.sample.yml
      - ansible.builtin.include_role:
          name: community.sap_install.sap_swpm
      vars:
        sap_swpm_ansible_role_mode: default
```

It can use the default `sample-variables-sap-swpm-default-mode-webdisp-install.yml` from the `playbooks/vars` directory.

