### PR TITLE
sap_ha_pacemaker_cluster: AWS improvements

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -67,7 +67,7 @@
     __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [__stonith_resource_element] }}"
   vars:
     __stonith_resource_element:
-      id: "res_{{ sap_ha_pacemaker_cluster_stonith_default.id }}"
+      id: "{{ sap_ha_pacemaker_cluster_stonith_default.id }}"
       agent: "{{ sap_ha_pacemaker_cluster_stonith_default.agent }}"
       instance_attrs:
         - attrs: |-

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -77,7 +77,7 @@
                 'name': 'pcmk_host_map',
                 'value': __sap_ha_pacemaker_cluster_pcmk_host_map
               }]) -%}
-            {%- for agent_opt in (sap_ha_pacemaker_cluster_stonith_default.options | dict2items) -%}
+            {%- for agent_opt in (sap_ha_pacemaker_cluster_stonith_default.options | default({}) | dict2items) -%}
               {% set aopts = attrs.extend([
                 {
                   'name': agent_opt.key,
@@ -90,7 +90,7 @@
                   'name': fence_opt.key,
                   'value': fence_opt.value
                 }]) -%}
-            {%- endfor %}
+              {%- endfor %}
             {{ attrs }}
 
 - name: "SAP HA Prepare Pacemaker - Assemble the stonith resources from custom definition"

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -107,6 +107,19 @@
       vars:
         __sap_ha_pacemaker_cluster_platform_file: "{{ role_path }}/tasks/{{ item }}"
 
+    # Stop and disable services that conflict with cluster setups,
+    # for instance cloud-init services on cloud platforms
+    - name: "SAP HA Install Pacemaker - Stop and disable services"
+      when: sap_ha_pacemaker_cluster_disable_services is defined
+      ansible.builtin.service:
+        name: "{{ service_item }}"
+        enabled: false
+        state: stopped
+      loop: "{{ sap_ha_pacemaker_cluster_disable_services }}"
+      loop_control:
+        loop_var: service_item
+        label: "{{ service_item }}"
+
     # Before we are ready to call the ha_cluster role, we want to validate
     # that the minimum required parameters are defined and not empty.
     # TODO: make this smarter, currently all these vars are pre-defined anyway

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/include_vars_platform.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/include_vars_platform.yml
@@ -13,11 +13,11 @@
 # pcmk_host_map format: <hostname1>:<host1-id>;<hostname2>:<host2-id>...
 - name: "SAP HA Prepare Pacemaker - AWS EC2 VS - Assemble host mapping"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_pcmk_host_map: >
+    __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
         {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].ansible_board_asset_tag }}
-      {%-  if not loop.last %};{% endif -%}
-      {%- endfor %}
+        {%- if not loop.last %};{% endif %}
+      {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_aws_ec2_vs"
 
 
@@ -29,31 +29,31 @@
 # pcmk_host_map format: <hostname1>:<host1-id>;<hostname2>:<host2-id>...
 - name: "SAP HA Prepare Pacemaker - IBM Power VS from IBM Cloud - Assemble host mapping"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_pcmk_host_map: >-
+    __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
         {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].sap_ha_pacemaker_cluster_ibmcloud_powervs_host_guid }}
-      {%-  if not loop.last %};{%- endif -%}
-      {%- endfor %}
+        {%- if not loop.last %};{% endif %}
+      {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_ibmcloud_powervs"
 
 
 # pcmk_host_map format: <hostname1>:<host1-id>;<hostname2>:<host2-id>...
 - name: "SAP HA Prepare Pacemaker - IBM Cloud VS - Assemble host mapping"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_pcmk_host_map: >-
+    __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
         {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].__sap_ha_pacemaker_cluster_register_ibmcloud_vs_host.stdout }}
-      {%-  if not loop.last %};{%- endif -%}
-      {%- endfor %}
+        {%- if not loop.last %};{% endif %}
+      {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_ibmcloud_vs"
 
 
 # pcmk_host_map format: <hostname1>:<hostname1>;<hostname2>:<hostname2>...
 - name: "SAP HA Prepare Pacemaker - MS Azure VM - Assemble host mapping"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_pcmk_host_map: >-
+    __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
         {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].ansible_hostname }}
-      {%-  if not loop.last %};{%- endif -%}
-      {%- endfor %}
+        {%- if not loop.last %};{% endif %}
+      {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_msazure_vm"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -16,13 +16,16 @@ __sap_ha_pacemaker_cluster_repos:
 # Predefine
 __sap_ha_pacemaker_cluster_aws_instances: []
 
+# When aws credentials and region are not defined it will
+# default to using the aws cli configuration.
+# aws cli is configured by default for the VIP resource.
 sap_ha_pacemaker_cluster_stonith_default:
   id: "res_fence_aws"
   agent: "stonith:fence_aws"
-  options:
-    access_key: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
-    secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
-    region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
+#  options:
+#    access_key: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
+#    secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
+#    region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
 
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: aws_vpc_move_ip

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -41,3 +41,10 @@ __sap_ha_pacemaker_cluster_available_vip_agents:
   # Supported agent to manage Virtual/Overlay IPs for SAP on AWS by updating VPC Routing Table.
   aws_vpc_move_ip:
     agent: "ocf:heartbeat:aws-vpc-move-ip"
+
+# RHEL 8.6 and later:
+# Services that must be disabled and stopped for the VIP to work
+# otherwise AWS cloud-init keeps deleting the IP
+sap_ha_pacemaker_cluster_disable_services:
+  - nm-cloud-setup.timer
+  - nm-cloud-setup


### PR DESCRIPTION
**Fixes of stonith resource configuration:**
- line break in pcmk_host_map variables caused fencing not working
- commented out AWS credentials from default stonith definition, it will automatically use the aws cli credentials that are configured anyway for the VIP resource
- cosmetical fix of a duplicate pattern in the resource name

**Added:**
AWS cloud-init services are disabled and stopped.
--> Required to avoid removal of the floating Overlay IP.