### PR TITLE
sap_general_preconfigure: Improve SELinux handling

### DIFF
--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -237,11 +237,27 @@ Can be useful if you want to implement your own reboot handling.<br>
 
 One of the SELinux states to be set on the system.<br>
 
+### sap_general_preconfigure_create_directories
+- _Type:_ `bool`
+- _Default:_ `true`
+
+Set to `false` if you do not want the SAP directories to be created by the role.<br>
+The SAP directories will always be created if `sap_general_preconfigure_modify_selinux_labels`<br>
+(see below) is set to `true`, no matter how `sap_general_preconfigure_create_directories` is set.<br>
+
+### sap_general_preconfigure_sap_directories
+- _Type:_ `list` with elements of type `str`
+- _Default:_
+  - /usr/sap
+
+List of SAP directories to be created.<br>
+
 ### sap_general_preconfigure_modify_selinux_labels
 - _Type:_ `bool`
 - _Default:_ `true`
 
-Set to `false` if you do not want to modify the SELinux labels for the SAP directory `/usr/sap`.<br>
+Set to `false` if you do not want to modify the SELinux labels for the SAP directores set<br>
+in variable `sap_general_preconfigure_sap_directories`.<br>
 
 ### sap_general_preconfigure_size_of_tmpfs_gb
 - _Type:_ `str`

--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -115,8 +115,18 @@ sap_general_preconfigure_selinux_state: 'permissive'
 # - permissive
 # - disabled
 
+sap_general_preconfigure_create_directories: true
+# Set to `false` if you do not want the SAP directories to be created by the role.
+# The SAP directories will always be created if `sap_general_preconfigure_modify_selinux_labels`
+# (see below) is set to `true`, no matter how `sap_general_preconfigure_create_directories` is set.
+
+sap_general_preconfigure_sap_directories:
+  - /usr/sap
+# List of SAP directories to be created.
+
 sap_general_preconfigure_modify_selinux_labels: true
-# Set to `false` if you do not want to modify the SELinux labels for the SAP directory `/usr/sap`.
+# Set to `false` if you do not want to modify the SELinux labels for the SAP directores set
+# in variable `sap_general_preconfigure_sap_directories`.
 
 sap_general_preconfigure_size_of_tmpfs_gb: "{{ ((0.75 * (ansible_memtotal_mb + ansible_swaptotal_mb)) / 1024) | round | int }}"
 # The size of the tmpfs in GB. The formula used here is mentioned in SAP note 941735.

--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -240,10 +240,29 @@ argument_specs:
         required: false
         type: str
 
+      sap_general_preconfigure_create_directories:
+        default: true
+        description:
+          - Set to `false` if you do not want the SAP directories to be created by the role.
+          - The SAP directories will always be created if `sap_general_preconfigure_modify_selinux_labels`
+          - (see below) is set to `true`, no matter how `sap_general_preconfigure_create_directories` is set.
+        required: false
+        type: bool
+
+      sap_general_preconfigure_sap_directories:
+        default:
+          - '/usr/sap'
+        description:
+          - List of SAP directories to be created.
+        required: false
+        type: list
+        elements: str
+
       sap_general_preconfigure_modify_selinux_labels:
         default: true
         description:
-          - Set to `false` if you do not want to modify the SELinux labels for the SAP directory `/usr/sap`.
+          - Set to `false` if you do not want to modify the SELinux labels for the SAP directores set
+          - in variable `sap_general_preconfigure_sap_directories`.
         required: false
         type: bool
 

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -4,13 +4,35 @@
   ansible.builtin.debug:
     var: __sap_general_preconfigure_sapnotes_versions | difference([''])
 
-- name: Configure - Create directory '/usr/sap'
+- name: Configure - Set directory variables for setting SELinux file contexts
+  ansible.builtin.set_fact:
+    sap_general_preconfigure_fact_targets_setypes: "{{ sap_general_preconfigure_fact_targets_setypes | d([]) +
+      [__sap_general_preconfigure_tmp_dict_target_setype] }}"
+  loop: "{{ sap_general_preconfigure_sap_directories }}"
+  loop_control:
+    loop_var: line_item
+  vars:
+    __sap_general_preconfigure_tmp_dict_target_setype:
+      target: "{{ line_item }}(/.*)?"
+      setype: 'usr_t'
+  when: sap_general_preconfigure_modify_selinux_labels
+
+- name: Configure - Display directory variable
+  ansible.builtin.debug:
+    var: sap_general_preconfigure_fact_targets_setypes
+  when: sap_general_preconfigure_modify_selinux_labels
+
+- name: Configure - Create directories
   ansible.builtin.file:
-    path: '/usr/sap'
+    path: "{{ line_item }}"
     state: directory
     mode: '0755'
     owner: root
     group: root
+  loop: "{{ sap_general_preconfigure_sap_directories }}"
+  loop_control:
+    loop_var: line_item
+  when: sap_general_preconfigure_create_directories or sap_general_preconfigure_modify_selinux_labels
 
 - name: Configure - Include configuration actions for required sapnotes
   ansible.builtin.include_tasks: "sapnote/{{ sap_note_line_item.number }}.yml"

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
@@ -18,15 +18,15 @@
   register: __sap_general_preconfigure_register_selinux_config_type_changed
   notify: __sap_general_preconfigure_reboot_handler
 
