### PR TITLE
Issue 385 new detection method - further changes

### DIFF
--- a/roles/sap_install_media_detect/README.md
+++ b/roles/sap_install_media_detect/README.md
@@ -44,6 +44,7 @@ This role does not depend on any other Ansible Role.
 ## Tags
 
 With the following tags, the role can be called to perform certain activities only:
+- tag `sap_install_media_detect_zip_handling`: Only perform the task for enabling the listing and extracting of files of type `ZIP`.
 - tag `sap_install_media_detect_rar_handling`: Only perform the tasks for enabling the listing and extracting of files of type `RAR`. This
   includes enabling and disabling the EPEL repo for RHEL systems, if desired.
 - tag `sap_install_media_detect_add_file_extension`: Add file name extensions to any files in `sap_install_media_detect_source_directory` which are of type `RAR` or `ZIP` and have no ending. Needs to be used with tag `sap_install_media_detect_create_file_list_phase_1`.

--- a/roles/sap_install_media_detect/defaults/main.yml
+++ b/roles/sap_install_media_detect/defaults/main.yml
@@ -66,16 +66,16 @@ sap_install_media_detect_move_or_copy_archives: true
 sap_install_media_detect_assert_after_sapfile: true
 
 # Typical parameter settings for SAP S/4HANA:
-sap_install_media_detect_db: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
-sap_install_media_detect_db_client: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
-sap_install_media_detect_swpm: true
-sap_install_media_detect_hostagent: true
-sap_install_media_detect_igs: true
-sap_install_media_detect_kernel: true
+#sap_install_media_detect_db: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
+#sap_install_media_detect_db_client: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
+#sap_install_media_detect_swpm: true
+#sap_install_media_detect_hostagent: true
+#sap_install_media_detect_igs: true
+#sap_install_media_detect_kernel: true
 #sap_install_media_detect_kernel_db: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
 #                                                 (only necessary if there is more than one SAPEXEDB file in the source directory)
-sap_install_media_detect_webdisp: false
-sap_install_media_detect_export: 'saps4hana'  # saps4hana, sapbw4hana, sapecc, sapecc_ides,
+#sap_install_media_detect_webdisp: false
+#sap_install_media_detect_export: 'saps4hana'  # saps4hana, sapbw4hana, sapecc, sapecc_ides,
 #                                                sapnwas_abap, sapnwas_java, sapsolman_abap, sapsolman_java
 
 # Typical parameter settings for SAP ERP 6.0 EHP8 with SAP HANA database:

--- a/roles/sap_install_media_detect/defaults/main.yml
+++ b/roles/sap_install_media_detect/defaults/main.yml
@@ -65,7 +65,19 @@ sap_install_media_detect_move_or_copy_archives: true
 # following parameter to 'false' to skip this step.
 sap_install_media_detect_assert_after_sapfile: true
 
-# Typical parameter settings for SAP S/4HANA:
+sap_install_media_detect_db: ''         # saphana, sapase, sapmaxdb, oracledb, ibmdb2
+sap_install_media_detect_db_client: ''  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
+sap_install_media_detect_swpm: false
+sap_install_media_detect_hostagent: false
+sap_install_media_detect_igs: false
+sap_install_media_detect_kernel: false
+sap_install_media_detect_kernel_db: ''  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
+#                                         (only necessary if there is more than one SAPEXEDB file in the source directory)
+sap_install_media_detect_webdisp: false
+sap_install_media_detect_export: ''     # saps4hana, sapbw4hana, sapecc, sapecc_ides,
+#                                         sapnwas_abap, sapnwas_java, sapsolman_abap, sapsolman_java
+
+# Example for parameter settings for SAP S/4HANA:
 #sap_install_media_detect_db: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
 #sap_install_media_detect_db_client: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
 #sap_install_media_detect_swpm: true
@@ -78,7 +90,7 @@ sap_install_media_detect_assert_after_sapfile: true
 #sap_install_media_detect_export: 'saps4hana'  # saps4hana, sapbw4hana, sapecc, sapecc_ides,
 #                                                sapnwas_abap, sapnwas_java, sapsolman_abap, sapsolman_java
 
-# Typical parameter settings for SAP ERP 6.0 EHP8 with SAP HANA database:
+# Example for parameter settings for SAP ERP 6.0 EHP8 with SAP HANA database:
 #sap_install_media_detect_db: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
 #sap_install_media_detect_db_client: 'saphana'  # saphana, sapase, sapmaxdb, oracledb, ibmdb2
 #sap_install_media_detect_swpm: true

--- a/roles/sap_install_media_detect/tasks/find_files_after_extraction.yml
+++ b/roles/sap_install_media_detect/tasks/find_files_after_extraction.yml
@@ -33,7 +33,7 @@
     patterns: "SAP_HANA_CLIENT"
   register: sap_hana_client_path
   ignore_errors: true
-  when: sap_install_media_detect_db == "saphana"
+  when: sap_install_media_detect_db | d('') == 'saphana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find IBM Db2
   ansible.builtin.find:
@@ -43,7 +43,7 @@
     patterns: ".*LINUXX86_64.*"
     use_regex: true
   register: detect_directory_ibmdb2_extracted
-  when: sap_install_media_detect_db == "ibmdb2"
+  when: sap_install_media_detect_db | d('') == 'ibmdb2'
 
 - name: SAP Install Media Detect - Find files after extraction - Find IBM Db2 Client
   ansible.builtin.find:
@@ -53,7 +53,7 @@
     patterns: ".*DATA_UNITS.*"
     use_regex: true
   register: detect_directory_ibmdb2_client_extracted
-  when: sap_install_media_detect_db == "ibmdb2"
+  when: sap_install_media_detect_db | d('') == 'ibmdb2'
 
 - name: SAP Install Media Detect - Find files after extraction - Find Oracle DB
   ansible.builtin.find:
@@ -63,7 +63,7 @@
     patterns: ".*LINUX_X86_64.*"
     use_regex: true
   register: detect_directory_oracledb_extracted
-  when: sap_install_media_detect_db == "oracledb"
+  when: sap_install_media_detect_db | d('') == 'oracledb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find Oracle DB Client
   ansible.builtin.find:
@@ -73,7 +73,7 @@
     patterns: ".*OCL_LINUX_X86_64.*"
     use_regex: true
   register: detect_directory_oracledb_client_extracted
-  when: sap_install_media_detect_db == "oracledb"
+  when: sap_install_media_detect_db | d('') == 'oracledb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ASE
   ansible.builtin.find:
@@ -83,7 +83,7 @@
     patterns: ".*SYBASE_LINUX.*"
     use_regex: true
   register: detect_directory_sapase_extracted
-  when: sap_install_media_detect_db == "sapase"
+  when: sap_install_media_detect_db | d('') == 'sapase'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ASE Client
   ansible.builtin.find:
@@ -93,7 +93,7 @@
     patterns: "sybodbc"
     use_regex: true
   register: detect_directory_sapase_client_extracted
-  when: sap_install_media_detect_db == "sapase"
+  when: sap_install_media_detect_db | d('') == 'sapase'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP MaxDB
   ansible.builtin.find:
@@ -103,7 +103,7 @@
     patterns: '.*MaxDB_7.9.*'
     use_regex: true
   register: detect_directory_sapmaxdb_extracted
-  when: sap_install_media_detect_db == "sapmaxdb"
+  when: sap_install_media_detect_db | d('') == 'sapmaxdb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXE
   ansible.builtin.shell: ls SAPEXE_*.SAR
@@ -111,7 +111,7 @@
     chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_kernel_independent_file_name_get
   changed_when: false
-  when: sap_install_media_detect_kernel
+  when: sap_install_media_detect_kernel | d(false)
 
 - name: SAP Install Media Detect - Find files after extraction - Fail if more than one SAPEXE found
   ansible.builtin.fail:
@@ -130,7 +130,7 @@
         chdir: "{{ sap_swpm_software_path }}"
       register: sap_swpm_kernel_dependent_file_name_get
       changed_when: false
