### PR TITLE
sap_install_media_detect: Implement remote_dir

### DIFF
--- a/roles/sap_install_media_detect/tasks/detect_backup_saphana.yml
+++ b/roles/sap_install_media_detect/tasks/detect_backup_saphana.yml
@@ -2,6 +2,26 @@
 
 - name: Identify SAP HANA Backup files
   ansible.builtin.find:
+    paths: "{{ sap_install_media_detect_source_directory }}"
+    recurse: true
+    file_type: directory
+    patterns: '.*COMPLETE.*'
+    use_regex: true
+  register: backup_saphana_find_dir_source
+
+- name: SAP Install Media Detect - SAP HANA Backup files - Copy files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ line_item.path }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item.path | basename }}"
+    remote_src: true
+  loop:
+    "{{ backup_saphana_find_dir_source.files }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
+
+- name: Re-identify SAP HANA Backup files
+  ansible.builtin.find:
     paths: "{{ sap_install_media_detect_backup_directory }}"
     recurse: true
     file_type: directory

--- a/roles/sap_install_media_detect/tasks/detect_export_sapbw4hana.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapbw4hana.yml
@@ -12,15 +12,33 @@
 
 - name: SAP Install Media Detect - SAP BW/4HANA EXPORT - Identify SAP BW/4HANA EXPORT files
   ansible.builtin.find:
-    paths: "{{ __sap_install_media_detect_software_main_directory }}"
+    paths: "{{ sap_install_media_detect_source_directory }}"
+    recurse: true
+    file_type: file
+    patterns: '.*BW4.*EXPORT.*'
+    use_regex: true
+  register: bw4hana_export_files_source
+
+- name: SAP Install Media Detect - SAP BW/4HANA EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ line_item.path }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item.path | basename }}"
+    remote_src: true
+  loop:
+    "{{ bw4hana_export_files_source.files }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
+
+- name: SAP Install Media Detect - SAP BW/4HANA EXPORT - Re-identify SAP BW/4HANA EXPORT files
+  ansible.builtin.find:
+    paths: "{{ sap_install_media_detect_target_directory }}"
     recurse: true
     file_type: file
     patterns: '.*BW4.*EXPORT.*'
     use_regex: true
   register: bw4hana_export_files
 
-- name: SAP Install Media Detect - SAP BW/4HANA EXPORT - Local Directory source - move SAP BW/4HANA EXPORT files
+- name: SAP Install Media Detect - SAP BW/4HANA EXPORT - Move SAP BW/4HANA EXPORT files
   ansible.builtin.command: mv "{{ item.path }}" "{{ __sap_install_media_detect_software_main_directory }}/sapbw4hana_export/{{ item.path | basename }}"
   with_items: "{{ bw4hana_export_files.files }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc.yml
@@ -12,7 +12,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Create Directories
+- name: SAP Install Media Detect - SAP ECC EXPORT - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -23,11 +23,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapecc_export/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapecc_export_extracted/"
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - List files in directory
+- name: SAP Install Media Detect - SAP ECC EXPORT - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP ECC EXPORT - Detect ZIP files (including no file extensions), ignore errors
@@ -36,7 +36,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -46,7 +46,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -68,7 +68,18 @@
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_rar.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP ECC EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_ecc_export.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP ECC EXPORT - If any ZIP, then extract the SAP ECC Installation Export file (unzip) # noqa no-changed-when
@@ -101,16 +112,14 @@
     use_regex: true
   register: detect_directory_export_extracted
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-list files in directory
+- name: SAP Install Media Detect - SAP ECC EXPORT - Re-list files in directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   changed_when: false
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-detect ZIP files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP ECC EXPORT - Re-detect ZIP files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then echo {{ item }}; fi
   register: detect_directory_files_zip_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -119,10 +128,8 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-detect RAR files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP ECC EXPORT - Re-detect RAR files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then echo {{ item }}; fi
   register: detect_directory_files_rar_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -131,11 +138,9 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
-- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - re-identify SAP ECC EXPORT files # noqa risky-shell-pipe
+- name: SAP Install Media Detect - SAP ECC EXPORT - Re-identify SAP ECC EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
        if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXPORT_' ; then
@@ -153,12 +158,8 @@
     - "{{ detect_directory_files_rar_repeated.results | map(attribute='stdout') | select() }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC EXPORT - Local Directory source - move SAP ECC EXPORT compressed archive files
+- name: SAP Install Media Detect - SAP ECC EXPORT - Move SAP ECC EXPORT compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapecc_export/{{ item }}"
   with_items:
     - "{{ detect_directory_files_ecc_export_repeated.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapecc_ides.yml
