### PR TITLE
sap_ha_pacemaker_cluster: fix issue #370 - argument_specs limitation

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -159,16 +159,6 @@ These options are applied to fencing resources this role uses automatically for 
 The listed options are set by default.<br>
 Additional options can be added by defining this parameter in dictionary format and adding the defaults plus any valid stonith resource key-value pair.<br>
 
-- **pcmk_reboot_retries**<br>
-    _Default:_ `4`<br>
-    STONITH resource parameter to define how often it retries to restart a node.
-- **pcmk_reboot_timeout**<br>
-    _Default:_ `400`<br>
-    STONITH resource parameter to define after which timeout a node restart is returned as failed.
-- **power_timeout**<br>
-    _Default:_ `240`<br>
-    STONITH resource parameter to test X seconds for status change after ON/OFF.
-
 Example:
 
 ```yaml

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -126,29 +126,6 @@ argument_specs:
         required: false
         type: dict
 
-        options:
-
-          pcmk_reboot_retries:
-            default: 4
-            description:
-              - STONITH resource parameter to define how often it retries to restart a node.
-            required: false
-            type: int
-
-          pcmk_reboot_timeout:
-            default: 400
-            description:
-              - STONITH resource parameter to define after which timeout a node restart is returned as failed.
-            required: false
-            type: int
-
-          power_timeout:
-            default: 240
-            description:
-              - STONITH resource parameter to test X seconds for status change after ON/OFF.
-            required: false
-            type: int
-
       sap_ha_pacemaker_cluster_hana_automated_register:
         default: true
         description:


### PR DESCRIPTION
For a dict that can be enhanced with custom key-value pairs, `options:` can not be used to explain the default options, because the arguments validation will not allow additional options other than those defined explicitly.

This change removes the `options:` section from the parameter specification of `sap_ha_pacemaker_cluster_fence_options` (including updated rebuild of the arguments README section).