-      when: sap_install_media_detect_kernel
+      when: sap_install_media_detect_kernel | d(false)
 
     - name: SAP Install Media Detect - Find files after extraction - Fail if more than one SAPEXEDB file found, database unspecific
       ansible.builtin.fail:
@@ -150,7 +150,7 @@
       register: __sap_install_media_detect_register_db_dependent_kernel_files
       changed_when: false
       when:
-        - sap_install_media_detect_kernel
+        - sap_install_media_detect_kernel | d(false)
         - sap_install_media_detect_kernel_db is defined
 
     - name: SAP Install Media Detect - Find files after extraction - Set fact with the results of the sapfile command
@@ -238,7 +238,7 @@
     chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_igs_file_name_get
   changed_when: false
-  when: sap_install_media_detect_igs
+  when: sap_install_media_detect_igs | d(false)
 
 - name: SAP Install Media Detect - Find files after extraction - Find IGS Helper, latest version
   ansible.builtin.shell: set -o pipefail && ls -1tr igshelper*.sar | tail -1
@@ -246,7 +246,7 @@
     chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_igs_helper_file_name_get
   changed_when: false
-  when: sap_install_media_detect_igs
+  when: sap_install_media_detect_igs | d(false)
 
 - name: SAP Install Media Detect - Find files after extraction - Find WEBDISP
   ansible.builtin.shell: ls SAPWEBDISP_*.SAR
@@ -255,7 +255,7 @@
   register: sap_swpm_web_dispatcher_file_name_get
   ignore_errors: true
   changed_when: false
-  when: sap_install_media_detect_webdisp
+  when: sap_install_media_detect_webdisp | d(false)
 
 - name: SAP Install Media Detect - Find files after extraction - Fail if more than one WEBDISP found
   ansible.builtin.fail:
@@ -272,7 +272,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_ecc_export_extracted
-  when: sap_install_media_detect_export == "sapecc"
+  when: sap_install_media_detect_export | d('') == 'sapecc'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ECC IDES Export
   ansible.builtin.find:
@@ -282,7 +282,7 @@
     patterns: '.*EXP.*'
     use_regex: true
   register: detect_directory_ecc_ides_export_extracted
-  when: sap_install_media_detect_export == "sapecc_ides"
+  when: sap_install_media_detect_export | d('') == 'sapecc_ides'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP S/4HANA Export
   ansible.builtin.find:
@@ -292,7 +292,7 @@
     patterns: '.*S4.*EXPORT.*'
     use_regex: true
   register: s4hana_export_files
-  when: sap_install_media_detect_export == "saps4hana"
+  when: sap_install_media_detect_export | d('') == 'saps4hana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP BW/4HANA Export
   ansible.builtin.find:
@@ -302,7 +302,7 @@
     patterns: '.*BW4.*EXPORT.*'
     use_regex: true
   register: bw4hana_export_files
-  when: sap_install_media_detect_export == "sapbw4hana"
+  when: sap_install_media_detect_export | d('') == 'sapbw4hana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP NetWeaver AS (ABAP) platform only Export
   ansible.builtin.find:
@@ -312,7 +312,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_nwas_abap_export_extracted
-  when: sap_install_media_detect_export == "sapnwas_abap"
+  when: sap_install_media_detect_export | d('') == 'sapnwas_abap'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP NetWeaver AS (JAVA) platform only Export
   ansible.builtin.find:
@@ -322,7 +322,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_nwas_java_export_extracted
-  when: sap_install_media_detect_export == "sapnwas_java"
+  when: sap_install_media_detect_export | d('') == 'sapnwas_java'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP Solution Manager (ABAP) platform only Export
   ansible.builtin.find:
@@ -332,7 +332,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_solgmr_abap_export_extracted
-  when: sap_install_media_detect_export == "sapsolman_abap"
+  when: sap_install_media_detect_export | d('') == 'sapsolman_abap'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP Solution Manager (JAVA) platform only Export
   ansible.builtin.find:
@@ -342,4 +342,4 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_solgmr_java_export_extracted
-  when: sap_install_media_detect_export == "sapsolman_java"
+  when: sap_install_media_detect_export | d('') == 'sapsolman_java'

--- a/roles/sap_install_media_detect/tasks/find_files_after_extraction.yml
+++ b/roles/sap_install_media_detect/tasks/find_files_after_extraction.yml
@@ -33,7 +33,9 @@
     patterns: "SAP_HANA_CLIENT"
   register: sap_hana_client_path
   ignore_errors: true
-  when: sap_install_media_detect_db | d('') == 'saphana'
+  when:
+    - sap_install_media_detect_db == 'saphana' or
+      sap_install_media_detect_db_client == 'saphana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find IBM Db2
   ansible.builtin.find:
@@ -43,7 +45,7 @@
     patterns: ".*LINUXX86_64.*"
     use_regex: true
   register: detect_directory_ibmdb2_extracted
-  when: sap_install_media_detect_db | d('') == 'ibmdb2'
+  when: sap_install_media_detect_db == 'ibmdb2'
 
 - name: SAP Install Media Detect - Find files after extraction - Find IBM Db2 Client
   ansible.builtin.find:
@@ -53,7 +55,9 @@
     patterns: ".*DATA_UNITS.*"
     use_regex: true
   register: detect_directory_ibmdb2_client_extracted
-  when: sap_install_media_detect_db | d('') == 'ibmdb2'
+  when:
+    - sap_install_media_detect_db == 'ibmdb2' or
+      sap_install_media_detect_db_client == 'ibmdb2'
 
 - name: SAP Install Media Detect - Find files after extraction - Find Oracle DB
   ansible.builtin.find:
@@ -63,7 +67,7 @@
     patterns: ".*LINUX_X86_64.*"
     use_regex: true
   register: detect_directory_oracledb_extracted
-  when: sap_install_media_detect_db | d('') == 'oracledb'
+  when: sap_install_media_detect_db == 'oracledb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find Oracle DB Client
   ansible.builtin.find:
@@ -73,7 +77,9 @@
     patterns: ".*OCL_LINUX_X86_64.*"
     use_regex: true
   register: detect_directory_oracledb_client_extracted
-  when: sap_install_media_detect_db | d('') == 'oracledb'
+  when:
+    - sap_install_media_detect_db == 'oracledb' or
+      sap_install_media_detect_db_client == 'oracledb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ASE
   ansible.builtin.find:
@@ -83,7 +89,7 @@
     patterns: ".*SYBASE_LINUX.*"
     use_regex: true
   register: detect_directory_sapase_extracted
-  when: sap_install_media_detect_db | d('') == 'sapase'
+  when: sap_install_media_detect_db == 'sapase'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ASE Client
   ansible.builtin.find:
@@ -93,7 +99,9 @@
     patterns: "sybodbc"
     use_regex: true
   register: detect_directory_sapase_client_extracted
-  when: sap_install_media_detect_db | d('') == 'sapase'
+  when:
+    - sap_install_media_detect_db == 'sapase' or
+      sap_install_media_detect_db_client == 'sapase'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP MaxDB
   ansible.builtin.find:
@@ -103,7 +111,7 @@
     patterns: '.*MaxDB_7.9.*'
     use_regex: true
   register: detect_directory_sapmaxdb_extracted
-  when: sap_install_media_detect_db | d('') == 'sapmaxdb'
+  when: sap_install_media_detect_db == 'sapmaxdb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXE
   ansible.builtin.shell: ls SAPEXE_*.SAR
@@ -111,7 +119,7 @@
     chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_kernel_independent_file_name_get
   changed_when: false
-  when: sap_install_media_detect_kernel | d(false)
+  when: sap_install_media_detect_kernel
 
 - name: SAP Install Media Detect - Find files after extraction - Fail if more than one SAPEXE found
   ansible.builtin.fail:
