### PR TITLE
sap_general_preconfigure, sap_hana_preconfigure: Install the ibm-power-managed-rhelX package

### DIFF
--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -183,6 +183,27 @@ The default for this variable is set in the vars file which corresponds to the d
 The default is to install or check if the minimum package versions are installed as defined in the vars files.<br>
 Set to `false` if you do not install or check these minimum package versions.<br>
 
+### sap_general_preconfigure_install_ibm_power_tools
+- _Type:_ `bool`
+- _Default:_ `true`
+
+Set this parameter to `false` to not install the IBM Power Systems service and productivity tools.<br>
+See also SAP note 2679703.<br>
+
+### sap_general_preconfigure_add_ibm_power_repo
+- _Type:_ `bool`
+- _Default:_ `true`
+
+Set this parameter to `false` if you do not want to add the IBM Power tools repository (e.g. because the packages<br>
+are already available on the local network). The IBM Power Systems service and productivity tools will only<br>
+be installed if the variable `sap_general_preconfigure_install_ibm_power_tools` is set to `true`, which is the default.<br>
+
+### sap_general_preconfigure_ibm_power_repo_url
+- _Type:_ `str`
+- _Default:_ `'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'`
+
+URL for the IBM Power Systems service and productivity tools, see https://www.ibm.com/support/pages/service-and-productivity-tools<br>
+
 ### sap_general_preconfigure_update
 - _Type:_ `bool`
 - _Default:_ `false`

--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -82,6 +82,18 @@ sap_general_preconfigure_min_package_check: true
 # The default is to install or check if the minimum package versions are installed as defined in the vars files.
 # Set to `false` if you do not install or check these minimum package versions.
 
+sap_general_preconfigure_install_ibm_power_tools: true
+# Set this parameter to `false` to not install the IBM Power Systems service and productivity tools.
+# See also SAP note 2679703.
+
+sap_general_preconfigure_add_ibm_power_repo: true
+# Set this parameter to `false` if you do not want to add the IBM Power tools repository (e.g. because the packages
+# are already available on the local network). The IBM Power Systems service and productivity tools will only
+# be installed if the variable `sap_general_preconfigure_install_ibm_power_tools` is set to `true`, which is the default.
+
+sap_general_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
+# URL for the IBM Power Systems service and productivity tools, see https://www.ibm.com/support/pages/service-and-productivity-tools
+
 sap_general_preconfigure_update: false
 # By default, the role will not update the system, for avoiding an unintentional minor OS release update.
 # Set this parameter to `true` if you want to update your system to the latest package versions.

--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -179,6 +179,30 @@ argument_specs:
         required: false
         type: bool
 
+      sap_general_preconfigure_install_ibm_power_tools:
+        default: true
+        description:
+          - Set this parameter to `false` to not install the IBM Power Systems service and productivity tools.
+          - See also SAP note 2679703.
+        required: false
+        type: bool
+
+      sap_general_preconfigure_add_ibm_power_repo:
+        default: true
+        description:
+          - Set this parameter to `false` if you do not want to add the IBM Power tools repository (e.g. because the packages
+          - are already available on the local network). The IBM Power Systems service and productivity tools will only
+          - be installed if the variable `sap_general_preconfigure_install_ibm_power_tools` is set to `true`, which is the default.
+        required: false
+        type: bool
+
+      sap_general_preconfigure_ibm_power_repo_url:
+        default: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
+        description:
+          - URL for the IBM Power Systems service and productivity tools, see https://www.ibm.com/support/pages/service-and-productivity-tools
+        required: false
+        type: str
+
       sap_general_preconfigure_update:
         default: false
         description:

--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -157,9 +157,12 @@
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: Get install status of required IBM packages
-  ansible.builtin.shell: set -o pipefail && yum info installed {{ __sap_general_preconfigure_required_ppc64le | map('quote') | join(' ') }} | awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
+  ansible.builtin.shell: |
+    set -o pipefail && yum info installed {{ __sap_general_preconfigure_required_ppc64le | map('quote') | join(' ') }} |
+    awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
   register: __sap_general_preconfigure_register_required_ppc64le_packages_assert
   changed_when: no
+  when: ansible_architecture == "ppc64le"
 
 - name: Assert that all required IBM packages are installed
   ansible.builtin.assert:

--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -156,6 +156,23 @@
     loop_var: line_item
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
+- name: Get install status of required IBM packages
+  ansible.builtin.shell: set -o pipefail && yum info installed {{ __sap_general_preconfigure_required_ppc64le | map('quote') | join(' ') }} | awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
+  register: __sap_general_preconfigure_register_required_ppc64le_packages_assert
+  changed_when: no
+
+- name: Assert that all required IBM packages are installed
+  ansible.builtin.assert:
+    that: "'{{ line_item }}' in __sap_general_preconfigure_register_required_ppc64le_packages_assert.stdout_lines"
+    fail_msg: "FAIL: Package '{{ line_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ line_item }}' is installed."
+  with_items:
+    - "{{ __sap_general_preconfigure_required_ppc64le }}"
+  loop_control:
+    loop_var: line_item
+  when: ansible_architecture == "ppc64le"
+  ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+
 - name: Minimum required package version check
   when:
     - sap_general_preconfigure_min_package_check|bool

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -132,10 +132,36 @@
     name: "{{ sap_general_preconfigure_packages }}"
     state: present
 
