### PR TITLE
sap_ha_pacemaker_cluster: improved ASCS/ERS check logic

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -160,9 +160,10 @@ Mandatory for the cluster setup on AWS EC2 instances.<br>
 
 ### sap_ha_pacemaker_cluster_aws_vip_update_rt
 
-- _Type:_ `list`
+- _Type:_ `string`
 
 List one more routing table IDs for managing Virtual IP failover through routing table changes.<br>
+Multiple routing tables must be defined as a comma-separated string (no spaces).<br>
 Mandatory for the VIP resource configuration in AWS EC2 environments.<br>
 
 ### sap_ha_pacemaker_cluster_cluster_name
@@ -346,7 +347,7 @@ Time difference needed between to primary time stamps, if a dual-primary situati
 If the time difference is less than the time gap, then the cluster holds one or both instances in a "WAITING" status.<br>
 This is to give an admin a chance to react on a failover. A failed former primary will be registered after the time difference is passed.<br>
 
-### sap_ha_pacemaker_cluster_hana_instance_number
+### sap_ha_pacemaker_cluster_hana_instance_nr
 
 - _Type:_ `string`
 

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -113,7 +113,8 @@ sap_ha_pacemaker_cluster_hacluster_user_password: "{{ ha_cluster_hacluster_passw
 ################################################################################
 
 sap_ha_pacemaker_cluster_hana_sid: "{{ sap_hana_sid | default('') }}"
-sap_ha_pacemaker_cluster_hana_instance_number: "{{ sap_hana_instance_number | default('') }}"
+# Keeping 'sap_ha_pacemaker_cluster_hana_instance_number' for the time being for backwards compatibility.
+sap_ha_pacemaker_cluster_hana_instance_nr: "{{ sap_ha_pacemaker_cluster_hana_instance_number | default(sap_hana_instance_number) | default('') }}"
 
 # Optional parameters to customize SAPHana resources
 # AUTOMATED_REGISTER
@@ -125,9 +126,9 @@ sap_ha_pacemaker_cluster_hana_prefer_site_takeover: true
 
 
 # SAP HANA - Resource IDs (names) as convenience parameters.
-sap_ha_pacemaker_cluster_hana_resource_name: "SAPHana_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_number }}"
+sap_ha_pacemaker_cluster_hana_resource_name: "SAPHana_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_hana_resource_clone_name: "{{ sap_ha_pacemaker_cluster_hana_resource_name }}-clone"
-sap_ha_pacemaker_cluster_hana_topology_resource_name: "SAPHanaTopology_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_number }}"
+sap_ha_pacemaker_cluster_hana_topology_resource_name: "SAPHanaTopology_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_hana_topology_resource_clone_name: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}-clone"
 
 
@@ -136,9 +137,9 @@ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name: "{{ sap_ha_pacemaker
 #
 # Mandatory: primary VIP address definition in HANA scale-up clusters
 sap_ha_pacemaker_cluster_vip_hana_primary_ip_address: ''
-sap_ha_pacemaker_cluster_vip_hana_primary_resource_name: "vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_number }}_primary"
+sap_ha_pacemaker_cluster_vip_hana_primary_resource_name: "vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary"
 sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address: ''
-sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name: "vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_number }}_readonly"
+sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name: "vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly"
 
 
 ################################################################################
@@ -273,7 +274,7 @@ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool: false
 ## Infrastructure Platform variables, shown here for visibility only and should not be given default values
 
 ## AWS platform, EC2 Virtual Servers
-# sap_ha_pacemaker_cluster_aws_vip_update_rt: []
+# sap_ha_pacemaker_cluster_aws_vip_update_rt
 # sap_ha_pacemaker_cluster_aws_access_key_id
 # sap_ha_pacemaker_cluster_aws_secret_access_key
 # sap_ha_pacemaker_cluster_aws_region

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -598,9 +598,9 @@ argument_specs:
       ##########################################################################
 
       sap_ha_pacemaker_cluster_aws_vip_update_rt:
-        type: list
         description:
           - List one more routing table IDs for managing Virtual IP failover through routing table changes.
+          - Multiple routing tables must be defined as a comma-separated string (no spaces).
           - Mandatory for the VIP resource configuration in AWS EC2 environments.
 
       sap_ha_pacemaker_cluster_aws_region:

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -265,7 +265,7 @@ argument_specs:
           - Inherits the value of `sap_hana_sid`, when defined.
           - Mandatory for SAP HANA cluster setups.
 