@@ -121,26 +129,30 @@
     - sap_swpm_kernel_independent_file_name_get.stdout_lines | count > 1
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXEDB, database unspecific - block
-  when: sap_install_media_detect_kernel_db is not defined
+  when:
+    - sap_install_media_detect_kernel
+    - sap_install_media_detect_kernel_db is not defined or
+      sap_install_media_detect_kernel_db | length == 0
   block:
 
     - name: SAP Install Media Detect - Find files after extraction - Find SAPEXEDB, database unspecific
       ansible.builtin.shell: ls SAPEXEDB_*.SAR
       args:
         chdir: "{{ sap_swpm_software_path }}"
-      register: sap_swpm_kernel_dependent_file_name_get
+      register: sap_swpm_kernel_dependent_file_name_get_db_unspecific
       changed_when: false
-      when: sap_install_media_detect_kernel | d(false)
 
     - name: SAP Install Media Detect - Find files after extraction - Fail if more than one SAPEXEDB file found, database unspecific
       ansible.builtin.fail:
         msg: "No, or more than one, SAPEXEDB file has been detected."
       when:
-        - sap_install_media_detect_kernel
-        - sap_swpm_kernel_dependent_file_name_get.stdout_lines | count != 1
+        - sap_swpm_kernel_dependent_file_name_get_db_unspecific.stdout_lines | count != 1
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXEDB, database specific - block
-  when: sap_install_media_detect_kernel_db is defined
+  when:
+    - sap_install_media_detect_kernel
+    - sap_install_media_detect_kernel_db is defined
+    - sap_install_media_detect_kernel_db | length > 0
   block:
 
     - name: SAP Install Media Detect - Find files after extraction - Find SAPEXEDB, database specific
@@ -149,9 +161,6 @@
         chdir: "{{ sap_swpm_software_path }}"
       register: __sap_install_media_detect_register_db_dependent_kernel_files
       changed_when: false
-      when:
-        - sap_install_media_detect_kernel | d(false)
-        - sap_install_media_detect_kernel_db is defined
 
     - name: SAP Install Media Detect - Find files after extraction - Set fact with the results of the sapfile command
       ansible.builtin.set_fact:
@@ -171,7 +180,7 @@
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for SAP HANA
       ansible.builtin.set_fact:
-        sap_swpm_kernel_dependent_file_name_get: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_hdb') | first).file }}"
+        sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_hdb') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'saphana'
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_hdb') | length == 1
@@ -185,7 +194,7 @@
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for SAP ASE
       ansible.builtin.set_fact:
-        sap_swpm_kernel_dependent_file_name_get: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ase') | first).file }}"
+        sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ase') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'sapase'
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ase') | length == 1
@@ -199,7 +208,7 @@
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for SAP MAXDB
       ansible.builtin.set_fact:
-        sap_swpm_kernel_dependent_file_name_get: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ada') | first).file }}"
+        sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ada') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'sapmaxdb'
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ada') | length == 1
@@ -213,7 +222,7 @@
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for Oracle DB
       ansible.builtin.set_fact:
-        sap_swpm_kernel_dependent_file_name_get: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ora') | first).file }}"
+        sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ora') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'oracledb'
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ora') | length == 1
@@ -227,7 +236,7 @@
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for IBM Db2
       ansible.builtin.set_fact:
-        sap_swpm_kernel_dependent_file_name_get: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_db6') | first).file }}"
+        sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_db6') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'ibmdb2'
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_db6') | length == 1
@@ -238,7 +247,7 @@
     chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_igs_file_name_get
   changed_when: false
-  when: sap_install_media_detect_igs | d(false)
+  when: sap_install_media_detect_igs
 
 - name: SAP Install Media Detect - Find files after extraction - Find IGS Helper, latest version
   ansible.builtin.shell: set -o pipefail && ls -1tr igshelper*.sar | tail -1
@@ -246,7 +255,7 @@
     chdir: "{{ sap_swpm_software_path }}"
   register: sap_swpm_igs_helper_file_name_get
   changed_when: false
-  when: sap_install_media_detect_igs | d(false)
+  when: sap_install_media_detect_igs
 
 - name: SAP Install Media Detect - Find files after extraction - Find WEBDISP
   ansible.builtin.shell: ls SAPWEBDISP_*.SAR
@@ -255,7 +264,7 @@
   register: sap_swpm_web_dispatcher_file_name_get
   ignore_errors: true
   changed_when: false
-  when: sap_install_media_detect_webdisp | d(false)
+  when: sap_install_media_detect_webdisp
 
 - name: SAP Install Media Detect - Find files after extraction - Fail if more than one WEBDISP found
   ansible.builtin.fail:
@@ -272,7 +281,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_ecc_export_extracted
-  when: sap_install_media_detect_export | d('') == 'sapecc'
+  when: sap_install_media_detect_export == 'sapecc'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ECC IDES Export
   ansible.builtin.find:
@@ -282,7 +291,7 @@
     patterns: '.*EXP.*'
     use_regex: true
   register: detect_directory_ecc_ides_export_extracted
-  when: sap_install_media_detect_export | d('') == 'sapecc_ides'
+  when: sap_install_media_detect_export == 'sapecc_ides'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP S/4HANA Export
   ansible.builtin.find:
@@ -292,7 +301,7 @@
     patterns: '.*S4.*EXPORT.*'
     use_regex: true
   register: s4hana_export_files
-  when: sap_install_media_detect_export | d('') == 'saps4hana'
+  when: sap_install_media_detect_export == 'saps4hana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP BW/4HANA Export
   ansible.builtin.find:
@@ -302,7 +311,7 @@
     patterns: '.*BW4.*EXPORT.*'
     use_regex: true
   register: bw4hana_export_files
-  when: sap_install_media_detect_export | d('') == 'sapbw4hana'
+  when: sap_install_media_detect_export == 'sapbw4hana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP NetWeaver AS (ABAP) platform only Export
   ansible.builtin.find:
@@ -312,7 +321,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_nwas_abap_export_extracted
-  when: sap_install_media_detect_export | d('') == 'sapnwas_abap'
+  when: sap_install_media_detect_export == 'sapnwas_abap'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP NetWeaver AS (JAVA) platform only Export
   ansible.builtin.find:
@@ -322,7 +331,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_nwas_java_export_extracted
-  when: sap_install_media_detect_export | d('') == 'sapnwas_java'
+  when: sap_install_media_detect_export == 'sapnwas_java'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP Solution Manager (ABAP) platform only Export
   ansible.builtin.find:
@@ -332,7 +341,7 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_solgmr_abap_export_extracted
-  when: sap_install_media_detect_export | d('') == 'sapsolman_abap'
+  when: sap_install_media_detect_export == 'sapsolman_abap'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP Solution Manager (JAVA) platform only Export
   ansible.builtin.find:
@@ -342,4 +351,4 @@
     patterns: '.*DATA_UNITS.*'
     use_regex: true
   register: detect_directory_solgmr_java_export_extracted
-  when: sap_install_media_detect_export | d('') == 'sapsolman_java'
+  when: sap_install_media_detect_export == 'sapsolman_java'

--- a/roles/sap_install_media_detect/tasks/main.yml
+++ b/roles/sap_install_media_detect/tasks/main.yml
@@ -12,6 +12,13 @@
       tags: sap_install_media_detect_provide_sapfile_utility
   tags: sap_install_media_detect_provide_sapfile_utility
 
+- name: SAP Install Media Detect - Prepare - Enable zip handling
+  ansible.builtin.include_tasks:
+    file: prepare/enable_zip_handling.yml
+    apply:
+      tags: sap_install_media_detect_zip_handling
+  tags: sap_install_media_detect_zip_handling
+
 - name: SAP Install Media Detect - Prepare - Enable rar handling
   ansible.builtin.include_tasks:
     file: prepare/enable_rar_handling.yml

