### PR TITLE
sap_hana_install: Solve issue #213

### DIFF
--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -191,6 +191,12 @@ sap_hana_install_system_restart: 'n'
 # create_initial_tenant, default: 'y'
 sap_hana_install_create_initial_tenant: 'y'
 
+# The following variable can be used to modify the log_mode to 'overwrite' after the installation has finished.
+# If unset or set to 'normal', the role will leave the log_mode to 'normal', which is required for SAP HANA
+# System Replication. The log_mode 'overwrite' is useful for limiting cost or capacity if System Replication
+# is not used.
+#sap_hana_install_log_mode: 'overwrite'
+
 # If the following variable is specified, the role will perform a scaleout installation or it will add additional
 # hosts to an existing HANA system.
 # Corresponding hdblcm parameter: addhosts

--- a/roles/sap_hana_install/tasks/post_install/log_mode.yml
+++ b/roles/sap_hana_install/tasks/post_install/log_mode.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: SAP HANA Post Install - Set log_mode to overwrite
+- name: SAP HANA Post Install - Set log_mode to overwrite, no initial tenant
   ansible.builtin.shell: |
       LD_LIBRARY_PATH=/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/exe \
       /usr/sap/{{ sap_hana_install_sid }}/SYS/exe/hdb/hdbsql \
@@ -10,20 +10,61 @@
       -u SYSTEM \
       -p '{{ sap_hana_install_db_system_password | d(sap_hana_install_master_password) }}' \
       -m <<EOF
-      ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
-      ALTER SYSTEM ALTER CONFIGURATION('global.ini','HOST','{{ ansible_hostname }}') SET ('persistence','log_mode') = 'overwrite' WITH RECONFIGURE;
-      ALTER SYSTEM ALTER CONFIGURATION('global.ini','DATABASE','{{ sap_hana_install_sid }}') SET ('persistence','log_mode') = 'overwrite' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'HOST', '{{ ansible_hostname }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
       EOF
   args:
     executable: /bin/bash
   become: true
   become_user: "{{ sap_hana_install_sid | lower }}adm"
-  when: not ansible_check_mode
+  when:
+    - not ansible_check_mode
+    - sap_hana_install_create_initial_tenant == 'n'
+    - sap_hana_install_log_mode | d('') == 'overwrite'
   changed_when: no
-  register: __sap_hana_install_hdbsql_logmode
+  register: __sap_hana_install_register_hdbsql_logmode_no_initial_tenant
   tags: sap_hana_install_set_log_mode
 
-- name: SAP HANA Post Install - Display the output of hdbsql
+- name: SAP HANA Post Install - Display the output of hdbsql, no initial tenant
   ansible.builtin.debug:
-    var: __sap_hana_install_hdbsql_logmode.stdout_lines
+    var: __sap_hana_install_register_hdbsql_logmode_no_initial_tenant.stdout_lines
   tags: sap_hana_install_set_log_mode
+  when:
+    - not ansible_check_mode
+    - sap_hana_install_create_initial_tenant == 'n'
+    - sap_hana_install_log_mode | d('') == 'overwrite'
+
+- name: SAP HANA Post Install - Set log_mode to overwrite, with initial tenant
+  ansible.builtin.shell: |
+      LD_LIBRARY_PATH=/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/exe \
+      /usr/sap/{{ sap_hana_install_sid }}/SYS/exe/hdb/hdbsql \
+      -n '{{ ansible_hostname }}' \
+      -i '{{ sap_hana_install_number }}' \
+      -d SYSTEMDB \
+      -u SYSTEM \
+      -p '{{ sap_hana_install_db_system_password | d(sap_hana_install_master_password) }}' \
+      -m <<EOF
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'HOST', '{{ ansible_hostname }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'DATABASE', '{{ sap_hana_install_sid }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
+      EOF
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: "{{ sap_hana_install_sid | lower }}adm"
+  when:
+    - not ansible_check_mode
+    - sap_hana_install_create_initial_tenant == 'y'
+    - sap_hana_install_log_mode | d('') == 'overwrite'
+  changed_when: no
+  register: __sap_hana_install_register_hdbsql_logmode_with_initial_tenant
+  tags: sap_hana_install_set_log_mode
+
+- name: SAP HANA Post Install - Display the output of hdbsql, with initial tenant
+  ansible.builtin.debug:
+    var: __sap_hana_install_register_hdbsql_logmode_with_initial_tenant.stdout_lines
+  tags: sap_hana_install_set_log_mode
+  when:
+    - not ansible_check_mode
+    - sap_hana_install_create_initial_tenant == 'y'
+    - sap_hana_install_log_mode | d('') == 'overwrite'


### PR DESCRIPTION
This change:

- sets `log_mode` to `overwrite` only if the new role parameter `sap_hana_install_log_mode` is set to `overwrite`
- sets `log_mode` to `overwrite` only for the initial tenant database if `sap_hana_install_create_initial_tenant` had been set to `y`.