+- name: Install the ibm-power-repo package
+  ansible.builtin.package:
+    name: "{{ sap_general_preconfigure_ibm_power_repo_url }}"
+    state: present
+    disable_gpg_check: True
+  when:
+    - ansible_architecture == "ppc64le"
+    - sap_general_preconfigure_install_ibm_power_tools | d(true)
+    - sap_general_preconfigure_add_ibm_power_repo | d(true)
+
+- name: Accept the license for the IBM Service and Productivity Tools
+  ansible.builtin.shell: LESS=+q /opt/ibm/lop/configure <<<'y'
+  when:
+    - ansible_architecture == "ppc64le"
+    - sap_general_preconfigure_install_ibm_power_tools | d(true)
+    - sap_general_preconfigure_add_ibm_power_repo | d(true)
+
+# Reason for noqa: Both yum and dnf support "state: latest"
+- name: Install the IBM Service and Productivity Tools # noqa package-latest
+  ansible.builtin.package:
+    state: latest
+    name: "{{ __sap_general_preconfigure_required_ppc64le }}"
+  when:
+    - ansible_architecture == "ppc64le"
+    - sap_general_preconfigure_install_ibm_power_tools | d(true)
+
 - name: Ensure that the minimum required package versions are installed
   when:
-    - sap_general_preconfigure_min_package_check|bool
-    - __sap_general_preconfigure_min_pkgs|d([])
+    - sap_general_preconfigure_min_package_check | bool
+    - __sap_general_preconfigure_min_pkgs | d([])
   block:
 
     - name: Create a list of minimum required package versions to be installed

--- a/roles/sap_general_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_7.yml
@@ -116,6 +116,33 @@ __sap_general_preconfigure_packages_s390x:
 
 __sap_general_preconfigure_packages: "{{ lookup('vars', '__sap_general_preconfigure_packages_' + ansible_architecture) }}"
 
+# As per https://www14.software.ibm.com/support/customercare/sas/f/lopdiags/home.html :
+__sap_general_preconfigure_required_ppc64le:
+  - librtas
+  - src
+  - rsct.core.utils
+  - rsct.core
+  - rsct.basic
+  - rsct.opt.storagerm
+  - devices.chrp.base.ServiceRM
+  - DynamicRM
+  - ncurses-libs
+  - readline
+  - sqlite
+  - sg3_utils
+  - libgcc
+  - libstdc++
+  - zlib
+  - iprutils
+  - lsvpd
+  - libvpd
+  - libservicelog
+  - servicelog
+  - powerpc-utils
+  - powerpc-utils-python
+  - ppc64-diag
+  - IBMinvscout
+
 __sap_general_preconfigure_min_packages_7_2:
 
 __sap_general_preconfigure_min_packages_7_3:

--- a/roles/sap_general_preconfigure/vars/RedHat_8.0.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_8.0.yml
@@ -47,6 +47,9 @@ __sap_general_preconfigure_packages:
   - nfs-utils
   - bind-utils
 
+__sap_general_preconfigure_required_ppc64le:
+  - ibm-power-managed-rhel8
+
 # SAP notes 2772999 (setup) and 2812427 (kernel):
 __sap_general_preconfigure_min_pkgs:
   - [ 'setup', '2.12.2-2.el8_0.1' ]

--- a/roles/sap_general_preconfigure/vars/RedHat_8.1.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_8.1.yml
@@ -69,6 +69,9 @@ __sap_general_preconfigure_packages_s390x:
 
 __sap_general_preconfigure_packages: "{{ lookup('vars', '__sap_general_preconfigure_packages_' + ansible_architecture) }}"
 
+__sap_general_preconfigure_required_ppc64le:
+  - ibm-power-managed-rhel8
+
 __sap_general_preconfigure_min_pkgs:
   - [ 'setup', '2.12.2-2.el8_1.1' ]
 

--- a/roles/sap_general_preconfigure/vars/RedHat_8.2.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_8.2.yml
@@ -69,5 +69,8 @@ __sap_general_preconfigure_packages_s390x:
 
 __sap_general_preconfigure_packages: "{{ lookup('vars', '__sap_general_preconfigure_packages_' + ansible_architecture) }}"
 
+__sap_general_preconfigure_required_ppc64le:
+  - ibm-power-managed-rhel8
+
 __sap_general_preconfigure_kernel_parameters_default:
   - { name: vm.max_map_count, value: '2147483647' }

