### PR TITLE
sap_ha_pacemaker_cluster: enh: NW post-installation

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_netweaver_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_netweaver_postinstallation.yml
@@ -1,0 +1,97 @@
+---
+# After NetWeaver ASCS/ERS instances were configured in the cluster,
+# they must be disabled from automatically (re)starting outside of
+# cluster control.
+
+- name: "SAP HA Pacemaker - (ASCS profile) Prevent automatic restart of enqueue server"
+  ansible.builtin.replace:
+    path: "{{ sap_ha_pacemaker_cluster_netweaver_abap_ascs_sapinstance_start_profile_string }}"
+    backup: true
+    regexp: 'Restart_Program_01'
+    replace: 'Start_Program_01'
+
+- name: "SAP HA Pacemaker - (ERS profile) Prevent automatic restart"
+  ansible.builtin.replace:
+    path: "{{ sap_ha_pacemaker_cluster_netweaver_abap_ers_sapinstance_start_profile_string }}"
+    backup: true
+    regexp: 'Restart_Program_00'
+    replace: 'Start_Program_00'
+
+# Comment out lines in /usr/sap/sapservices, which
+# - contain the target instance profile names
+# - are not commented out yet
+- name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
+  ansible.builtin.replace:
+    path: /usr/sap/sapservices
+    backup: true
+    regexp: '^([^#\n].+{{ sapserv_item }}.+)$'
+    replace: '# \1'
+  loop:
+    - "{{ sap_ha_pacemaker_cluster_netweaver_abap_ascs_sapinstance_instance_name }}"
+    - "{{ sap_ha_pacemaker_cluster_netweaver_abap_ers_sapinstance_instance_name }}"
+  loop_control:
+    loop_var: sapserv_item
+
+- name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/SAP{{ sap_ha_pacemaker_cluster_netweaver_sid }}_{{ systemd_item }}.service"
+  loop:
+    - "{{ sap_ha_pacemaker_cluster_netweaver_abap_ascs_instance_number }}"
+    - "{{ sap_ha_pacemaker_cluster_netweaver_abap_ers_instance_number }}"
+  loop_control:
+    loop_var: systemd_item
+    label: "SAP{{ sap_ha_pacemaker_cluster_netweaver_sid }}_{{ systemd_item }}.service"
+  register: __sap_ha_pacemaker_cluster_register_instance_service
+
+- name: "SAP HA Pacemaker - (systemd) Save found ASCS/ERS services"
+  ansible.builtin.set_fact:
+    sap_ha_pacemaker_cluster_instance_services_fact: "{{
+      __sap_ha_pacemaker_cluster_register_instance_service.results
+      | selectattr('stat.exists')
+      | map(attribute='stat.path')
+      | regex_replace('/etc/systemd/system/', '')
+      }}"
+
+# BLOCK:
+# When the systemd based SAP startup framework is used, make sure that the
+# instance services do not auto-start.
+- name: "SAP HA Pacemaker - Block to disable systemd auto-start of instances"
+  when:
+    - sap_ha_pacemaker_cluster_instance_services_fact is defined
+    - sap_ha_pacemaker_cluster_instance_services_fact | length > 0
+  block:
+
+    - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance units"
+      ansible.builtin.service:
+        name: "{{ instance_srv_item }}"
+        enabled:
+      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop_control:
+        loop_var: instance_srv_item
+
+    # Creates a config file for the services.
+    # Parent directories will be created when missing.
+    - name: "SAP HA Pacemaker - (systemd) Create ASCS/ERS instance unit config file"
+      ansible.builtin.lineinfile:
+        create: true
+        path: "/etc/systemd/system/{{ dropfile_item }}.d/HA.conf"
+        line: "[Service]"
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop_control:
+        loop_var: dropfile_item
+
+    - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance unit auto-restart"
+      ansible.builtin.lineinfile:
+        path: "/etc/systemd/system/{{ dropfile_item }}.d/HA.conf"
+        regex: '^Restart\s*=\s*no'
+        insertafter: '^[Service]$'
+        line: "Restart=no"
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop_control:
+        loop_var: dropfile_item

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_netweaver_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_netweaver_postinstallation.yml
@@ -64,7 +64,7 @@
     - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance units"
       ansible.builtin.service:
         name: "{{ instance_srv_item }}"
-        enabled:
+        enabled: false
       loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
       loop_control:
         loop_var: instance_srv_item

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -186,6 +186,7 @@
     # Resource defaults settings were added to "ha_cluster" in Apr 2023 (GH version 1.9.0)
     # https://github.com/linux-system-roles/ha_cluster#ha_cluster_resource_defaults
     # Keeping separate for compatibility with older versions of the ha_cluster role.
+    # TODO: Change resource defaults update to "ha_cluster" native syntax.
     - name: "SAP HA Install Pacemaker - Check resource defaults"
       ansible.builtin.command:
         cmd: |
@@ -216,6 +217,15 @@
       tags: srhook
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
+
+    - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS post installation"
+      ansible.builtin.include_tasks:
+        file: configure_netweaver_postinstallation.yml
+        apply:
+          tags: nwas_postinst
+      tags: nwas_postinst
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'ascs_ers') | length > 0
 
 ### END OF BLOCK: prerequisite changes and cluster setup
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -225,7 +225,7 @@
           tags: nwas_postinst
       tags: nwas_postinst
       when:
-        - sap_ha_pacemaker_cluster_host_type | select('search', 'ascs_ers') | length > 0
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
 
 ### END OF BLOCK: prerequisite changes and cluster setup
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_aws_ec2_vs.yml
@@ -58,7 +58,7 @@
             - name: ip
               value: "{{ vip_list_item.value }}"
             - name: interface
-              value: "{{ sap_ha_pacemaker_cluster_aws_vip_client_interface }}"
+              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
             - name: routing_table
               value: "{{ sap_ha_pacemaker_cluster_aws_vip_update_rt | join(',') }}"
   when:

--- a/roles/sap_storage_setup/tasks/main.yml
+++ b/roles/sap_storage_setup/tasks/main.yml
@@ -28,9 +28,6 @@
 # Create a list of elements from {{ sap_storage_setup_definition }} for all
 # mountpoint elements that are not already reported as mounted in ansible facts.
 
-# NOTE: The conditional of this task requires Jinja2 version >= 2.11.0 (released January 2020)
-# Reference: https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.map
-
 - name: SAP Storage Setup - Determine which local filesystems are not configured yet
   when:
     - new_mounts_item.nfs_path is not defined
@@ -91,7 +88,8 @@
     file: "{{ sap_storage_setup_cloud_type }}_tasks/configure_local_filesystems.yml"
 
 
-# NOTE: The conditional of this task requires Jinja2 version >= 2.11.0 (released January 2020)
+# NOTE: The "default" in the conditional of this task requires
+# Jinja2 version >= 2.11.0 (released January 2020)
 # Reference: https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.map
 - name: SAP Storage Setup - Configure swap
   ansible.builtin.include_tasks:


### PR DESCRIPTION
Main content of this change is post-installation tasks after NetWeaver instance configuration inside the cluster.

Additional minor fixes:
- `sap_storage_setup`: misleading comments corrected
- AWS platform: corrected the VIP parameter name for the NIC in one task (after recent parameter name change)