### PR TITLE
sap_ha_pacemaker_cluster: README update

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -108,12 +108,10 @@ The Ansible Role is sequential:
 
 ## Tips
 
-### Disable automatic cluster start on boot
+Check out the [role variables of the `ha_cluster` Linux System Role](https://github.com/linux-system-roles/ha_cluster/blob/main/README.md) for additional possible settings that can be applied when using the `sap_ha_pacemaker_cluster` role.
 
-By default the cluster services will automatically start on system boot. This can be disabled, for instance for the purpose of troubleshooting after a node had failed.<br>
-The `ha_cluster` Linux System Role, which is used to configure the pacemaker cluster, provides a parameter to control this behavior.<br>
-
-Permanently disable the automated start by adding `ha_cluster_start_on_boot: false` to the input variables when executing the role `sap_ha_pacemaker_cluster`.
+For example:<br>
+Adding `ha_cluster_start_on_boot: false` to disable the automatic start of cluster services on boot.
 
 ## Sample
 

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -106,6 +106,15 @@ The Ansible Role is sequential:
 - Execute `ha_cluster` Ansible Role with Linux Pacemaker definition
 - Instantiate Linux Pacemaker cluster
 
+## Tips
+
+### Disable automatic cluster start on boot
+
+By default the cluster services will automatically start on system boot. This can be disabled, for instance for the purpose of troubleshooting after a node had failed.<br>
+The `ha_cluster` Linux System Role, which is used to configure the pacemaker cluster, provides a parameter to control this behavior.<br>
+
+Permanently disable the automated start by adding `ha_cluster_start_on_boot: false` to the input variables when executing the role `sap_ha_pacemaker_cluster`.
+
 ## Sample
 
 Please see a full sample using multiple hosts to create an SAP S/4HANA Distributed deployment in the [/playbooks](../../playbooks/) directory of the Ansible Collection `sap_install`.
@@ -127,18 +136,8 @@ Red Hat for SAP Community of Practice, Janine Fuchs, IBM Lab for SAP Solutions
 Minimum required parameters:
 
 - [ha_cluster_hacluster_password](#ha_cluster_hacluster_password)
-- [sap_hana_cluster_nodes](#sap_hana_cluster_nodes)
 - [sap_hana_instance_number](#sap_hana_instance_number)
-- [sap_hana_sid](#sap_hana_sid)
-- [sap_hana_vip](#sap_hana_vip)
 
-On cloud platforms additional parameters are required:
-
-- AWS: `sap_ha_pacemaker_cluster_aws_*` variables
-- AWS: `sap_ha_pacemaker_cluster_vip_update_rt`
-- IBM Cloud: `sap_ha_pacemaker_cluster_ibmcloud_*` variables
-
----
 
 ### ha_cluster
 
@@ -324,14 +323,6 @@ sap_ha_pacemaker_cluster_resource_defaults:
   resource-stickiness: 1000
 ```
 
-### sap_ha_pacemaker_cluster_sap_type
-
-- _Type:_ `str`
-- _Default:_ `saphana_scaleup`
-
-The SAP landscape to be installed.<br>
-_Currently only SAP HANA scale-up is supported_<br>
-
 ### sap_ha_pacemaker_cluster_vip_client_interface
 
 - _Type:_ `str`
@@ -354,7 +345,7 @@ Customize the name of the resource managing the Virtual IP.<br>
 List one more routing table IDs for managing Virtual IP failover through routing table changes.<br>
 Required for VIP configuration in AWS EC2 environments.<br>
 
-### sap_hana_cluster_nodes <sup>required</sup>
+### sap_hana_cluster_nodes
 
 - _Type:_ `list`
 
@@ -390,14 +381,14 @@ sap_hana_cluster_nodes:
 
 The instance number of the SAP HANA database which is role will configure in the cluster.<br>
 
-### sap_hana_sid <sup>required</sup>
+### sap_hana_sid
 
 - _Type:_ `str`
 
-The SAP System ID of the instance that will be configured in the cluster.<br>
-The SAP SID must follow SAP specifications - see SAP Note 1979280.<br>
+The SAP HANA SID of the instance that will be configured in the cluster.<br>
+The SID must follow SAP specifications - see SAP Note 1979280.<br>
 
-### sap_hana_vip <sup>required</sup>
+### sap_hana_vip
 
 - _Type:_ `dict`
 


### PR DESCRIPTION
A few adjustments were made to sync the README with previous argument specs changes.
A "Tips" sections has been added with a link to the `ha_cluster` LSR README for additional parameters and the suggestion of issue #364 used as example.