### PR TITLE
sap_ha_pacemaker_cluster: fix missing value in platform task conditional

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -2,6 +2,33 @@
 # The following variables are constructed here in order to be provided as
 # input for the included 'ha_cluster' system role.
 
+- name: "SAP HA Prepare Pacemaker - Block when no STONITH resource is defined"
+  when:
+    - sap_ha_pacemaker_cluster_stonith_default is not defined
+      or sap_ha_pacemaker_cluster_stonith_default | length == 0
+    - sap_ha_pacemaker_cluster_stonith_custom is not defined
+      or sap_ha_pacemaker_cluster_stonith_custom | length == 0
+  block:
+
+    - name: "SAP HA Prepare Pacemaker - Set STONITH to disabled when no fencing resource is defined"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_cluster_properties:
+          - attrs:
+              - name: stonith-enabled
+                value: false
+
+    - name: "SAP HA Prepare Pacemaker - Warn that there is no STONITH configured"
+      ansible.builtin.pause:
+        seconds: 5
+        prompt: |
+
+          WARNING: No STONITH resource is defined and STONITH is disabled!
+
+          Recommendation: Add a STONITH resource and set cluster property
+                          "stonith-enabled=true"
+                          before using this cluster for production services.
+# END of block
+
 - name: "SAP HA Prepare Pacemaker - Define cluster stonith properties"
   when:
     - sap_ha_pacemaker_cluster_cluster_properties is defined

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/include_vars_platform.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/include_vars_platform.yml
@@ -24,7 +24,7 @@
 - name: "SAP HA Prepare Pacemaker - IBM Power VS from IBM Cloud - Set variable for fencing agent"
   ansible.builtin.set_fact:
     sap_ha_pacemaker_cluster_ibmcloud_powervs_host_guid: "{{ __sap_ha_pacemaker_cluster_register_ibmcloud_powervs_host }}"
-  when: __sap_ha_pacemaker_cluster_platform == ""
+  when: __sap_ha_pacemaker_cluster_platform == "cloud_ibmcloud_powervs"
 
 # pcmk_host_map format: <hostname1>:<host1-id>;<hostname2>:<host2-id>...
 - name: "SAP HA Prepare Pacemaker - IBM Power VS from IBM Cloud - Assemble host mapping"


### PR DESCRIPTION
This fix is required for the role to work for not explicitly discovered platforms (like ovirt).

**edit**
Additional fix to disable STONITH when there is no stonith resource defined.
If stonith is enabled with no fencing resource configured, it will prevent other resources from starting.