@@ -12,7 +12,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Create Directories
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -23,11 +23,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapecc_ides_export/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapecc_ides_export_extracted/"
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - List files in directory
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP ECC IDES EXPORT - Detect ZIP files (including no file extensions), ignore errors
@@ -36,7 +36,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -46,7 +46,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -68,7 +68,18 @@
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_rar.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_ecc_export.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP ECC IDES EXPORT - If any ZIP, then extract the SAP ECC Installation Export file (unzip) # noqa no-changed-when
@@ -101,16 +112,14 @@
     use_regex: true
   register: detect_directory_export_extracted
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-list files in directory
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Re-list files in directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   changed_when: false
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-detect ZIP files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Re-detect ZIP files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then echo {{ item }}; fi
   register: detect_directory_files_zip_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -119,10 +128,8 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-detect RAR files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Re-detect RAR files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then echo {{ item }}; fi
   register: detect_directory_files_rar_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -131,11 +138,9 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - re-identify SAP ECC IDES EXPORT files # noqa risky-shell-pipe
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Re-identify SAP ECC IDES EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
        if zipinfo -1 {{ item }} | grep -Eq '*EXP[0-9]'; then
@@ -153,12 +158,8 @@
     - "{{ detect_directory_files_rar_repeated.results | map(attribute='stdout') | select() }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Local Directory source - move SAP ECC IDES EXPORT compressed archive files
+- name: SAP Install Media Detect - SAP ECC IDES EXPORT - Move SAP ECC IDES EXPORT compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapecc_ides_export/{{ item }}"
   with_items:
     - "{{ detect_directory_files_ecc_export_repeated.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_abap.yml
@@ -23,11 +23,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_abap_export/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_abap_export_extracted/"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - List files in directory
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Detect ZIP files (including no file extensions), ignore errors
@@ -36,7 +36,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: no
 
@@ -46,7 +46,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: no
 
@@ -68,7 +68,18 @@
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_rar.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_nwas_abap_export.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - If any ZIP, then extract the SAP NetWeaver (ABAP) Installation Export file (unzip) # noqa no-changed-when
@@ -101,16 +112,14 @@
     use_regex: true
   register: detect_directory_export_extracted
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-list files in directory
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Re-list files in directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   changed_when: false
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-detect ZIP files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Re-detect ZIP files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then echo {{ item }}; fi
   register: detect_directory_files_zip_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -119,10 +128,8 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-detect RAR files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Re-detect RAR files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then echo {{ item }}; fi
   register: detect_directory_files_rar_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -131,11 +138,9 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
        if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP'; then
@@ -153,12 +158,8 @@
     - "{{ detect_directory_files_rar_repeated.results | map(attribute='stdout') | select() }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Local Directory source - move EXPORT compressed archive files
+- name: SAP Install Media Detect - SAP NetWeaver AS (ABAP) platform only EXPORT - Move EXPORT compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_abap_export/{{ item }}"
   with_items:
     - "{{ detect_directory_files_nwas_abap_export_repeated.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapnwas_java.yml
@@ -12,7 +12,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Create Directories
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -23,11 +23,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_java_export/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_java_export_extracted/"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - List files in directory
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Detect ZIP files (including no file extensions), ignore errors
@@ -36,7 +36,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -46,7 +46,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -68,7 +68,18 @@
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_rar.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_nwas_java_export.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - If any ZIP, then extract the SAP NetWeaver (JAVA) Installation Export file (unzip) # noqa no-changed-when
@@ -101,16 +112,14 @@
     use_regex: true
   register: detect_directory_export_extracted
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-list files in directory
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Re-list files in directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   changed_when: false
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-detect ZIP files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Re-detect ZIP files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then echo {{ item }}; fi
   register: detect_directory_files_zip_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -119,10 +128,8 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-detect RAR files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Re-detect RAR files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'RAR')" ]; then echo {{ item }}; fi
   register: detect_directory_files_rar_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -131,11 +138,9 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then
        if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/JAVA_EXPORT_JDMP'; then
@@ -153,12 +158,8 @@
     - "{{ detect_directory_files_rar_repeated.results | map(attribute='stdout') | select() }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - Local Directory source - move EXPORT compressed archive files
+- name: SAP Install Media Detect - SAP NetWeaver AS (JAVA) platform only EXPORT - move EXPORT compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_java_export/{{ item }}"
   with_items:
     - "{{ detect_directory_files_nwas_java_export_repeated.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_export_saps4hana.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_saps4hana.yml
