### PR TITLE
sap_swpm: fix post-execution update of the hdbuserstore with correct host name

### DIFF
--- a/roles/sap_swpm/tasks/post_install.yml
+++ b/roles/sap_swpm/tasks/post_install.yml
@@ -33,3 +33,17 @@
       - '   IP                 -       {{ ansible_default_ipv4.address | d(ansible_all_ipv4_addresses[0]) }}  '
 #      - '   Master Password    -       {{ sap_swpm_master_password }} '
 #      - '   DDIC 000 Password  -       {{ sap_swpm_ddic_000_password }} '
+
+- name: SAP SWPM Post Install - Enforce Connection Info in hdbuserstore
+  ansible.builtin.shell: |
+    /usr/sap/{{ sap_swpm_sid }}/hdbclient/hdbuserstore \
+    SET DEFAULT \
+    {{ sap_swpm_db_host }}:3{{ sap_swpm_db_instance_nr }}13@{{ sap_swpm_db_sid }} \
+    {{ sap_swpm_db_schema_abap }} '{{ sap_swpm_db_system_password }}'
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: "{{ sap_swpm_sid | lower }}adm"
+  when: sap_swpm_install_saphostagent is defined and sap_swpm_install_saphostagent
+  register: __sap_swpm_post_install_register_hdbuserstore_connection
+  changed_when: __sap_swpm_post_install_register_hdbuserstore_connection is succeeded


### PR DESCRIPTION
A new Ansible Task to update the hdbuserstore to update the hostname insead of IP address correctly

Problem arises when communication between NWAS VM and HANA DB VM must happen over dedicated/different subnet (IP address) than the SAP HANA DB host's primary subnet/IP address.

For example `hdbuserstore SET DEFAULT <dbhost>:30215 SAPBS4 Perf0rm` where dbhost can be IP address or hostname.

Current behaviour:
- HANA LPAR has 3 networks attached to it.
    - 10.51.0.x (management subnet),
    - 10.52.0.x (backup subnet)
    - 10.53.0.x (sap subnet)
- Communication/traffic must flow between nw and HANA host using 10.53.0.x sap subnet
- Even though passing 10.53.0.x IP to `sap_swpm_db_ip` during installation somehow the SAP SWPM installation retrieves the management IP of HANA LPAR 10.51.0.x(management subnet), and hdbuserstore list has 10.51.0.x IP making communication over this subnet instead of SAP subnet 10.53.0.x

Current swpm role:
````
su - s4hadm
Last login: Fri Aug 25 12:44:18 EDT 2023
s4h-nw-1:s4hadm 6> hdbuserstore list
DATA FILE       : /home/s4hadm/.hdb/s4h-nw-1/SSFS_HDB.DAT
KEY FILE        : /home/s4hadm/.hdb/s4h-nw-1/SSFS_HDB.KEY
KEY DEFAULT
  ENV : 10.51.0.91:30213
  USER: SAPHANADB
  DATABASE: HDB

ACTIVE RECORDS  : 5
DELETED RECORDS : 4
NUMBER OF COMPLETE KEY: 1

Operation succeed.
````

With this fix:

```
su - s4hadm
Last login: Fri Aug 25 12:44:18 EDT 2023
s4h-nw-1:s4hadm 6> hdbuserstore list
DATA FILE       : /home/s4hadm/.hdb/s4h-nw-1/SSFS_HDB.DAT
KEY FILE        : /home/s4hadm/.hdb/s4h-nw-1/SSFS_HDB.KEY
KEY DEFAULT
  ENV : sap-hanadb:30213
  USER: SAPHANADB
  DATABASE: HDB

ACTIVE RECORDS  : 5
DELETED RECORDS : 4
NUMBER OF COMPLETE KEY: 1

Operation succeed.
```