### PR TITLE
gh actions: install fixed ansible-compat version to keep compatibility

### DIFF
--- a/.github/workflows/ansible-lint-sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_general_preconfigure.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_general_preconfigure

--- a/.github/workflows/ansible-lint-sap_ha_install_hana_hsr.yml
+++ b/.github/workflows/ansible-lint-sap_ha_install_hana_hsr.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_ha_install_hana_hsr

--- a/.github/workflows/ansible-lint-sap_hana_install.yml
+++ b/.github/workflows/ansible-lint-sap_hana_install.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_hana_install

--- a/.github/workflows/ansible-lint-sap_hana_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_hana_preconfigure.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_hana_preconfigure

--- a/.github/workflows/ansible-lint-sap_hypervisor_node_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_hypervisor_node_preconfigure.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_hypervisor_node_preconfigure

--- a/.github/workflows/ansible-lint-sap_netweaver_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_netweaver_preconfigure.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_netweaver_preconfigure

--- a/.github/workflows/ansible-lint-sap_swpm.yml
+++ b/.github/workflows/ansible-lint-sap_swpm.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_swpm

--- a/.github/workflows/ansible-lint-sap_vm_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_vm_preconfigure.yml
@@ -24,15 +24,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_vm_preconfigure

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -16,15 +16,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
 #      - name: Install collection dependencies
 #        run: ansible-galaxy collection install community.general

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -16,15 +16,17 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.9'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint==6.8.6
+        run: |
+          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible-compat==3.0.2
 
 #      - name: Install collection dependencies
 #        run: ansible-galaxy collection install community.general


### PR DESCRIPTION
2 days ago ansible-compat version 4.0.1 has been released. This version is automatically installed by the ansible-lint dependencies, but does not seem to be compatible with ansible-lint versions <6.12.2.

In order to keep 6.8.6 ansible-lint for the time being, this update of the workflows makes sure that ansible-compat version 3.0.2 is explicitly installed.

Tested here:
https://github.com/ja9fuchs/community.sap_install/actions/runs/4874282848/jobs/8695013042