### PR TITLE
gh action - workaround for compatibility with older ansible-lint

### DIFF
--- a/.github/workflows/ansible-lint-sap_ha_pacemaker_cluster.yml
+++ b/.github/workflows/ansible-lint-sap_ha_pacemaker_cluster.yml
@@ -32,7 +32,9 @@ jobs:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_ha_pacemaker_cluster


### PR DESCRIPTION
Newly released ansible-compat version appears not compatible with ansible-lint versions <6.12.2 on python 3.9.

Working around by installing the previous working version of ansible-compat, 3.0.2.