### PR TITLE
sap_install_media_detect: Fix SAPCAR extraction error for SAP ASE Client

### DIFF
--- a/roles/sap_install_media_detect/tasks/organize_files.yml
+++ b/roles/sap_install_media_detect/tasks/organize_files.yml
@@ -174,7 +174,7 @@
 # We want the extracted files to be placed in the extraction_dir for this file, each file tree having its own separate directory.
 # So we can directly extract the sapcar files to the final extraction_dir.
 - name: SAP Install Media Detect - Organize all files - Extract non-HANA sapcar archive files
-  ansible.builtin.shell: >-
+  ansible.builtin.command: >-
     {{ __sap_install_media_detect_fact_sapcar_path }}
     -R {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}
     -xvf {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.file }}

--- a/roles/sap_install_media_detect/tasks/organize_files.yml
+++ b/roles/sap_install_media_detect/tasks/organize_files.yml
@@ -132,6 +132,10 @@
     - line_item.archive_type == 'rarexe'
     - line_item.extract_archive == 'y'
 
+# SAP HANA sapcar archive files have a directory structure with a single directory (e.g. SAP_HANA_DATBASE) which contains all files.
+# We want the extracted files to be placed in extraction_dir under this directory name, allowing multiple directories in extraction_dir.
+# So we create a temporary directory, move the file SIGNATURE.SMF (which the sapcar command extracts to the level above) to this directory,
+# and then move the single directory to the extraction_dir.
 - name: SAP Install Media Detect - Organize all files - Create temp dir for sapcar archive files - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
   ansible.builtin.file:
     path: "{{ __sap_install_media_detect_software_main_directory }}/tmp_extract"
@@ -161,6 +165,14 @@
     - line_item.archive_type == 'sapcar'
     - line_item.sap_file_type is search('saphana')
 
+- name: SAP Install Media Detect - Organize all files - Remove temp dir - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
+  ansible.builtin.file:
+    path: "{{ __sap_install_media_detect_software_main_directory }}/tmp_extract"
+    state: absent
+
+# Non-SAP HANA sapcar archive files can have various different directory structures: Can be all flat, or up to 13 directory levels.
+# We want the extracted files to be placed in the extraction_dir for this file, each file tree having its own separate directory.
+# So we can directly extract the sapcar files to the final extraction_dir.
 - name: SAP Install Media Detect - Organize all files - Extract non-HANA sapcar archive files
   ansible.builtin.shell: >-
     {{ __sap_install_media_detect_fact_sapcar_path }}
@@ -177,11 +189,6 @@
     - line_item.extract_archive == 'y'
     - line_item.archive_type == 'sapcar'
     - not line_item.sap_file_type is search('saphana')
-
-- name: SAP Install Media Detect - Organize all files - Remove temp dir - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
-  ansible.builtin.file:
-    path: "{{ __sap_install_media_detect_software_main_directory }}/tmp_extract"
-    state: absent
 
 - name: SAP Install Media Detect - Organize all files - Copy certain files to 'sap_hana' directory
   ansible.builtin.copy:

--- a/roles/sap_install_media_detect/tasks/organize_files.yml
+++ b/roles/sap_install_media_detect/tasks/organize_files.yml
@@ -140,7 +140,7 @@
     group: root
     mode: '0755'
 
-- name: SAP Install Media Detect - Organize all files - Extract sapcar archive files
+- name: SAP Install Media Detect - Organize all files - Extract HANA sapcar archive files
   ansible.builtin.shell: >-
     {{ __sap_install_media_detect_fact_sapcar_path }}
     -R {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
@@ -148,7 +148,7 @@
     -manifest SIGNATURE.SMF
     && extracted_dir=$(ls -d */)
     && mv SIGNATURE.SMF $extracted_dir
-    && mkdir -p {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}/$extracted_dir
+    && mkdir -p {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}
     && mv $extracted_dir {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}/
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}/tmp_extract"
@@ -157,8 +157,26 @@
     loop_var: line_item
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.archive_type == 'sapcar'
     - line_item.extract_archive == 'y'
+    - line_item.archive_type == 'sapcar'
+    - line_item.sap_file_type is search('saphana')
+
+- name: SAP Install Media Detect - Organize all files - Extract non-HANA sapcar archive files
+  ansible.builtin.shell: >-
+    {{ __sap_install_media_detect_fact_sapcar_path }}
+    -R {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}
+    -xvf {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.file }}
+    -manifest SIGNATURE.SMF
+  args:
+    chdir: "{{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}"
+  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop_control:
+    loop_var: line_item
+  when:
+    - sap_install_media_detect_extract_archives
+    - line_item.extract_archive == 'y'
+    - line_item.archive_type == 'sapcar'
+    - not line_item.sap_file_type is search('saphana')
 
 - name: SAP Install Media Detect - Organize all files - Remove temp dir - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
   ansible.builtin.file:


### PR DESCRIPTION
Solves issue #470 - found no deviation for any SAPCAR file which are to be extracted, with the exception of the SAP ASE client which now is handled properly by the role.
I also added two comments which explain why we handle SAPCAR file extraction differently for different types of SAPCAR files.