### PR TITLE
Solve issue 426

### DIFF
--- a/roles/sap_install_media_detect/defaults/main.yml
+++ b/roles/sap_install_media_detect/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+# Set this parameter to use either the unar package from EPEL or another software package for handling RAR files.
+# Based on this setting, the commands for listing and extracting RAR files are being set in tasks/prepare/enable_rar_handling.yml
 sap_install_media_detect_rar_package: 'EPEL'
 #sap_install_media_detect_rar_package: 'linux-rar'
 
@@ -9,13 +11,6 @@ sap_install_media_detect_epel_gpg_key_url: "https://download.fedoraproject.org/p
 # The EPEL GPG key can be removed with the rpm_key module and the URL for the key, or by using the rpm -e command.
 # For using the rpm -e command, set this variable to 'false'.
 sap_install_media_detect_use_rpm_key_module_for_removing_the_key: true
-
-# commands for handling rar files
-sap_install_media_detect_rar_list: '/usr/bin/lsar'
-sap_install_media_detect_rar_extract: '/usr/bin/unar'
-
-#sap_install_media_detect_rar_list: '/usr/bin/unrar lb'
-#sap_install_media_detect_rar_extract: '/usr/bin/unrar x'
 
 # If this role is running on a file server on which the SAP software is not to be installed, set the following to true.
 # If this role is running on a system on which the SAP software is to be installed, set the following to false.

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
@@ -38,10 +38,18 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Identify SAP ECC EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP ECC EXPORT - Identify SAP ECC EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXPORT_' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXPORT_' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXPORT_'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXPORT_'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_ecc_export
   changed_when: "item | length > 0"
   with_items:
@@ -117,10 +125,18 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-identify SAP ECC EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-identify SAP ECC EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXPORT_' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXPORT_' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXPORT_' ; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXPORT_'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_ecc_export_repeated
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
@@ -38,7 +38,7 @@
   ignore_errors: true
   changed_when: false
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP ECC EXPORT - Identify SAP ECC EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
@@ -125,7 +125,7 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-identify SAP ECC EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
@@ -68,7 +68,7 @@
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP ECC EXPORT - Find self-extracting RAR EXE (parent RAR file) and extract SAP ECC Installation Export files # noqa no-changed-when
-  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}" sapecc_export_extracted/ ; fi
+  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}{{ sap_install_media_detect_rar_extract_argument }}" sapecc_export_extracted/ ; fi
   with_items:
     - "{{ detect_directory_files_ecc_export.results | map(attribute='stdout') | select() }}"
   args:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
@@ -38,10 +38,18 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Identify SAP ECC IDES EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Identify SAP ECC IDES EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -Eq '*EXP[0-9]' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -Eq '*EXP[0-9]' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -Eq '*EXP[0-9]'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -Eq '*EXP[0-9]'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_ecc_export
   changed_when: "item | length > 0"
   with_items:
@@ -117,10 +125,18 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-identify SAP ECC IDES EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-identify SAP ECC IDES EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -Eq '*EXP[0-9]' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -Eq '*EXP[0-9]' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -Eq '*EXP[0-9]'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -Eq '*EXP[0-9]'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_ecc_export_repeated
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
@@ -38,7 +38,7 @@
   ignore_errors: true
   changed_when: false
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP ECC IDES EXPORT - Identify SAP ECC IDES EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
@@ -125,7 +125,7 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-identify SAP ECC IDES EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
@@ -68,7 +68,7 @@
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP ECC IDES EXPORT - Find self-extracting RAR EXE (parent RAR file) and extract SAP ECC Installation Export files # noqa no-changed-when
-  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}" sapecc_ides_export_extracted/ ; fi
+  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}{{ sap_install_media_detect_rar_extract_argument }}" sapecc_ides_export_extracted/ ; fi
   with_items:
     - "{{ detect_directory_files_ecc_export.results | map(attribute='stdout') | select() }}"
   args:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
@@ -68,7 +68,7 @@
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Find self-extracting RAR EXE (parent RAR file) and extract SAP NetWeaver (ABAP) Installation Export files # noqa no-changed-when
-  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}" sapnwas_abap_export_extracted/ ; fi
+  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}{{ sap_install_media_detect_rar_extract_argument }}" sapnwas_abap_export_extracted/ ; fi
   with_items:
     - "{{ detect_directory_files_nwas_abap_export.results | map(attribute='stdout') | select() }}"
   args:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
@@ -38,7 +38,7 @@
   ignore_errors: true
   changed_when: no
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
@@ -125,7 +125,7 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
@@ -38,10 +38,18 @@
   ignore_errors: true
   changed_when: no
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Identify EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXP'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_nwas_abap_export
   changed_when: "item | length > 0"
   with_items:
@@ -117,10 +125,18 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-identify EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/EXP'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_nwas_abap_export_repeated
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
@@ -38,10 +38,18 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Identify EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_nwas_java_export
   changed_when: "item | length > 0"
   with_items:
