### PR TITLE
sap_ha_pacemaker_cluster: fixed issue #365 - resource meta attributes…

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_common.yml
@@ -101,15 +101,14 @@
   vars:
     __clone_topology:
       resource_id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
-      promotable: "no"
       meta_attrs:
         - attrs:
             - name: clone-max
               value: 2
             - name: clone-node-max
               value: 1
-        - name: interleave
-          value: "true"
+            - name: interleave
+              value: "true"
   when:
     - __clone_topology.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
 
@@ -119,7 +118,6 @@
   vars:
     __clone_hana:
       resource_id: "{{ sap_ha_pacemaker_cluster_hana_resource_name }}"
-      promotable: "yes"
       meta_attrs:
         - attrs:
             - name: clone-max
@@ -127,6 +125,8 @@
             - name: clone-node-max
               value: 1
             - name: interleave
+              value: "true"
+            - name: promotable
               value: "true"
   when:
     - __clone_hana.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))


### PR DESCRIPTION
Resource config before the fix:

```
Clone: SAPHanaTopology_DB1_00-clone
  Meta Attrs: clone-max=2 clone-node-max=1 promotable=true
```

Resource config after the fix (different SID on different cluster):
```
 Clone: SAPHanaTopology_DB2_00-clone
  Meta Attrs: clone-max=2 clone-node-max=1 interleave=true
```

The cause was the wrong placement of a meta-attribute definition and a bad indentation.