-- name: Determine the current SELinux state
-  ansible.builtin.command: getenforce
-  register: __sap_general_preconfigure_register_getenforce
-  check_mode: no
-  changed_when: false
+# Set a new SELinux mode variable to the SELinux status if 'disabled' or otherwise to
+# the value of the 'mode' member ('permissive' or 'enforcing')
+- name: SELinux - Set an SELinux mode variable
+  ansible.builtin.set_fact:
+    __sap_general_preconfigure_fact_selinux_mode: "{{ (ansible_selinux.status == 'disabled') | ternary (ansible_selinux.status, ansible_selinux.mode) }}"
 
-- name: SELinux - Display the current SELinux state
+- name: SELinux - Display the current SELinux mode or status
   ansible.builtin.debug:
-    var: __sap_general_preconfigure_register_getenforce.stdout
+    var: __sap_general_preconfigure_fact_selinux_mode
 
 # Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
 - name: SELinux - Set the flag that reboot is needed to apply changes # noqa no-handler
@@ -34,14 +34,12 @@
     sap_general_preconfigure_fact_reboot_required: true
   when: __sap_general_preconfigure_register_selinux_config_state_changed.changed or
         __sap_general_preconfigure_register_selinux_config_type_changed.changed or
-        __sap_general_preconfigure_register_getenforce.stdout | lower !=
-          sap_general_preconfigure_selinux_state
+        __sap_general_preconfigure_fact_selinux_mode != sap_general_preconfigure_selinux_state
 
 - name: Call Reboot handler if necessary
   ansible.builtin.command: /bin/true
   notify: __sap_general_preconfigure_reboot_handler
-  when: __sap_general_preconfigure_register_getenforce.stdout | lower !=
-          sap_general_preconfigure_selinux_state
+  when: __sap_general_preconfigure_fact_selinux_mode != sap_general_preconfigure_selinux_state
 
 - name: Set or unset SELinux kernel parameter, RHEL 8 and RHEL 9
   when:
@@ -105,7 +103,7 @@
     msg: "WARN: The SELinux file context cannot be set on an SELinux disabled system!"
   when:
     - sap_general_preconfigure_modify_selinux_labels
-    - __sap_general_preconfigure_register_getenforce.stdout | lower == 'disabled'
+    - __sap_general_preconfigure_fact_selinux_mode == 'disabled'
 
 - name: SELinux - Configure SELinux file contexts
   ansible.builtin.include_role:
@@ -120,4 +118,4 @@
   when:
     - sap_general_preconfigure_modify_selinux_labels
     - sap_general_preconfigure_selinux_state != 'disabled'
-    - __sap_general_preconfigure_register_getenforce.stdout | lower != 'disabled'
+    - __sap_general_preconfigure_fact_selinux_mode != 'disabled'

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
@@ -24,6 +24,10 @@
   check_mode: no
   changed_when: false
 
+- name: SELinux - Display the current SELinux state
+  ansible.builtin.debug:
+    var: __sap_general_preconfigure_register_getenforce.stdout
+
 # Reason for noqa: We need to notify a handler in another role, which is not possible from a handler in the current role
 - name: SELinux - Set the flag that reboot is needed to apply changes # noqa no-handler
   ansible.builtin.set_fact:
@@ -96,14 +100,24 @@
   ansible.builtin.debug:
     var: sap_general_preconfigure_fact_reboot_required | d(false)
 
-- name: Configure '/usr/sap' SELinux file labels
+- name: SELinux - Warn if the SELinux file contexts cannot be set
+  ansible.builtin.debug:
+    msg: "WARN: The SELinux file context cannot be set on an SELinux disabled system!"
+  when:
+    - sap_general_preconfigure_modify_selinux_labels
+    - __sap_general_preconfigure_register_getenforce.stdout | lower == 'disabled'
+
+- name: SELinux - Configure SELinux file contexts
   ansible.builtin.include_role:
     name: '{{ sap_general_preconfigure_system_roles_collection }}.selinux'
   vars:
     selinux_booleans:
       - { name: 'selinuxuser_execmod', state: 'on' }
     selinux_fcontexts:
-      - { target: '/usr/sap(/.*)?', setype: 'usr_t' }
+      - "{{ sap_general_preconfigure_fact_targets_setypes }}"
     selinux_restore_dirs:
-      - '/usr/sap'
-  when: sap_general_preconfigure_modify_selinux_labels
+      - "{{ sap_general_preconfigure_sap_directories }}"
+  when:
+    - sap_general_preconfigure_modify_selinux_labels
+    - sap_general_preconfigure_selinux_state != 'disabled'
+    - __sap_general_preconfigure_register_getenforce.stdout | lower != 'disabled'


### PR DESCRIPTION
- Fixes #464: Allow more directories than just `/usr/sap` to be created and SELinux labeled
- Also fixes #355. The role will now skip calling the `lsr/selinux` role if the current SELinux state is `disabled` and a relabeling is requested. It will also display a warning message about this fact. After a reboot, once the SELinux state is `permissive` or `enforcing`, the role can be called again and then perform the SELinux relabeling.