@@ -12,15 +12,33 @@
 
 - name: SAP Install Media Detect - SAP S/4HANA EXPORT - Identify SAP S/4HANA EXPORT files
   ansible.builtin.find:
-    paths: "{{ __sap_install_media_detect_software_main_directory }}"
+    paths: "{{ sap_install_media_detect_source_directory }}"
+    recurse: true
+    file_type: file
+    patterns: '.*S4.*EXPORT.*'
+    use_regex: true
+  register: s4hana_export_files_source
+
+- name: SAP Install Media Detect - SAP S/4HANA EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ line_item.path }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item.path | basename }}"
+    remote_src: true
+  loop:
+    "{{ s4hana_export_files_source.files }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
+
+- name: SAP Install Media Detect - SAP S/4HANA EXPORT - Re-Identify SAP S/4HANA EXPORT files
+  ansible.builtin.find:
+    paths: "{{ sap_install_media_detect_source_directory }}"
     recurse: true
     file_type: file
     patterns: '.*S4.*EXPORT.*'
     use_regex: true
   register: s4hana_export_files
 
-- name: SAP Install Media Detect - SAP S/4HANA EXPORT - Local Directory source - move SAP S/4HANA EXPORT files
+- name: SAP Install Media Detect - SAP S/4HANA EXPORT - Move SAP S/4HANA EXPORT files
   ansible.builtin.command: mv "{{ item.path }}" "{{ __sap_install_media_detect_software_main_directory }}/saps4hana_export/{{ item.path | basename }}"
   with_items: "{{ s4hana_export_files.files }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_export_sapsolman_abap.yml
+++ b/roles/sap_install_media_detect/tasks/detect_export_sapsolman_abap.yml
@@ -12,7 +12,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Create Directories
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -23,11 +23,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_abap_export/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapsolman_abap_export_extracted/"
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - List files in directory
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Detect ZIP files (including no file extensions), ignore errors
@@ -36,7 +36,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -49,7 +49,18 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Copy EXPORT files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_nwas_abap_export.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - If any ZIP, then extract the SAP NetWeaver (ABAP) Installation Export file (unzip) # noqa no-changed-when
@@ -71,16 +82,14 @@
     use_regex: true
   register: detect_directory_export_extracted
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Local Directory source - re-list files in directory
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Re-list files in directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   changed_when: false
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Local Directory source - re-detect ZIP files (including no file extensions), ignore errors
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Re-detect ZIP files (including no file extensions), ignore errors
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then echo {{ item }}; fi
   register: detect_directory_files_zip_repeated
 #  changed_when: "item.stdout | length > 0"
@@ -89,11 +98,9 @@
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   ignore_errors: true
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Local Directory source - re-identify EXPORT files # noqa risky-shell-pipe
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Re-identify EXPORT files # noqa risky-shell-pipe
   ansible.builtin.shell: |
     if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then if zipinfo -1 {{ item }} | grep -q 'DATA_UNITS/EXP' ; then echo '{{ item }}' ; fi ; fi
   register: detect_directory_files_nwas_abap_export_repeated
@@ -102,12 +109,8 @@
     - "{{ detect_directory_files_zip_repeated.results | map(attribute='stdout') | select() }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"
 
-- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Local Directory source - move EXPORT compressed archive files
+- name: SAP Install Media Detect - SAP Solution Manager (ABAP) EXPORT - Move EXPORT compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapnwas_abap_export/{{ item }}"
   with_items:
     - "{{ detect_directory_files_nwas_abap_export_repeated.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_ibmdb2.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_ibmdb2.yml
@@ -36,7 +36,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - IBM Db2 - Create Directories
+- name: SAP Install Media Detect - IBM Db2 - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -49,11 +49,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/ibmdb2_client_extracted/"
     - "{{ __sap_install_media_detect_software_main_directory }}/ibmdb2_license_extracted/"
 
-- name: SAP Install Media Detect - IBM Db2 - List files in directory
+- name: SAP Install Media Detect - IBM Db2 - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - IBM Db2 - Detect ZIP files (including no file extensions), ignore errors
@@ -62,7 +62,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -75,7 +75,7 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 Client installation media # noqa risky-shell-pipe
@@ -86,7 +86,7 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - IBM Db2 - Identify IBM Db2 OEM license file # noqa risky-shell-pipe
@@ -97,10 +97,23 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - IBM Db2 - Copy IBM Db2 files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_ibmdb2.results | map(attribute='stdout') | select() }}"
+    - "{{ detect_directory_files_ibmdb2_client.results | map(attribute='stdout') | select() }}"
+    - "{{ detect_directory_files_ibmdb2_license.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
-- name: SAP Install Media Detect - IBM Db2 - Extract ZIP files of IBM DB2 installation media # noqa no-changed-when
+- name: SAP Install Media Detect - IBM Db2 - Extract ZIP files of IBM Db2 installation media # noqa no-changed-when
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then unzip {{ item }} -d {{ __sap_install_media_detect_software_main_directory }}/ibmdb2_extracted/{{ item }}_extracted; fi
   with_items:
     - "{{ detect_directory_files_ibmdb2.results | map(attribute='stdout') | select() }}"