@@ -117,10 +125,18 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-identify EXPORT files
+# Reason for noqa: shell output can be incorrect for complex if statements
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP' ; then echo '{{ item }}' ; fi ;
-    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
+       if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP'; then
+          echo '{{ item }}'
+       fi
+    elif [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then
+       if eval "{{ sap_install_media_detect_rar_list }}" {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP'; then
+          echo '{{ item }}'
+       fi
+    fi
   register: detect_directory_files_nwas_java_export_repeated
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
@@ -68,7 +68,7 @@
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Find self-extracting RAR EXE (parent RAR file) and extract SAP NetWeaver (JAVA) Installation Export files # noqa no-changed-when
-  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}" sapnwas_java_export_extracted/ ; fi
+  ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR self-extracting archive')" ]; then eval "{{ sap_install_media_detect_rar_extract }}" "{{ item }}{{ sap_install_media_detect_rar_extract_argument }}" sapnwas_java_export_extracted/ ; fi
   with_items:
     - "{{ detect_directory_files_nwas_java_export.results | map(attribute='stdout') | select() }}"
   args:

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
@@ -38,7 +38,7 @@
   ignore_errors: true
   changed_when: false
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
@@ -125,7 +125,7 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-# Reason for noqa: shell output can be incorrect for complex if statements
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then

--- a/roles/sap_install_media_detect/tasks/detect_export_sapsolman_abap.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapsolman_abap.yml
@@ -28,9 +28,10 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Identify EXPORT files
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_nwas_abap_export
   changed_when: "item | length > 0"
   with_items:
@@ -77,9 +78,10 @@
   when:
     - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Local Directory source - re-identify EXPORT files
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_nwas_abap_export_repeated
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_ibmdb2.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_ibmdb2.yml
@@ -30,9 +30,10 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 installation media
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 installation media # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'db2setup' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'db2setup' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_ibmdb2
   changed_when: "item | length > 0"
   with_items:
@@ -40,9 +41,10 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
 
-- name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 Client installation media
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 Client installation media # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'db6_update_client.sh' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'db6_update_client.sh' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_ibmdb2_client
   changed_when: "item | length > 0"
   with_items:
@@ -50,9 +52,10 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
 
-- name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 OEM license file
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 OEM license file # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'db2aese_c.lic' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'db2aese_c.lic' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_ibmdb2_license
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_oracledb.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_oracledb.yml
@@ -29,9 +29,10 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - Oracle DB - Identify Oracle DB installation media
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - Oracle DB - Identify Oracle DB installation media # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q '19cinstall.sh' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q '19cinstall.sh' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_oracledb
   changed_when: "item | length > 0"
   with_items:
@@ -39,9 +40,10 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
 
-- name: SAP Install Media Detect - Oracle DB - Identify Oracle DB Client installation media
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - Oracle DB - Identify Oracle DB Client installation media # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'OCL_LINUX_X86_64' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'OCL_LINUX_X86_64' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_oracledb_client
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_sapase.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_sapase.yml
@@ -29,9 +29,10 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - SAP ASE - Identify SAP ASE installation media
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - SAP ASE - Identify SAP ASE installation media # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'BD_SYBASE_ASE' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'BD_SYBASE_ASE' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_sapase
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_sapmaxdb.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_sapmaxdb.yml
@@ -28,9 +28,10 @@
   ignore_errors: true
   changed_when: false
 
-- name: SAP Install Media Detect - SAP MaxDB - Identify SAP MaxDB installation media
+# Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
+- name: SAP Install Media Detect - SAP MaxDB - Identify SAP MaxDB installation media # noqa risky-shell-pipe
   ansible.builtin.shell: |
-    set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'MaxDB_7.9' ; then echo '{{ item }}' ; fi ; fi
+    if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'MaxDB_7.9' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_sapmaxdb
   changed_when: "item | length > 0"
   with_items:

--- a/roles/sap_install_media_detect/tasks/prepare/enable_rar_handling.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/enable_rar_handling.yml
@@ -46,13 +46,11 @@
         name: unar
         state: present
 
-    - name: SAP Install Media Detect - Prepare - EPEL - Set fact for listing the content of a RAR file
+    - name: SAP Install Media Detect - Prepare - EPEL - Set facts
       ansible.builtin.set_fact:
         sap_install_media_detect_rar_list: '/usr/bin/lsar'
-
-    - name: SAP Install Media Detect - Prepare - EPEL - Set fact for extracting a RAR file
-      ansible.builtin.set_fact:
         sap_install_media_detect_rar_extract: '/usr/bin/unar'
+        sap_install_media_detect_rar_extract_argument: ' -o'
 
 - name: SAP Install Media Detect - Prepare - Install an unrar package
   when: sap_install_media_detect_rar_package != 'EPEL'
@@ -63,10 +61,8 @@
         name: "{{ sap_install_media_detect_rar_package }}"
         state: present
 
-    - name: SAP Install Media Detect - Prepare - unrar - Set fact for listing the content of a RAR file
+    - name: SAP Install Media Detect - Prepare - unrar - Set facts
       ansible.builtin.set_fact:
         sap_install_media_detect_rar_list: '/usr/bin/unrar lb'
-
-    - name: SAP Install Media Detect - Prepare - unrar - Set fact for extracting a RAR file
-      ansible.builtin.set_fact:
         sap_install_media_detect_rar_extract: '/usr/bin/unrar x'
+        sap_install_media_detect_rar_extract_argument: ''


### PR DESCRIPTION
- add ` -o` as an additional option to the `unar` command for specifying the destination extraction directory 
- remove all of `set -o pipefail` for all shell command sequences which contain `grep -q`
- add ` # noqa risky-shell-pipe` to the affected tasks and add `Reason for noqa: ...` in a comment right before the task 