--- a/roles/sap_install_media_detect/tasks/organize_files.yml
+++ b/roles/sap_install_media_detect/tasks/organize_files.yml
@@ -76,7 +76,7 @@
     loop_var: line_item
   when:
     - sap_install_media_detect_move_or_copy_archives
-    - sap_install_media_detect_db == 'saphana'
+    - sap_install_media_detect_db | d('') == 'saphana'
     - line_item.target_dir == 'auto'
 
 - name: SAP Install Media Detect - Organize all files - Create target directory 'sap_swpm_download_basket'
@@ -178,7 +178,7 @@
     loop_var: line_item
   when:
     - sap_install_media_detect_move_or_copy_archives
-    - sap_install_media_detect_db == 'saphana'
+    - sap_install_media_detect_db | d('') == 'saphana'
     - (line_item.sap_file_type == 'sapcar' or
        line_item.sap_file_type == 'saphana_client' or
        line_item.sap_file_type == 'sap_hostagent')

--- a/roles/sap_install_media_detect/tasks/prepare/check_directories.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/check_directories.yml
@@ -56,7 +56,7 @@
 
 - name: SAP Install Media Detect - Prepare - Check the status of 'sap_install_media_detect_source_directory'
   when: sap_install_media_detect_target_directory is undefined or
-        sap_install_media_detect_target_directory | string == "None" or
+        sap_install_media_detect_target_directory | string == 'None' or
         sap_install_media_detect_target_directory | string | length == 0
   block:
 

--- a/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
@@ -48,50 +48,50 @@
     (item.stdout.split(';')[1] == 'sapcar') or
     (item.stdout.split(';')[1] == 'sap_jvm') or
     (item.stdout.split(';')[1] == 'sap_unknown') or