@@ -111,7 +124,7 @@
              sap_install_media_detect_skip_extraction_if_target_dir_exists)
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
-- name: SAP Install Media Detect - IBM Db2 - Extract ZIP files of IBM DB2 Client installation media # noqa no-changed-when
+- name: SAP Install Media Detect - IBM Db2 - Extract ZIP files of IBM Db2 Client installation media # noqa no-changed-when
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then unzip {{ item }} -d {{ __sap_install_media_detect_software_main_directory }}/ibmdb2_client_extracted/{{ item }}_extracted; fi
   with_items:
     - "{{ detect_directory_files_ibmdb2_client.results | map(attribute='stdout') | select() }}"
@@ -122,7 +135,7 @@
              sap_install_media_detect_skip_extraction_if_target_dir_exists)
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
-- name: SAP Install Media Detect - IBM Db2 - Extract ZIP files of IBM DB2 OEM license file # noqa no-changed-when
+- name: SAP Install Media Detect - IBM Db2 - Extract ZIP files of IBM Db2 OEM license file # noqa no-changed-when
   ansible.builtin.shell: set -o pipefail && if [ ! -z "$(file {{ item }} | grep 'Zip archive data')" ]; then unzip {{ item }} -d {{ __sap_install_media_detect_software_main_directory }}/ibmdb2_license_extracted/{{ item }}_extracted; fi
   with_items:
     - "{{ detect_directory_files_ibmdb2_license.results | map(attribute='stdout') | select() }}"
@@ -150,11 +163,9 @@
     use_regex: true
   register: detect_directory_ibmdb2_client_extracted
 
-- name: SAP Install Media Detect - IBM Db2 - Local Directory source - move IBM Db2 compressed archive files
+- name: SAP Install Media Detect - IBM Db2 - Move IBM Db2 compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/ibmdb2/{{ item }}"
   with_items:
     - "{{ detect_directory_files_ibmdb2.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_ibmdb2_client.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_ibmdb2_license.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_oracledb.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_oracledb.yml
@@ -24,7 +24,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - Oracle DB - Create Directories
+- name: SAP Install Media Detect - Oracle DB - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -36,11 +36,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/oracledb_extracted/"
     - "{{ __sap_install_media_detect_software_main_directory }}/oracledb_client_extracted/"
 
-- name: SAP Install Media Detect - Oracle DB - List files in directory
+- name: SAP Install Media Detect - Oracle DB - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - Oracle DB - Detect ZIP files (including no file extensions), ignore errors
@@ -49,7 +49,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -62,7 +62,7 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
 
 # Reason for noqa: grep -q with pipefail shell option returns 141 instead of 0
 - name: SAP Install Media Detect - Oracle DB - Identify Oracle DB Client installation media # noqa risky-shell-pipe
@@ -73,7 +73,19 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - Oracle DB - Copy Oracle DB files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_oracledb.results | map(attribute='stdout') | select() }}"
+    - "{{ detect_directory_files_oracledb_client.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - Oracle DB - Extract ZIP files of Oracle DB installation media # noqa no-changed-when
@@ -115,10 +127,8 @@
     use_regex: true
   register: detect_directory_oracledb_client_extracted
 
-- name: SAP Install Media Detect - Oracle DB - Local Directory source - move Oracle DB compressed archive files
+- name: SAP Install Media Detect - Oracle DB - Move Oracle DB compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/oracledb/{{ item }}"
   with_items:
     - "{{ detect_directory_files_oracledb.results | map(attribute='stdout') | select() }}"
     - "{{ detect_directory_files_oracledb_client.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_sapase.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_sapase.yml
@@ -12,7 +12,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - SAP ASE - Create Directories
+- name: SAP Install Media Detect - SAP ASE - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -24,11 +24,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapase_extracted/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapase_client_extracted/"
 