-      sap_ha_pacemaker_cluster_hana_instance_number:
+      sap_ha_pacemaker_cluster_hana_instance_nr:
         description:
           - The instance number of the SAP HANA database which this role will configure in the cluster.
           - Inherits the value of `sap_hana_instance_number`, when defined.

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -128,25 +128,25 @@
         loop_var: nwas_profile_item
         label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Check where ASCS is running"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ascs
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function GetProcessList
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 15
       changed_when: false
       failed_when: false
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Check where ERS is running"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function GetProcessList
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 15
       changed_when: false
       failed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 3
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ascs
       ansible.builtin.shell: |
@@ -155,7 +155,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 3
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
       ansible.builtin.shell: |
@@ -164,7 +164,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Run HA check for ASCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 3
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha
       ansible.builtin.shell: |
@@ -173,7 +173,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Run HA check for ERS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 3
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha
       ansible.builtin.shell: |
@@ -182,14 +182,14 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HA check results for ASCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 3
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ascs_ha.stdout }}
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HA check results for ERS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 3
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ers_ha.stdout }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_common.yml
@@ -30,7 +30,7 @@
             - name: SID
               value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_number }}"
+              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
       operations:
         - action: start
           attrs:
@@ -61,7 +61,7 @@
             - name: SID
               value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_number }}"
+              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
             - name: AUTOMATED_REGISTER
               value: "{{ sap_ha_pacemaker_cluster_hana_automated_register | string }}"
             - name: DUPLICATE_PRIMARY_TIMEOUT

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -53,19 +53,19 @@
   ansible.builtin.include_tasks:
     file: construct_vars_hana_common.yml
   when:
-    - "'hana' in sap_ha_pacemaker_cluster_host_type[0]"
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP HANA Scale-up"
   ansible.builtin.include_tasks:
     file: construct_vars_hana_scaleup.yml
   when:
-    - "'hana_scaleup' in sap_ha_pacemaker_cluster_host_type[0]"
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver common"
   ansible.builtin.include_tasks:
     file: construct_vars_nwas_common.yml
   when:
-    - "'nwas_abap' in sap_ha_pacemaker_cluster_host_type[0]"
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ABAP ASCS/ERS"
   ansible.builtin.include_tasks:

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_aws_ec2_vs.yml
@@ -62,7 +62,7 @@
             - name: interface
               value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
             - name: routing_table
-              value: "{{ sap_ha_pacemaker_cluster_aws_vip_update_rt | join(',') }}"
+              value: "{{ sap_ha_pacemaker_cluster_aws_vip_update_rt }}"
   when:
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - sap_ha_pacemaker_cluster_vip_method == 'aws_vpc_move_ip'

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_msazure_vm.yml
@@ -29,7 +29,7 @@
 
 - name: "SAP HA Prepare Pacemaker - azure_lb resource agent - Define load balancer port for health check when SAP HANA scale-up HA"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_lb_port: "626{{ sap_ha_pacemaker_cluster_hana_instance_number }}"
+    __sap_ha_pacemaker_cluster_resource_lb_port: "626{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
   when: "'hana_scaleup' in sap_ha_pacemaker_cluster_host_type[0]" # REPLACE with substring in any of the strings contained in the list
 
 - name: "SAP HA Prepare Pacemaker - azure_lb resource agent - Add resource: Azure Load Balancer (NLB L-4) for VIP routing when SAP HANA scale-up HA"

--- a/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
@@ -15,18 +15,18 @@
   ansible.builtin.assert:
     that:
       - (
-          sap_ha_pacemaker_cluster_hana_instance_number | type_debug != 'int'
-          and sap_ha_pacemaker_cluster_hana_instance_number | length == 2
+          sap_ha_pacemaker_cluster_hana_instance_nr | type_debug != 'int'
+          and sap_ha_pacemaker_cluster_hana_instance_nr | length == 2
         )
         or
         (
-          sap_ha_pacemaker_cluster_hana_instance_number | type_debug == 'int'
-          and sap_ha_pacemaker_cluster_hana_instance_number is regex("^[0-9][0-9]$")
+          sap_ha_pacemaker_cluster_hana_instance_nr | type_debug == 'int'
+          and sap_ha_pacemaker_cluster_hana_instance_nr is regex("^[0-9][0-9]$")
         )
     fail_msg: |
 
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Requires 'sap_ha_pacemaker_cluster_hana_instance_number' to be defined.
+      Requires 'sap_ha_pacemaker_cluster_hana_instance_nr' to be defined.
 
       The instance number must be exactly 2 digits.
       Add quotes if the number starts with a 0!


### PR DESCRIPTION
- using `WaitforStarted` to allow instances to finish starting up
- type change: `sap_ha_pacemaker_cluster_aws_vip_update_rt` must be a string, not a list
- improved and aligned search conditionals