-    (sap_install_media_detect_swpm | d(false) and item.stdout.split(';')[1] == 'sap_swpm') or
-    (sap_install_media_detect_hostagent | d(false) and item.stdout.split(';')[1] == 'sap_hostagent') or
-    (sap_install_media_detect_igs | d(false) and item.stdout.split(';')[1] == 'sap_igs') or
-    (sap_install_media_detect_kernel | d(false) and item.stdout.split(';')[1] == 'sap_kernel') or
-    (sap_install_media_detect_kernel | d(false) and item.stdout.split(';')[1] is search('sap_kernel_db_')) or
-    (sap_install_media_detect_webdisp | d(false) and item.stdout.split(';')[1] == 'sap_webdisp') or
-    (sap_install_media_detect_db | d('') == 'saphana' and (
+    (sap_install_media_detect_swpm and item.stdout.split(';')[1] == 'sap_swpm') or
+    (sap_install_media_detect_hostagent and item.stdout.split(';')[1] == 'sap_hostagent') or
+    (sap_install_media_detect_igs and item.stdout.split(';')[1] == 'sap_igs') or
+    (sap_install_media_detect_kernel and item.stdout.split(';')[1] == 'sap_kernel') or
+    (sap_install_media_detect_kernel and item.stdout.split(';')[1] is search('sap_kernel_db_')) or
+    (sap_install_media_detect_webdisp and item.stdout.split(';')[1] == 'sap_webdisp') or
+    (sap_install_media_detect_db == 'saphana' and (
        item.stdout.split(';')[1] == 'saphana' or
        item.stdout.split(';')[1] == 'saphana_client' or
        item.stdout.split(';')[1] == 'saphana_other')
     ) or
-    (sap_install_media_detect_db_client | d('') == 'saphana' and item.stdout.split(';')[1] == 'saphana_client') or
-    (sap_install_media_detect_db | d('') == 'sapmaxdb' and item.stdout.split(';')[1] == 'sapmaxdb') or
-    (sap_install_media_detect_db | d('') == 'sapase' and (
+    (sap_install_media_detect_db_client == 'saphana' and item.stdout.split(';')[1] == 'saphana_client') or
+    (sap_install_media_detect_db == 'sapmaxdb' and item.stdout.split(';')[1] == 'sapmaxdb') or
+    (sap_install_media_detect_db == 'sapase' and (
        item.stdout.split(';')[1] == 'sapase' or
        item.stdout.split(';')[1] == 'sapase_client')
     ) or
-    (sap_install_media_detect_db_client | d('') == 'sapase' and item.stdout.split(';')[1] == 'sapase_client') or
-    (sap_install_media_detect_db | d('') == 'oracledb' and (
+    (sap_install_media_detect_db_client == 'sapase' and item.stdout.split(';')[1] == 'sapase_client') or
+    (sap_install_media_detect_db == 'oracledb' and (
        item.stdout.split(';')[1] == 'oracledb' or
        item.stdout.split(';')[1] == 'oracledb_client' or
        item.stdout.split(';')[1] == 'oracledb_tools')
     ) or
-    (sap_install_media_detect_db_client | d('') == 'oracledb' and item.stdout.split(';')[1] == 'oracledb_client') or
-    (sap_install_media_detect_db | d('') == 'ibmdb2' and (
+    (sap_install_media_detect_db_client == 'oracledb' and item.stdout.split(';')[1] == 'oracledb_client') or
+    (sap_install_media_detect_db == 'ibmdb2' and (
        item.stdout.split(';')[1] == 'ibmdb2' or
        item.stdout.split(';')[1] == 'ibmdb2_client' or
        item.stdout.split(';')[1] == 'ibmdb2_license')
     ) or
-    (sap_install_media_detect_db_client | d('') == 'ibmdb2' and item.stdout.split(';')[1] == 'ibmdb2_client') or
+    (sap_install_media_detect_db_client == 'ibmdb2' and item.stdout.split(';')[1] == 'ibmdb2_client') or
     (sap_install_media_detect_export == 'saps4hana' and (
        item.stdout.split(';')[1] == 'sap_export_s4hana' or
        item.stdout.split(';')[1] == 'sap_s4hana_lang')
     ) or
-    (sap_install_media_detect_export | d('') == 'sapbw4hana' and (
+    (sap_install_media_detect_export == 'sapbw4hana' and (
        item.stdout.split(';')[1] == 'sap_export_bw4hana' or
        item.stdout.split(';')[1] == 'sap_s4hana_lang')
     ) or
-    (sap_install_media_detect_export | d('') == 'sapnwas_abap' and item.stdout.split(';')[1] == 'sap_export_nwas_abap') or
-    (sap_install_media_detect_export | d('') == 'sapsolman_abap' and item.stdout.split(';')[1] == 'sap_export_solman_abap') or
-    (sap_install_media_detect_export | d('') == 'sapnwas_java' and item.stdout.split(';')[1] == 'sap_export_nwas_java') or
-    (sap_install_media_detect_export | d('') == 'sapsolman_java' and item.stdout.split(';')[1] == 'sap_export_solman_java') or
-    (sap_install_media_detect_export | d('') == 'sapecc' and item.stdout.split(';')[1] == 'sap_export_ecc') or
-    (sap_install_media_detect_export | d('') == 'sapecc_ides' and item.stdout.split(';')[1] == 'sap_export_ecc_ides')
+    (sap_install_media_detect_export == 'sapnwas_abap' and item.stdout.split(';')[1] == 'sap_export_nwas_abap') or
+    (sap_install_media_detect_export == 'sapsolman_abap' and item.stdout.split(';')[1] == 'sap_export_solman_abap') or
+    (sap_install_media_detect_export == 'sapnwas_java' and item.stdout.split(';')[1] == 'sap_export_nwas_java') or
+    (sap_install_media_detect_export == 'sapsolman_java' and item.stdout.split(';')[1] == 'sap_export_solman_java') or
+    (sap_install_media_detect_export == 'sapecc' and item.stdout.split(';')[1] == 'sap_export_ecc') or
+    (sap_install_media_detect_export == 'sapecc_ides' and item.stdout.split(';')[1] == 'sap_export_ecc_ides')
 
 - name: SAP Install Media Detect - Prepare - Asserts
   when:
@@ -109,7 +109,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_swpm') | length > 0
         fail_msg: "No file found for sap_swpm"
       when:
-        - sap_install_media_detect_swpm | d(false)
+        - sap_install_media_detect_swpm
 
     - name: SAP Install Media Detect - Prepare - Assert that exactly one SAP Kernel DB independent is present
       ansible.builtin.assert:
@@ -118,7 +118,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPEXE_') | length == 1
         fail_msg: "No, or more than one, DB independent SAP Kernel file found"
       when:
-        - sap_install_media_detect_kernel | d(false)
+        - sap_install_media_detect_kernel
 
     - name: SAP Install Media Detect - Prepare - Assert that exactly one SAP Kernel DB dependent is present
       ansible.builtin.assert:
@@ -127,7 +127,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPEXEDB_') | length == 1
         fail_msg: "No, or more than one, DB dependent SAP Kernel file found"
       when:
-        - sap_install_media_detect_kernel | d(false)
+        - sap_install_media_detect_kernel
         - sap_install_media_detect_kernel_db is not defined
 
     - name: SAP Install Media Detect - Prepare - Assert that exactly one matching SAP Kernel DB dependent is present
@@ -180,7 +180,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_hostagent') | length > 0
         fail_msg: "No SAP Host Agent file found"
       when:
-        - sap_install_media_detect_hostagent | d(false)
+        - sap_install_media_detect_hostagent
 
     - name: SAP Install Media Detect - Prepare - Assert that igsexe is present
       ansible.builtin.assert:
@@ -189,7 +189,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'igsexe') | length > 0
         fail_msg: "No igsexe file found"
       when:
-        - sap_install_media_detect_igs | d(false)
+        - sap_install_media_detect_igs
 
     - name: SAP Install Media Detect - Prepare - Assert that igshelper is present
       ansible.builtin.assert:
@@ -198,7 +198,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'igshelper') | length > 0
         fail_msg: "No igshelper file found"
       when:
-        - sap_install_media_detect_igs | d(false)
+        - sap_install_media_detect_igs
 
     - name: SAP Install Media Detect - Prepare - Assert that exactly one SAP WEBDISP is present
       ansible.builtin.assert:
@@ -207,7 +207,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPWEBDISP_') | length == 1
         fail_msg: "No, or more than one, SAPWEBDISP file found"
       when:
-        - sap_install_media_detect_webdisp | d(false)
+        - sap_install_media_detect_webdisp
 
     - name: SAP Install Media Detect - Prepare - Assert that saphana is present
       ansible.builtin.assert:
@@ -215,7 +215,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'saphana') | length > 0
         fail_msg: "No file found for saphana"
       when:
-        - sap_install_media_detect_db | d('') == 'saphana'
+        - sap_install_media_detect_db
 
     - name: SAP Install Media Detect - Prepare - Assert that saphana_client is present
       ansible.builtin.assert:
@@ -223,8 +223,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'saphana_client') | length > 0
         fail_msg: "No file found for saphana_client"
       when:
-        - sap_install_media_detect_db | d('') == 'saphana' or
-          sap_install_media_detect_db_client | d('') == 'saphana'
+        - sap_install_media_detect_db == 'saphana' or
+          sap_install_media_detect_db_client == 'saphana'
 
     - name: SAP Install Media Detect - Prepare - Assert that sapase is present
       ansible.builtin.assert:
@@ -232,7 +232,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sapase') | length > 0
         fail_msg: "No file found for sapase"
       when:
-        - sap_install_media_detect_db | d('') == 'sapase'
+        - sap_install_media_detect_db == 'sapase'
 
     - name: SAP Install Media Detect - Prepare - Assert that sapase_client is present
       ansible.builtin.assert:
@@ -240,8 +240,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sapase_client') | length > 0
         fail_msg: "No file found for sapase_client"
       when:
-        - sap_install_media_detect_db | d('') == 'sapase' or
-          sap_install_media_detect_db_client | d('') == 'sapase'
+        - sap_install_media_detect_db == 'sapase' or
+          sap_install_media_detect_db_client == 'sapase'
 
     - name: SAP Install Media Detect - Prepare - Assert that sapmaxdb is present
       ansible.builtin.assert:
@@ -249,7 +249,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sapmaxdb') | length > 0
         fail_msg: "No file found for sapmaxdb"
       when:
-        - sap_install_media_detect_db | d('') == 'sapmaxdb'
+        - sap_install_media_detect_db == 'sapmaxdb'
 
     - name: SAP Install Media Detect - Prepare - Assert that oracledb is present
       ansible.builtin.assert:
@@ -257,7 +257,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'oracledb') | length > 0
         fail_msg: "No file found for oracledb"
       when:
-        - sap_install_media_detect_db | d('') == 'oracledb'
+        - sap_install_media_detect_db == 'oracledb'
 
     - name: SAP Install Media Detect - Prepare - Assert that oracledb_client is present
       ansible.builtin.assert:
@@ -265,8 +265,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'oracledb_client') | length > 0
         fail_msg: "No file found for oracledb_client"
       when:
-        - sap_install_media_detect_db | d('') == 'oracledb' or
-          sap_install_media_detect_db_client | d('') == 'oracledb'
+        - sap_install_media_detect_db == 'oracledb' or
+          sap_install_media_detect_db_client == 'oracledb'
 
     - name: SAP Install Media Detect - Prepare - Assert that ibmdb2 is present
       ansible.builtin.assert:
@@ -274,7 +274,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'ibmdb2') | length > 0
         fail_msg: "No file found for ibmdb2"
       when:
-        - sap_install_media_detect_db | d('') == 'ibmdb2'
+        - sap_install_media_detect_db == 'ibmdb2'
 
     - name: SAP Install Media Detect - Prepare - Assert that ibmdb2_client is present
       ansible.builtin.assert:
@@ -282,8 +282,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'ibmdb2_client') | length > 0
         fail_msg: "No file found for ibmdb2_client"
       when:
-        - sap_install_media_detect_db | d('') == 'ibmdb2' or
-          sap_install_media_detect_db_client | d('') == 'ibmdb2'
+        - sap_install_media_detect_db == 'ibmdb2' or
+          sap_install_media_detect_db_client == 'ibmdb2'
 
     - name: SAP Install Media Detect - Prepare - Assert that ibmdb2_license is present
       ansible.builtin.assert:
@@ -291,7 +291,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'ibmdb2_license') | length > 0
         fail_msg: "No file found for ibmdb2_license"
       when:
-        - sap_install_media_detect_db | d('') == 'ibmdb2'
+        - sap_install_media_detect_db == 'ibmdb2'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_s4hana is present
       ansible.builtin.assert:
@@ -299,7 +299,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_s4hana') | length > 0
         fail_msg: "No file found for sap_export_s4hana"
       when:
-        - sap_install_media_detect_export | d('') == 'saps4hana'
+        - sap_install_media_detect_export == 'saps4hana'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_bw4hana is present
       ansible.builtin.assert:
@@ -307,7 +307,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_bw4hana') | length > 0
         fail_msg: "No file found for sap_export_bw4hana"
       when:
-        - sap_install_media_detect_export | d('') == 'sapbw4hana'
+        - sap_install_media_detect_export == 'sapbw4hana'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_ecc is present
       ansible.builtin.assert:
@@ -315,7 +315,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_ecc') | length > 0
         fail_msg: "No file found for sap_export_ecc"
       when:
-        - sap_install_media_detect_export | d('') == 'sapecc'
+        - sap_install_media_detect_export == 'sapecc'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_ecc_ides is present
       ansible.builtin.assert:
@@ -323,7 +323,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_ecc_ides') | length > 0
         fail_msg: "No file found for sap_export_ecc_ides"
       when:
-        - sap_install_media_detect_export | d('') == 'sapecc_ides'
+        - sap_install_media_detect_export == 'sapecc_ides'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_nwas_abap is present
       ansible.builtin.assert:
@@ -331,7 +331,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_nwas_abap') | length > 0
         fail_msg: "No file found for sap_export_nwas_abap"
       when:
-        - sap_install_media_detect_export | d('') == 'sapnwas_abap'
+        - sap_install_media_detect_export == 'sapnwas_abap'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_nwas_java is present
       ansible.builtin.assert:
@@ -339,7 +339,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_nwas_java') | length > 0
         fail_msg: "No file found for sap_export_nwas_java"
       when:
-        - sap_install_media_detect_export | d('') == 'sapnwas_java'
+        - sap_install_media_detect_export == 'sapnwas_java'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_solman_abap is present
       ansible.builtin.assert:
@@ -347,7 +347,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_solman_abap') | length > 0
         fail_msg: "No file found for sap_export_solman_abap"
       when:
-        - sap_install_media_detect_export | d('') == 'sapsolman_abap'
+        - sap_install_media_detect_export == 'sapsolman_abap'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_solman_java is present
       ansible.builtin.assert:
@@ -355,7 +355,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_solman_java') | length > 0
         fail_msg: "No file found for sap_export_solman_java"
       when:
-        - sap_install_media_detect_export | d('') == 'sapsolman_java'
+        - sap_install_media_detect_export == 'sapsolman_java'
 
 #- name: SAP Install Media Detect - Prepare - Identify the sapcar program
 #  ansible.builtin.set_fact:

--- a/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
@@ -54,40 +54,44 @@
     (sap_install_media_detect_kernel | d(false) and item.stdout.split(';')[1] == 'sap_kernel') or
     (sap_install_media_detect_kernel | d(false) and item.stdout.split(';')[1] is search('sap_kernel_db_')) or
     (sap_install_media_detect_webdisp | d(false) and item.stdout.split(';')[1] == 'sap_webdisp') or
-    (sap_install_media_detect_db == 'saphana' and (
+    (sap_install_media_detect_db | d('') == 'saphana' and (
        item.stdout.split(';')[1] == 'saphana' or
        item.stdout.split(';')[1] == 'saphana_client' or
        item.stdout.split(';')[1] == 'saphana_other')
     ) or
-    (sap_install_media_detect_db == 'sapmaxdb' and item.stdout.split(';')[1] == 'sapmaxdb') or
-    (sap_install_media_detect_db == 'sapase' and (
+    (sap_install_media_detect_db_client | d('') == 'saphana' and item.stdout.split(';')[1] == 'saphana_client') or
+    (sap_install_media_detect_db | d('') == 'sapmaxdb' and item.stdout.split(';')[1] == 'sapmaxdb') or
+    (sap_install_media_detect_db | d('') == 'sapase' and (
        item.stdout.split(';')[1] == 'sapase' or
        item.stdout.split(';')[1] == 'sapase_client')
     ) or
-    (sap_install_media_detect_db == 'oracledb' and (
+    (sap_install_media_detect_db_client | d('') == 'sapase' and item.stdout.split(';')[1] == 'sapase_client') or
+    (sap_install_media_detect_db | d('') == 'oracledb' and (
        item.stdout.split(';')[1] == 'oracledb' or
        item.stdout.split(';')[1] == 'oracledb_client' or
        item.stdout.split(';')[1] == 'oracledb_tools')
     ) or
-    (sap_install_media_detect_db == 'ibmdb2' and (
+    (sap_install_media_detect_db_client | d('') == 'oracledb' and item.stdout.split(';')[1] == 'oracledb_client') or
+    (sap_install_media_detect_db | d('') == 'ibmdb2' and (
        item.stdout.split(';')[1] == 'ibmdb2' or
        item.stdout.split(';')[1] == 'ibmdb2_client' or
        item.stdout.split(';')[1] == 'ibmdb2_license')
     ) or
+    (sap_install_media_detect_db_client | d('') == 'ibmdb2' and item.stdout.split(';')[1] == 'ibmdb2_client') or
     (sap_install_media_detect_export == 'saps4hana' and (
        item.stdout.split(';')[1] == 'sap_export_s4hana' or
        item.stdout.split(';')[1] == 'sap_s4hana_lang')
     ) or
-    (sap_install_media_detect_export == 'sapbw4hana' and (
+    (sap_install_media_detect_export | d('') == 'sapbw4hana' and (
        item.stdout.split(';')[1] == 'sap_export_bw4hana' or
        item.stdout.split(';')[1] == 'sap_s4hana_lang')
     ) or
-    (sap_install_media_detect_export == 'sapnwas_abap' and item.stdout.split(';')[1] == 'sap_export_nwas_abap') or
-    (sap_install_media_detect_export == 'sapsolman_abap' and item.stdout.split(';')[1] == 'sap_export_solman_abap') or
-    (sap_install_media_detect_export == 'sapnwas_java' and item.stdout.split(';')[1] == 'sap_export_nwas_java') or
-    (sap_install_media_detect_export == 'sapsolman_java' and item.stdout.split(';')[1] == 'sap_export_solman_java') or
-    (sap_install_media_detect_export == 'sapecc' and item.stdout.split(';')[1] == 'sap_export_ecc') or
-    (sap_install_media_detect_export == 'sapecc_ides' and item.stdout.split(';')[1] == 'sap_export_ecc_ides')
+    (sap_install_media_detect_export | d('') == 'sapnwas_abap' and item.stdout.split(';')[1] == 'sap_export_nwas_abap') or
+    (sap_install_media_detect_export | d('') == 'sapsolman_abap' and item.stdout.split(';')[1] == 'sap_export_solman_abap') or
+    (sap_install_media_detect_export | d('') == 'sapnwas_java' and item.stdout.split(';')[1] == 'sap_export_nwas_java') or
+    (sap_install_media_detect_export | d('') == 'sapsolman_java' and item.stdout.split(';')[1] == 'sap_export_solman_java') or
+    (sap_install_media_detect_export | d('') == 'sapecc' and item.stdout.split(';')[1] == 'sap_export_ecc') or
+    (sap_install_media_detect_export | d('') == 'sapecc_ides' and item.stdout.split(';')[1] == 'sap_export_ecc_ides')
 
 - name: SAP Install Media Detect - Prepare - Asserts
   when:
@@ -211,7 +215,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'saphana') | length > 0
         fail_msg: "No file found for saphana"
       when:
-        - (sap_install_media_detect_db | d('')) == 'saphana'
+        - sap_install_media_detect_db | d('') == 'saphana'
 
     - name: SAP Install Media Detect - Prepare - Assert that saphana_client is present
       ansible.builtin.assert:
@@ -219,8 +223,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'saphana_client') | length > 0
         fail_msg: "No file found for saphana_client"
       when:
-        - (sap_install_media_detect_db | d('')) == 'saphana' or
-          (sap_install_media_detect_db_client | d('')) == 'saphana'
+        - sap_install_media_detect_db | d('') == 'saphana' or
+          sap_install_media_detect_db_client | d('') == 'saphana'
 
     - name: SAP Install Media Detect - Prepare - Assert that sapase is present
       ansible.builtin.assert:
@@ -228,7 +232,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sapase') | length > 0
         fail_msg: "No file found for sapase"
       when:
-        - (sap_install_media_detect_db | d('')) == 'sapase'
+        - sap_install_media_detect_db | d('') == 'sapase'
 
     - name: SAP Install Media Detect - Prepare - Assert that sapase_client is present
       ansible.builtin.assert:
@@ -236,8 +240,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sapase_client') | length > 0
         fail_msg: "No file found for sapase_client"
       when:
-        - (sap_install_media_detect_db | d('')) == 'sapase' or
-          (sap_install_media_detect_db_client | d('')) == 'sapase'
+        - sap_install_media_detect_db | d('') == 'sapase' or
+          sap_install_media_detect_db_client | d('') == 'sapase'
 
     - name: SAP Install Media Detect - Prepare - Assert that sapmaxdb is present
       ansible.builtin.assert:
@@ -245,7 +249,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sapmaxdb') | length > 0
         fail_msg: "No file found for sapmaxdb"
       when:
-        - (sap_install_media_detect_db | d('')) == 'sapmaxdb'
+        - sap_install_media_detect_db | d('') == 'sapmaxdb'
 
     - name: SAP Install Media Detect - Prepare - Assert that oracledb is present
       ansible.builtin.assert:
@@ -253,7 +257,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'oracledb') | length > 0
         fail_msg: "No file found for oracledb"
       when:
-        - (sap_install_media_detect_db | d('')) == 'oracledb'
+        - sap_install_media_detect_db | d('') == 'oracledb'
 
     - name: SAP Install Media Detect - Prepare - Assert that oracledb_client is present
       ansible.builtin.assert:
@@ -261,8 +265,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'oracledb_client') | length > 0
         fail_msg: "No file found for oracledb_client"
       when:
-        - (sap_install_media_detect_db | d('')) == 'oracledb' or
-          (sap_install_media_detect_db_client | d('')) == 'oracledb'
+        - sap_install_media_detect_db | d('') == 'oracledb' or
+          sap_install_media_detect_db_client | d('') == 'oracledb'
 
     - name: SAP Install Media Detect - Prepare - Assert that ibmdb2 is present
       ansible.builtin.assert:
@@ -270,7 +274,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'ibmdb2') | length > 0
         fail_msg: "No file found for ibmdb2"
       when:
-        - (sap_install_media_detect_db | d('')) == 'ibmdb2'
+        - sap_install_media_detect_db | d('') == 'ibmdb2'
 
     - name: SAP Install Media Detect - Prepare - Assert that ibmdb2_client is present
       ansible.builtin.assert:
@@ -278,8 +282,8 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'ibmdb2_client') | length > 0
         fail_msg: "No file found for ibmdb2_client"
       when:
-        - (sap_install_media_detect_db | d('')) == 'ibmdb2' or
-          (sap_install_media_detect_db_client | d('')) == 'ibmdb2'
+        - sap_install_media_detect_db | d('') == 'ibmdb2' or
+          sap_install_media_detect_db_client | d('') == 'ibmdb2'
 
     - name: SAP Install Media Detect - Prepare - Assert that ibmdb2_license is present
       ansible.builtin.assert:
@@ -287,7 +291,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'ibmdb2_license') | length > 0
         fail_msg: "No file found for ibmdb2_license"
       when:
-        - (sap_install_media_detect_db | d('')) == 'ibmdb2'
+        - sap_install_media_detect_db | d('') == 'ibmdb2'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_s4hana is present
       ansible.builtin.assert:
@@ -295,7 +299,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_s4hana') | length > 0
         fail_msg: "No file found for sap_export_s4hana"
       when:
-        - (sap_install_media_detect_export | d('')) == 'saps4hana'
+        - sap_install_media_detect_export | d('') == 'saps4hana'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_bw4hana is present
       ansible.builtin.assert:
@@ -303,7 +307,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_bw4hana') | length > 0
         fail_msg: "No file found for sap_export_bw4hana"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapbw4hana'
+        - sap_install_media_detect_export | d('') == 'sapbw4hana'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_ecc is present
       ansible.builtin.assert:
@@ -311,7 +315,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_ecc') | length > 0
         fail_msg: "No file found for sap_export_ecc"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapecc'
+        - sap_install_media_detect_export | d('') == 'sapecc'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_ecc_ides is present
       ansible.builtin.assert:
@@ -319,7 +323,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_ecc_ides') | length > 0
         fail_msg: "No file found for sap_export_ecc_ides"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapecc_ides'
+        - sap_install_media_detect_export | d('') == 'sapecc_ides'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_nwas_abap is present
       ansible.builtin.assert:
@@ -327,7 +331,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_nwas_abap') | length > 0
         fail_msg: "No file found for sap_export_nwas_abap"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapnwas_abap'
+        - sap_install_media_detect_export | d('') == 'sapnwas_abap'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_nwas_java is present
       ansible.builtin.assert:
@@ -335,7 +339,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_nwas_java') | length > 0
         fail_msg: "No file found for sap_export_nwas_java"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapnwas_java'
+        - sap_install_media_detect_export | d('') == 'sapnwas_java'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_solman_abap is present
       ansible.builtin.assert:
@@ -343,7 +347,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_solman_abap') | length > 0
         fail_msg: "No file found for sap_export_solman_abap"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapsolman_abap'
+        - sap_install_media_detect_export | d('') == 'sapsolman_abap'
 
     - name: SAP Install Media Detect - Prepare - Assert that sap_export_solman_java is present
       ansible.builtin.assert:
@@ -351,7 +355,7 @@
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_export_solman_java') | length > 0
         fail_msg: "No file found for sap_export_solman_java"
       when:
-        - (sap_install_media_detect_export | d('')) == 'sapsolman_java'
+        - sap_install_media_detect_export | d('') == 'sapsolman_java'
 
 #- name: SAP Install Media Detect - Prepare - Identify the sapcar program
 #  ansible.builtin.set_fact:

--- a/roles/sap_install_media_detect/tasks/prepare/enable_zip_handling.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/enable_zip_handling.yml
@@ -1,0 +1,6 @@
+---
+
+- name: SAP Install Media Detect - Prepare - Ensure the presence of the 'unzip' package
+  ansible.builtin.package:
+    name: 'unzip'
+    state: present

--- a/roles/sap_install_media_detect/tasks/set_global_vars.yml
+++ b/roles/sap_install_media_detect/tasks/set_global_vars.yml
@@ -41,7 +41,7 @@
   ignore_errors: true
   when:
     - sap_install_media_detect_move_or_copy_archives
-    - sap_install_media_detect_db == "saphana"
+    - sap_install_media_detect_db == 'saphana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA - sap_hana_install, move_or_copy_archives parameter not set
   ansible.builtin.set_fact:
@@ -51,7 +51,7 @@
   ignore_errors: true
   when:
     - not sap_install_media_detect_move_or_copy_archives
-    - sap_install_media_detect_db == "saphana"
+    - sap_install_media_detect_db == 'saphana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA - sap_swpm
   ansible.builtin.set_fact:
@@ -59,7 +59,7 @@
   ignore_errors: true
   when:
     - sap_install_media_detect_move_or_copy_archives
-    - sap_install_media_detect_db == "saphana"
+    - sap_install_media_detect_db == 'saphana'
 
 # In 'find_files_after_extraction.yml', we search for a directory named 'LINUXX86_64'. For the role sap_swpm, we need to set
 # exactly this path
@@ -68,7 +68,7 @@
     sap_swpm_cd_ibmdb2_path: "{{ detect_directory_ibmdb2_extracted.files[0].path }}/" # for sap_swpm Ansible Role
     sap_swpm_cd_ibmdb2_client_path: "{{ detect_directory_ibmdb2_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_db == "ibmdb2"
+  when: sap_install_media_detect_db == 'ibmdb2'
 
 # In 'find_files_after_extraction.yml', we search for a directory name which contains 'LINUX_X86_64'. For the role sap_swpm, we need
 # to set the path which contains this directory, not the directory itself. For the Oracle client, we search for a directory name which
@@ -79,7 +79,7 @@
     sap_swpm_cd_oracle_path: "{{ detect_directory_oracledb_extracted.files[0].path | dirname }}/" # for sap_swpm Ansible Role
     sap_swpm_cd_oracle_client_path: "{{ detect_directory_oracledb_client_extracted.files[0].path | dirname }}/" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_db == "oracledb"
+  when: sap_install_media_detect_db == 'oracledb'
 
 # In 'find_files_after_extraction.yml', we search for a directory name which contains 'SYBASE_LINUX'. For the role sap_swpm, we need
 # to set exactly this path. For the ASE client, we search for a directory which contains 'sybodbc'. For the role
@@ -89,13 +89,13 @@
     sap_swpm_cd_sapase_path: "{{ detect_directory_sapase_extracted.files[0].path }}/" # for sap_swpm Ansible Role
     sap_swpm_cd_sapase_client_path: "{{ detect_directory_sapase_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_db == "sapase"
+  when: sap_install_media_detect_db == 'sapase'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP MaxDB
   ansible.builtin.set_fact:
     sap_swpm_cd_sapmaxdb_path: "{{ detect_directory_sapmaxdb_extracted.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_db == "sapmaxdb"
+  when: sap_install_media_detect_db == 'sapmaxdb'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAPEXE
   ansible.builtin.set_fact:
@@ -141,7 +141,7 @@
   ansible.builtin.set_fact:
     sap_swpm_cd_export_path: "{{ detect_directory_ecc_export_extracted.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapecc"
+  when: sap_install_media_detect_export == 'sapecc'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP ECC IDES
   ansible.builtin.set_fact:
@@ -149,31 +149,31 @@
     sap_swpm_cd_export_pt1_path: "{{ (detect_directory_ecc_ides_export_extracted.files | map(attribute='path') | map('dirname') | list | select() | unique)[0] }}/" # for sap_swpm Ansible Role
     sap_swpm_cd_export_pt2_path: "{{ (detect_directory_ecc_ides_export_extracted.files | map(attribute='path') | map('dirname') | list | select() | unique)[1] }}/" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapecc_ides"
+  when: sap_install_media_detect_export == 'sapecc_ides'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP S/4HANA
   ansible.builtin.set_fact:
     sap_swpm_cd_export_path: "{{ s4hana_export_files.files[0].path | dirname }}" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "saps4hana"
+  when: sap_install_media_detect_export == 'saps4hana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP BW/4HANA
   ansible.builtin.set_fact:
     sap_swpm_cd_export_path: "{{ bw4hana_export_files.files[0].path | dirname }}" # for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapbw4hana"
+  when: sap_install_media_detect_export == 'sapbw4hana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP NetWeaver AS (ABAP) platform only
   ansible.builtin.set_fact:
     sap_swpm_cd_export_path: "{{ detect_directory_nwas_abap_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapnwas_abap"
+  when: sap_install_media_detect_export == 'sapnwas_abap'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP NetWeaver AS (JAVA) platform only
   ansible.builtin.set_fact:
     sap_swpm_cd_export_path: "{{ detect_directory_nwas_java_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapnwas_java"
+  when: sap_install_media_detect_export == 'sapnwas_java'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP Solution Manager (ABAP)
   ansible.builtin.set_fact:
@@ -181,13 +181,13 @@
     sap_swpm_cd_export_pt1_path: "{{ detect_directory_solgmr_abap_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
     sap_swpm_cd_export_pt2_path: "{{ detect_directory_solgmr_abap_export_extracted.files[1].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapsolman_abap"
+  when: sap_install_media_detect_export == 'sapsolman_abap'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP Solution Manager (JAVA)
   ansible.builtin.set_fact:
     sap_swpm_cd_export_path: "{{ detect_directory_solgmr_java_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
-  when: sap_install_media_detect_export == "sapsolman_java"
+  when: sap_install_media_detect_export == 'sapsolman_java'
 
 - name: SAP Install Media Detect - Detection completed - Set fact for displaying all variables
   ansible.builtin.set_fact:

--- a/roles/sap_install_media_detect/tasks/set_global_vars.yml
+++ b/roles/sap_install_media_detect/tasks/set_global_vars.yml
@@ -53,13 +53,14 @@
     - not sap_install_media_detect_move_or_copy_archives
     - sap_install_media_detect_db == 'saphana'
 
-- name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA - sap_swpm
+- name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA Client - sap_swpm
   ansible.builtin.set_fact:
     sap_swpm_cd_rdbms_path: "{{ sap_hana_client_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when:
     - sap_install_media_detect_move_or_copy_archives
-    - sap_install_media_detect_db == 'saphana'
+    - sap_install_media_detect_db == 'saphana' or
+      sap_install_media_detect_db_client == 'saphana'
 
 # In 'find_files_after_extraction.yml', we search for a directory named 'LINUXX86_64'. For the role sap_swpm, we need to set
 # exactly this path
@@ -69,6 +70,12 @@
     sap_swpm_cd_ibmdb2_client_path: "{{ detect_directory_ibmdb2_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db == 'ibmdb2'
+
+- name: SAP Install Media Detect - Detection completed - Set facts for IBM Db2 Client
+  ansible.builtin.set_fact:
+    sap_swpm_cd_ibmdb2_client_path: "{{ detect_directory_ibmdb2_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ignore_errors: true
+  when: sap_install_media_detect_db_client == 'ibmdb2'
 
 # In 'find_files_after_extraction.yml', we search for a directory name which contains 'LINUX_X86_64'. For the role sap_swpm, we need
 # to set the path which contains this directory, not the directory itself. For the Oracle client, we search for a directory name which
@@ -81,6 +88,12 @@
   ignore_errors: true
   when: sap_install_media_detect_db == 'oracledb'
 
+- name: SAP Install Media Detect - Detection completed - Set facts for Oracle DB Client
+  ansible.builtin.set_fact:
+    sap_swpm_cd_oracle_client_path: "{{ detect_directory_oracledb_client_extracted.files[0].path | dirname }}/" # for sap_swpm Ansible Role
+  ignore_errors: true
+  when: sap_install_media_detect_db_client == 'oracledb'
+
 # In 'find_files_after_extraction.yml', we search for a directory name which contains 'SYBASE_LINUX'. For the role sap_swpm, we need
 # to set exactly this path. For the ASE client, we search for a directory which contains 'sybodbc'. For the role
 # sap_swpm, we need to set exactly this path.
@@ -90,6 +103,12 @@
     sap_swpm_cd_sapase_client_path: "{{ detect_directory_sapase_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db == 'sapase'
+
+- name: SAP Install Media Detect - Detection completed - Set facts for SAP ASE Client
+  ansible.builtin.set_fact:
+    sap_swpm_cd_sapase_client_path: "{{ detect_directory_sapase_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ignore_errors: true
+  when: sap_install_media_detect_db_client == 'sapase'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP MaxDB
   ansible.builtin.set_fact:
@@ -106,17 +125,20 @@
 - name: SAP Install Media Detect - Detection completed - Set facts for SAPEXEDB, unspecific
   ansible.builtin.set_fact:
     sap_swpm_kernel_dependent_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_kernel_dependent_file_name: "{{ sap_swpm_kernel_dependent_file_name_get.stdout }}"
+    sap_swpm_kernel_dependent_file_name: "{{ sap_swpm_kernel_dependent_file_name_get_db_unspecific.stdout }}"
   when:
-    - sap_install_media_detect_kernel_db is not defined
     - sap_install_media_detect_kernel
+    - sap_install_media_detect_kernel_db is not defined or
+      sap_install_media_detect_kernel_db | length == 0
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAPEXEDB, specific
   ansible.builtin.set_fact:
     sap_swpm_kernel_dependent_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_kernel_dependent_file_name: "{{ sap_swpm_kernel_dependent_file_name_get }}"
+    sap_swpm_kernel_dependent_file_name: "{{ sap_swpm_kernel_dependent_file_name_get_db_specific }}"
   when:
+    - sap_install_media_detect_kernel
     - sap_install_media_detect_kernel_db is defined
+    - sap_install_media_detect_kernel_db | length > 0
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP IGS
   ansible.builtin.set_fact:


### PR DESCRIPTION
This PR contains the following changes:
- set all SAP product related vars in `defaults/main.yml` to empty or, in case of boolean, to false
- no longer set vars to defaults in comparisons (because all vars are already set in `defaults/main.yml`)
- add more DB client file handling code, to support cases where only the DB client files are needed and not all the DB installation files
- use different variable names of `sap_swpm_kernel_dependent_file_name_get` for db unspecific and for db specific cases
- ensure the unzip package is present so the `sapfile` utility will work even on systems where the `sap*preconfigure` roles have not been executed before
- replace double quotes by single quotes in string comparisons