-- name: SAP Install Media Detect - SAP ASE - List files in directory
+- name: SAP Install Media Detect - SAP ASE - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP ASE - Detect ZIP files (including no file extensions), ignore errors
@@ -37,7 +37,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -50,16 +50,38 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP ASE - Copy SAP ASE files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_sapase.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP ASE - Identify SAP ASE Client installation media
   ansible.builtin.find:
-    paths: "{{ __sap_install_media_detect_software_main_directory }}"
+    paths: "{{ sap_install_media_detect_source_directory }}"
     recurse: true
     file_type: file
     patterns: '.*ASEBC.*'
     use_regex: true
   register: detect_directory_files_sapase_client
+
+- name: SAP Install Media Detect - SAP ASE - Copy SAP ASE files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ line_item.path }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item.path | basename }}"
+    remote_src: true
+  loop:
+    "{{ detect_directory_files_sapase_client.files }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP ASE - Extract ZIP files of SAP ASE installation media # noqa no-changed-when
@@ -102,9 +124,7 @@
     use_regex: true
   register: detect_directory_sapase_client_extracted
 
-- name: SAP Install Media Detect - SAP ASE - Local Directory source - move SAP ASE compressed archive files
+- name: SAP Install Media Detect - SAP ASE - Move SAP ASE compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapase/{{ item }}"
   with_items:
     - "{{ detect_directory_files_sapase.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_sapanydb_sapmaxdb.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapanydb_sapmaxdb.yml
@@ -12,7 +12,7 @@
   when:
     - not sap_install_media_detect_skip_extraction_if_target_dir_exists
 
-- name: SAP Install Media Detect - SAP MaxDB - Create Directories
+- name: SAP Install Media Detect - SAP MaxDB - Ensure directories exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -23,11 +23,11 @@
     - "{{ __sap_install_media_detect_software_main_directory }}/sapmaxdb/"
     - "{{ __sap_install_media_detect_software_main_directory }}/sapmaxdb_extracted/"
 
-- name: SAP Install Media Detect - SAP MaxDB - List files in directory
+- name: SAP Install Media Detect - SAP MaxDB - List files in source directory
   ansible.builtin.command: find . -maxdepth 1 -type f
   register: detect_directory_files
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   changed_when: false
 
 - name: SAP Install Media Detect - SAP MaxDB - Detect ZIP files (including no file extensions), ignore errors
@@ -36,7 +36,7 @@
   with_items:
     - "{{ detect_directory_files.stdout_lines }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   ignore_errors: true
   changed_when: false
 
@@ -49,7 +49,18 @@
   with_items:
     - "{{ detect_directory_files_zip.results | map(attribute='stdout') | select() }}"
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - SAP MaxDB - Copy SAP MaxDB files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item }}"
+    remote_src: true
+  with_items:
+    - "{{ detect_directory_files_sapmaxdb.results | map(attribute='stdout') | select() }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 # Reason for noqa: Difficult to determine the change status in the shell command sequence
 - name: SAP Install Media Detect - SAP MaxDB - Extract ZIP files of SAP MaxDB installation media # noqa no-changed-when
@@ -71,9 +82,7 @@
     use_regex: true
   register: detect_directory_sapmaxdb_extracted
 
-- name: SAP Install Media Detect - SAP MaxDB - Local Directory source - move SAP MaxDB compressed archive files
+- name: SAP Install Media Detect - SAP MaxDB - Move SAP MaxDB compressed archive files
   ansible.builtin.command: mv "{{ __sap_install_media_detect_software_main_directory }}/{{ item }}" "{{ __sap_install_media_detect_software_main_directory }}/sapmaxdb/{{ item }}"
   with_items:
     - "{{ detect_directory_files_sapmaxdb.results | map(attribute='stdout') | select() }}"
-  when:
-    - sap_install_media_detect_source == "local_dir"

--- a/roles/sap_install_media_detect/tasks/detect_sapcar.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapcar.yml
@@ -3,13 +3,20 @@
 - name: SAP Install Media Detect - SAPCAR - Get SAPCAR executable file from folder - {{ __sap_install_media_detect_software_main_directory }}
   ansible.builtin.shell: ls SAPCAR*.EXE
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: sap_swpm_sapcar_file_name_get
   changed_when: false
 
 - name: SAP Install Media Detect - SAPCAR - Set fact
   ansible.builtin.set_fact:
     sap_swpm_sapcar_file_name: "{{ sap_swpm_sapcar_file_name_get.stdout }}"
+
+- name: SAP Install Media Detect - SAPCAR - Copy SAPCAR file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ sap_swpm_sapcar_file_name }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ sap_swpm_sapcar_file_name | basename }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAPCAR - Change ownership of SAPCAR
   ansible.builtin.file:

