### PR TITLE
workflows: version locking of ansible packages for compatibility

### DIFF
--- a/.github/workflows/ansible-lint-sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_general_preconfigure.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_general_preconfigure

--- a/.github/workflows/ansible-lint-sap_ha_install_hana_hsr.yml
+++ b/.github/workflows/ansible-lint-sap_ha_install_hana_hsr.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_ha_install_hana_hsr

--- a/.github/workflows/ansible-lint-sap_hana_install.yml
+++ b/.github/workflows/ansible-lint-sap_hana_install.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_hana_install

--- a/.github/workflows/ansible-lint-sap_hana_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_hana_preconfigure.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_hana_preconfigure

--- a/.github/workflows/ansible-lint-sap_hypervisor_node_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_hypervisor_node_preconfigure.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_hypervisor_node_preconfigure

--- a/.github/workflows/ansible-lint-sap_netweaver_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_netweaver_preconfigure.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_netweaver_preconfigure

--- a/.github/workflows/ansible-lint-sap_storage_setup.yml
+++ b/.github/workflows/ansible-lint-sap_storage_setup.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_storage_setup

--- a/.github/workflows/ansible-lint-sap_swpm.yml
+++ b/.github/workflows/ansible-lint-sap_swpm.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_swpm

--- a/.github/workflows/ansible-lint-sap_vm_preconfigure.yml
+++ b/.github/workflows/ansible-lint-sap_vm_preconfigure.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
       - name: Run ansible-lint
         working-directory: /home/runner/work/community.sap_install/community.sap_install/roles/sap_vm_preconfigure

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -25,8 +25,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip3 install ansible ansible-lint==6.8.6
+          pip3 install ansible==7.5.0
           pip3 install ansible-compat==3.0.2
+          pip3 install ansible-core==2.14.5
+          pip3 install ansible-lint==6.8.6
 
 #      - name: Install collection dependencies
 #        run: ansible-galaxy collection install community.general


### PR DESCRIPTION
Locking the Ansible environment to the following versions, in order to keep the dependencies compatible with our locked ansible-lint version.

```
Package                 Version
----------------------- ---------
ansible                 7.5.0
ansible-compat          3.0.2
ansible-core            2.14.5
ansible-lint            6.8.6
```