--- a/roles/sap_general_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_8.yml
@@ -81,5 +81,8 @@ __sap_general_preconfigure_packages_s390x:
 
 __sap_general_preconfigure_packages: "{{ lookup('vars', '__sap_general_preconfigure_packages_' + ansible_architecture) }}"
 
+__sap_general_preconfigure_required_ppc64le:
+  - ibm-power-managed-rhel8
+
 __sap_general_preconfigure_kernel_parameters_default:
   - { name: vm.max_map_count, value: '2147483647' }

--- a/roles/sap_general_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_9.yml
@@ -89,5 +89,8 @@ __sap_general_preconfigure_packages_s390x:
 
 __sap_general_preconfigure_packages: "{{ lookup('vars', '__sap_general_preconfigure_packages_' + ansible_architecture) }}"
 
+__sap_general_preconfigure_required_ppc64le:
+  - ibm-power-managed-rhel9
+
 __sap_general_preconfigure_kernel_parameters_default:
   - { name: vm.max_map_count, value: '2147483647' }

--- a/roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml
@@ -82,9 +82,12 @@
 ### # yum -y install ibm-power-managed-rhel7
 ###
 - name: Get install status of required IBM packages
-  ansible.builtin.shell: set -o pipefail && yum info installed {{ __sap_hana_preconfigure_required_ppc64le | map('quote') | join(' ') }} | awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
+  ansible.builtin.shell: |
+    set -o pipefail && yum info installed {{ __sap_hana_preconfigure_required_ppc64le | map('quote') | join(' ') }} |
+    awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
   register: __sap_hana_preconfigure_register_required_ppc64le_packages_assert
   changed_when: no
+  when: ansible_architecture == "ppc64le"
 
 - name: Assert that all required IBM packages are installed
   ansible.builtin.assert:

--- a/roles/sap_hana_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_8.yml
@@ -268,7 +268,7 @@ __sap_hana_preconfigure_packages_min_install:
 __sap_hana_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
 
 __sap_hana_preconfigure_required_ppc64le:
-  - ibm-power-managed-8
+  - ibm-power-managed-rhel8
 
 # Network related kernel parameters as set in SAP Note 2382421:
 __sap_hana_preconfigure_kernel_parameters_default:

--- a/roles/sap_hana_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_8.yml
@@ -268,29 +268,7 @@ __sap_hana_preconfigure_packages_min_install:
 __sap_hana_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
 
 __sap_hana_preconfigure_required_ppc64le:
-  - librtas
-  - src
-  - rsct.core.utils
-  - rsct.core
-  - rsct.basic
-  - rsct.opt.storagerm
-  - devices.chrp.base.ServiceRM
-  - DynamicRM
-  - ncurses-libs
-  - readline
-  - sqlite
-  - sg3_utils
-  - libgcc
-  - libstdc++
-  - zlib
-  - iprutils
-  - lsvpd
-  - libvpd
-  - libservicelog
-  - servicelog
-  - powerpc-utils
-  - ppc64-diag
-  - IBMinvscout
+  - ibm-power-managed-8
 
 # Network related kernel parameters as set in SAP Note 2382421:
 __sap_hana_preconfigure_kernel_parameters_default:

--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -238,29 +238,7 @@ __sap_hana_preconfigure_packages_min_install:
 __sap_hana_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
 
 __sap_hana_preconfigure_required_ppc64le:
-  - librtas
-  - src
-  - rsct.core.utils
-  - rsct.core
-  - rsct.basic
-  - rsct.opt.storagerm
-  - devices.chrp.base.ServiceRM
-  - DynamicRM
-  - ncurses-libs
-  - readline
-  - sqlite
-  - sg3_utils
-  - libgcc
-  - libstdc++
-  - zlib
-  - iprutils
-  - lsvpd
-  - libvpd
-  - libservicelog
-  - servicelog
-  - powerpc-utils
-  - ppc64-diag
-  - IBMinvscout
+  - ibm-power-managed-9
 
 # Network related kernel parameters as set in SAP Note 2382421:
 __sap_hana_preconfigure_kernel_parameters_default:

--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -238,7 +238,7 @@ __sap_hana_preconfigure_packages_min_install:
 __sap_hana_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
 
 __sap_hana_preconfigure_required_ppc64le:
-  - ibm-power-managed-9
+  - ibm-power-managed-rhel9
 
 # Network related kernel parameters as set in SAP Note 2382421:
 __sap_hana_preconfigure_kernel_parameters_default:


### PR DESCRIPTION
As per SAP note https://me.sap.com/notes/2679703, version 4, the ibm-power-managed-rhelX package has to be installed on ppc64le for all SAP HANA and NetWeaver/ABAP application server systems, for RHEL 8 and 9.
This PR replaces the list of individual packages by `ibm-power-managed-rhelX` in role `sap_hana_preconfigure` (so the interface does not change), and enables the installation and installation assertion of these packages in the role `sap_general_preconfigure`.