--- a/roles/sap_install_media_detect/tasks/detect_saphana.yml
+++ b/roles/sap_install_media_detect/tasks/detect_saphana.yml
@@ -12,16 +12,11 @@
     owner: root
     group: root
 
-- name: SAP Install Media Detect - SAP HANA - Copy SAPCAR file
-  ansible.builtin.shell: |
-    cp {{ __sap_install_media_detect_software_main_directory }}/{{ sap_swpm_sapcar_file_name_get.stdout }} {{ sap_hana_install_directory }}/{{ sap_swpm_sapcar_file_name_get.stdout }}
-  changed_when: true
-
 # IMDB SAR Files
 - name: SAP Install Media Detect - SAP HANA - Get all IMDB SAR files in folder - {{ __sap_install_media_detect_software_main_directory }}
   ansible.builtin.shell: ls IMDB*.SAR
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: imdb_sarfiles_list
   changed_when: false
 
@@ -30,6 +25,17 @@
     sap_hana_install_imdb_sar: "{{ imdb_sarfiles_list.stdout.split() }}"
   when:
     - not( imdb_sarfiles_list.stdout == '' )
+
+- name: SAP Install Media Detect - SAP HANA - Copy all IMDB SAR files to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ line_item.path | basename }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item.path | basename }}"
+    remote_src: true
+  loop:
+    "{{ sap_hana_install_imdb_sar }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP HANA - Copy SAP HANA files
   ansible.builtin.shell: |
@@ -52,6 +58,11 @@
     mode: '0755'
     owner: root
     group: root
+
+- name: SAP Install Media Detect - SAP HANA - Copy SAPCAR file
+  ansible.builtin.shell: |
+    cp {{ __sap_install_media_detect_software_main_directory }}/{{ sap_swpm_sapcar_file_name_get.stdout }} {{ sap_hana_install_directory }}/{{ sap_swpm_sapcar_file_name_get.stdout }}
+  changed_when: true
 
 # Create directory  {{ sap_hana_install_directory }}/extracted
 # This is where all extracted .SAR files will be stored

--- a/roles/sap_install_media_detect/tasks/detect_saphostagent.yml
+++ b/roles/sap_install_media_detect/tasks/detect_saphostagent.yml
@@ -13,14 +13,21 @@
     group: root
 
 # SAPHOSTAGENT
-- name: SAP Install Media Detect - SAP Host Agent - Get SAPHOSTAGENT SAR file from folder - {{ __sap_install_media_detect_software_main_directory }}
+- name: SAP Install Media Detect - SAP Host Agent - Get SAPHOSTAGENT SAR file from folder - {{ sap_install_media_detect_source_directory }}
   ansible.builtin.shell: ls SAPHOSTAGENT*SAR
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: saphostagent_sarfile
   changed_when: false
 
-- name: SAP Install Media Detect - SAP Host Agent - Copy SAPHOSTAGENT SAR file
+- name: SAP Install Media Detect - SAP Host Agent - Copy SAPHOSTAGENT SAR file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ saphostagent_sarfile.stdout }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ saphostagent_sarfile.stdout }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
+
+- name: SAP Install Media Detect - SAP Host Agent - Copy SAPHOSTAGENT SAR file to subdirectory
   ansible.builtin.shell: |
     cp {{ __sap_install_media_detect_software_main_directory }}/{{ saphostagent_sarfile.stdout }} {{ sap_hostagent_install_directory }}/{{ saphostagent_sarfile.stdout }}
   changed_when: true

--- a/roles/sap_install_media_detect/tasks/detect_sapigs.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapigs.yml
@@ -1,11 +1,18 @@
 ---
 
-- name: SAP Install Media Detect - SAP IGS - Get IGS from software path
+- name: SAP Install Media Detect - SAP IGS - Get IGS from software path in source directory
   ansible.builtin.shell: ls igsexe*.sar
   args:
-    chdir: "{{ sap_swpm_software_path }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: sap_swpm_igs_file_name_get
   changed_when: false
+
+- name: SAP Install Media Detect - SAP IGS - Copy SAP IGS file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ sap_swpm_igs_file_name_get.stdout }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ sap_swpm_igs_file_name_get.stdout }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP IGS - Set fact for IGS
   ansible.builtin.set_fact:
@@ -20,12 +27,19 @@
   failed_when: not sap_swpm_igs_file_name_stat.stat.exists
 
 # 4. IGS Helper
