### PR TITLE
sap_ha_pacemaker_cluster: fix: GCP vip resource force cidr 32

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
@@ -14,6 +14,8 @@
               value: "{{ vip_list_item.value }}"
             - name: cidr_netmask
               value: 32
+            - name: nic
+              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
   when:
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - (sap_ha_pacemaker_cluster_vip_method == 'ipaddr') or

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
@@ -12,6 +12,8 @@
         - attrs:
             - name: ip
               value: "{{ vip_list_item.value }}"
+            - name: cidr_netmask
+              value: 32
   when:
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - (sap_ha_pacemaker_cluster_vip_method == 'ipaddr') or


### PR DESCRIPTION
In Google cloud platform the primary instance IP is by default /32 and the VIP must also be /32 to avoid conflicts with the routing.

Adding the cidr_netmask to the IPaddr2 resources with a hard-coded value of 32 for the time being, until further detection functionality has been added to make this dynamic for all platforms.