### PR TITLE
sap_swpm: Improve the detection of variables in inifile.params

### DIFF
--- a/roles/sap_swpm/tasks/swpm/detect_variables.yml
+++ b/roles/sap_swpm/tasks/swpm/detect_variables.yml
@@ -2,68 +2,70 @@
 
 # Detect Product ID
 - name: SAP SWPM - Detect Product ID
-  ansible.builtin.shell: |
-    set -o pipefail && sed -n '3p' {{ sap_swpm_tmpdir.path }}/inifile.params | awk 'NF{print $(NF-1)}' | tr -d \'
+  ansible.builtin.command: |
+    awk 'BEGIN{IGNORECASE=1;a=0}
+      /Product ID/&&a==0{a=1; gsub ("#", ""); gsub ("\047", ""); product_id=$NF}
+      END{print product_id}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_product_id_detect
   changed_when: false
 
 # Set fact for product id
-- name: Set SAP product ID
+- name: SAP SWPM - Set SAP product ID
   ansible.builtin.set_fact:
     sap_swpm_product_catalog_id: "{{ sap_swpm_inifile_product_id_detect.stdout }}"
 
-- name: Display SAP product ID
+- name: SAP SWPM - Display SAP product ID
   ansible.builtin.debug:
     msg:
       - "Product ID is {{ sap_swpm_product_catalog_id }}"
 
 # Detect Software Path
 - name: SAP SWPM - Detect Software Path
-  ansible.builtin.shell: |
-    set -o pipefail && cat {{ sap_swpm_tmpdir.path }}/inifile.params | grep archives.downloadBasket | awk '{ print $3 }'
+  ansible.builtin.command: |
+    awk '!/^#/&&/archives.downloadBasket/{print $3}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_software_path
   changed_when: false
 
 # Set fact for software path
-- name: Set Software Path
+- name: SAP SWPM - Set Software Path
   ansible.builtin.set_fact:
     sap_swpm_software_path: "{{ sap_swpm_inifile_software_path.stdout }}"
 
-- name: Display SAP SID
+- name: SAP SWPM - Display Software Path
   ansible.builtin.debug:
     msg:
       - "Software path is {{ sap_swpm_software_path }}"
 
 # Detect SID
 - name: SAP SWPM - Detect SID
-  ansible.builtin.shell: |
-    set -o pipefail && cat {{ sap_swpm_tmpdir.path }}/inifile.params | grep NW_GetSidNoProfiles.sid | awk '{ print $3 }'
+  ansible.builtin.command: |
+    awk '!/^#/&&/NW_GetSidNoProfiles.sid/{print $3}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_sid
   changed_when: false
 
 # Set fact for SID
-- name: Set SID
+- name: SAP SWPM - Set SID
   ansible.builtin.set_fact:
     sap_swpm_sid: "{{ sap_swpm_inifile_sid.stdout }}"
 
-- name: Display SAP SID
+- name: SAP SWPM - Display SAP SID
   ansible.builtin.debug:
     msg:
       - "SAP SID {{ sap_swpm_sid }}"
 
 # Detect FQDN
 - name: SAP SWPM - Detect FQDN
-  ansible.builtin.shell: |
-    set -o pipefail && cat {{ sap_swpm_tmpdir.path }}/inifile.params | grep NW_getFQDN.FQDN | awk '{ print $3 }'
+  ansible.builtin.command: |
+    awk '!/^#/&&/NW_getFQDN.FQDN/{print $3}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_fqdn
   changed_when: false
 
 # Set fact for FQDN
-- name: Set FQDN
+- name: SAP SWPM - Set FQDN
   ansible.builtin.set_fact:
     sap_swpm_fqdn: "{{ sap_swpm_inifile_fqdn.stdout }}"
 
-- name: Display FQDN
+- name: SAP SWPM - Display FQDN
   ansible.builtin.debug:
     msg:
       - "SAP fqdn {{ sap_swpm_fqdn }}"


### PR DESCRIPTION
This PR contains the following improvements:
- The variable `sap_swpm_inifile_product_id_detect` will be detected correctly from one of the following lines in inifile.params:
```
# Installation service 'SAP S/4HANA Server 2021 > SAP HANA Database > Installation > Application Server ABAP > Standard System > Standard System', product id 'NW_ABAP_OneHost:BS2016.ERP608.HDB.PD'     #
```
or
```
### inifile.params generated for SWPM Catalog Product ID is NW_ABAP_OneHost:BS2016.ERP608.HDB.PD
```
If both lines are present, the first occurrence will be used.
- The variables `archives.downloadBasket`, `NW_GetSidNoProfiles.sid` and `NW_getFQDN.FQDN` are now determined only from lines which do not start with `#  `.
- The Ansible `shell` module is no longer required. The `command` module is sufficient because we do no longer need pipes.
- The task titles now all start with `SAP SWPM - `.