-- name: SAP Install Media Detect - SAP IGS - Get IGS Helper from software path
+- name: SAP Install Media Detect - SAP IGS - Get IGS Helper from software path in source directory
   ansible.builtin.shell: ls igshelper*.sar
   args:
-    chdir: "{{ sap_swpm_software_path }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: sap_swpm_igs_helper_file_name_get
   changed_when: false
+
+- name: SAP Install Media Detect - SAP IGS - Copy SAP IGS helper file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ sap_swpm_igs_helper_file_name_get.stdout }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ sap_swpm_igs_helper_file_name_get.stdout }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP IGS - Set fact for IGS
   ansible.builtin.set_fact:

--- a/roles/sap_install_media_detect/tasks/detect_sapkernel.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapkernel.yml
@@ -1,12 +1,19 @@
 ---
 
 # 5. SAPEXEDB
-- name: SAP Install Media Detect - SAP Kernel - Get SAPEXEDB from software path
+- name: SAP Install Media Detect - SAP Kernel - Get SAPEXEDB from software path in source directory
   ansible.builtin.shell: ls SAPEXEDB_*.SAR
   args:
-    chdir: "{{ sap_swpm_software_path }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: sap_swpm_kernel_dependent_file_name_get
   changed_when: false
+
+- name: SAP Install Media Detect - SAP Kernel - Copy SAPEXEDB file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ sap_swpm_kernel_dependent_file_name_get.stdout }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ sap_swpm_kernel_dependent_file_name_get.stdout }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP Kernel - Set fact for SAPEXEDB
   ansible.builtin.set_fact:
@@ -20,12 +27,19 @@
   failed_when: not sap_swpm_kernel_dependent_file_name_stat.stat.exists
 
 # 6. SAPEXE
-- name: SAP Install Media Detect - SAP Kernel - Get SAPEXE from software path
+- name: SAP Install Media Detect - SAP Kernel - Get SAPEXE from software path in source directory
   ansible.builtin.shell: ls SAPEXE_*.SAR
   args:
-    chdir: "{{ sap_swpm_software_path }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: sap_swpm_kernel_independent_file_name_get
   changed_when: false
+
+- name: SAP Install Media Detect - SAP Kernel - Copy SAPEXEDB file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ sap_swpm_kernel_independent_file_name_get.stdout }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ sap_swpm_kernel_independent_file_name_get.stdout }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP Kernel - Set fact for SAPEXE
   ansible.builtin.set_fact:

--- a/roles/sap_install_media_detect/tasks/detect_sapswpm.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapswpm.yml
@@ -20,18 +20,24 @@
   changed_when: true
 
 # SWPM
-- name: SAP Install Media Detect - SAP SWPM - Get SWPM from {{ __sap_install_media_detect_software_main_directory }}
+- name: SAP Install Media Detect - SAP SWPM - Get SWPM from {{ sap_install_media_detect_source_directory }}
   ansible.builtin.shell: ls SWPM*.SAR
   args:
-    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
+    chdir: "{{ sap_install_media_detect_source_directory }}"
   register: sap_swpm_swpm_sar_file_name_get
   changed_when: false
 
-- name: SAP Install Media Detect - SAP SWPM - Copy SWPM file
+- name: SAP Install Media Detect - SAP SWPM - Copy SWPM file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ sap_install_media_detect_source_directory }}/{{ sap_swpm_swpm_sar_file_name_get.stdout }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ sap_swpm_swpm_sar_file_name_get.stdout }}"
+    remote_src: true
+  when: sap_install_media_detect_source == 'remote_dir'
+
+- name: SAP Install Media Detect - SAP SWPM - Copy SWPM file to sap_swpm subdirectory
   ansible.builtin.shell: |
     cp {{ __sap_install_media_detect_software_main_directory }}/{{ sap_swpm_swpm_sar_file_name_get.stdout }} {{ __sap_install_media_detect_software_main_directory }}/sap_swpm/{{ sap_swpm_swpm_sar_file_name_get.stdout }}
   changed_when: true
-
 
 - name: SAP Install Media Detect - SAP SWPM - Check availability of software path - {{ sap_swpm_software_path }}
   ansible.builtin.stat:
@@ -48,38 +54,6 @@
     owner: root
     group: root
 
-
-################
-# Prepare software path
-################
-
-# Software Path
-
-# Backup Location - this is moved to install_type/restore_install.yml
-
-# - name: SAP SWPM Pre Install - Check backup location
-
-#   block:
-
-#   - name: SAP Install Media Detect - SAP SWPM - Check availability backup location - {{ sap_swpm_backup_location }}
-#     ansible.builtin.stat:
-#       path: "{{ sap_swpm_backup_location }}"
-#     register: sap_swpm_backup_location_stat
-#     failed_when: not sap_swpm_backup_location_stat.stat.exists and '.CP' in sap_swpm_product_catalog_id
-
-#   - name: SAP Install Media Detect - SAP SWPM - Change ownership of backup location - {{ sap_swpm_backup_location }}
-#     ansible.builtin.file:
-#       path: "{{ sap_swpm_backup_location }}"
-#       state: directory
-#       recurse: yes
-#       mode: '0755'
-#       owner: root
-#       group: root
-#     when:
-#       - sap_swpm_backup_location_stat.stat.exists and sap_swpm_backup_location_stat.stat.isdir
-
-#   when:
-#     - "'restore' in sap_swpm_swpm_installation_type"
 
 # SWPM Path
 

--- a/roles/sap_install_media_detect/tasks/detect_sapwebdisp.yml
+++ b/roles/sap_install_media_detect/tasks/detect_sapwebdisp.yml
@@ -1,13 +1,25 @@
 ---
 
 # 7. Web Dispatcher
-- name: SAP Install Media Detect - SAP WebDisp - Get WEBDISP from software path
+- name: SAP Install Media Detect - SAP WebDisp - Get WEBDISP from software path in source directory
   ansible.builtin.shell: ls SAPWEBDISP_*.SAR
   args:
-    chdir: "{{ sap_swpm_software_path }}"
+    chdir: "{{ __sap_install_media_detect_software_main_directory }}/sap_swpm"
+#    chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_web_dispatcher_file_name_get
   ignore_errors: true
   changed_when: false
+
+- name: SAP Install Media Detect - SAP WebDisp - Copy WEBDISP file to {{ sap_install_media_detect_target_directory }}
+  ansible.builtin.copy:
+    src: "{{ line_item.path }}"
+    dest: "{{ sap_install_media_detect_target_directory }}/{{ line_item.path | basename }}"
+    remote_src: true
+  loop:
+    "{{ sap_swpm_web_dispatcher_file_name_get.stdout }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_install_media_detect_source == 'remote_dir'
 
 - name: SAP Install Media Detect - SAP WebDisp - Set fact for WEBDISP
   ansible.builtin.set_fact:

--- a/roles/sap_install_media_detect/tasks/prepare/check_directories.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/check_directories.yml
@@ -23,9 +23,10 @@
         fail_msg: "FAIL: Directory {{ sap_install_media_detect_target_directory }} is not writable!"
         success_msg: "PASS: Directory {{ sap_install_media_detect_target_directory }} is writable."
 
-    - name: SAP Install Media Detect - Prepare - Set the variable sap_install_media_detect_source in case of writable remote file system
+    - name: SAP Install Media Detect - Prepare - Set facts in case of remote file system'
       ansible.builtin.set_fact:
         sap_install_media_detect_source: 'remote_dir'
+        __sap_install_media_detect_software_main_directory: "{{ sap_install_media_detect_target_directory }}"
 
 - name: SAP Install Media Detect - Prepare - Check the status of 'sap_install_media_detect_source_directory'
   when: sap_install_media_detect_target_directory is undefined or
@@ -49,7 +50,12 @@
         fail_msg: "FAIL: Directory {{ sap_install_media_detect_source_directory }} is not writable!"
         success_msg: "PASS: Directory {{ sap_install_media_detect_source_directory }} is writable."
 
-    - name: SAP Install Media Detect - Prepare - Set some variables in case of writable local file system
+    - name: SAP Install Media Detect - Prepare - Set facts in case of local file system'
       ansible.builtin.set_fact:
         sap_install_media_detect_source: 'local_dir'
         __sap_install_media_detect_software_main_directory: "{{ sap_install_media_detect_source_directory }}"
+
+- name: SAP Install Media Detect - Prepare - Status report
+  ansible.builtin.debug:
+    msg: "Reading from '{{ sap_install_media_detect_source_directory }}'.
+          Storing and extracting on '{{ __sap_install_media_detect_software_main_directory }}'."


### PR DESCRIPTION
The mechanism is as follows:
- If the variable 'sap_install_media_detect_target_directory' is definied and if this directory is writable, then the variable sap_install_media_detect_source is set to 'remote_dir', and this directory is used for copying and extracting files and also for moving the files as the last step.
- In all cases, as the first step, we create the required destination directories on the local, writable file system.
- Then we are creating a list of files for the product by checking the source directory.
- In case of remote_dir, we are then copying the identified files to the local directory.
- All remaining steps (extracting, moving and populating the final list of files) are done on the local directory.