### PR TITLE
sap_swpm: variable corrections

### DIFF
--- a/playbooks/vars/sample-variables-sap-swpm-advanced-mode-s4hana-onehost-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-advanced-mode-s4hana-onehost-install.yml
@@ -10,12 +10,14 @@ sap_install_media_detect_kernel: true
 sap_install_media_detect_webdisp: false
 sap_install_media_detect_db: "saphana"
 
+# Manual set critical software paths
+# sap_swpm_sapcar_path: /software/sapcar
+# sap_swpm_swpm_path: /software/sap_swpm
+# sap_swpm_software_path: /software/sap_download_basket
 
 # NOTE: Values in Dictionary Keys for instance numbers must be string using '01' single quote, otherwise SAP SWPM will crash
 
 sap_swpm_ansible_role_mode: "advanced"
-sap_swpm_sapcar_path: /software/sap_downloads
-sap_swpm_swpm_path: /software/sap_downloads
 
 sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
 

--- a/playbooks/vars/sample-variables-sap-swpm-advanced-templates-mode.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-advanced-templates-mode.yml
@@ -11,8 +11,14 @@ sap_install_media_detect_source: local_dir
 #sap_install_media_detect_webdisp: false
 #sap_install_media_detect_db: "saphana"
 
+# Manual set critical software paths
+# sap_swpm_sapcar_path: /software/sapcar
+# sap_swpm_swpm_path: /software/sap_swpm
+# sap_swpm_software_path: /software/sap_download_basket
 
 # NOTE: Values in Dictionary Keys for instance numbers must be string using '01' single quote, otherwise SAP SWPM will crash
+
+sap_swpm_ansible_role_mode: advanced_templates
 
 sap_swpm_templates_install_dictionary:
 

--- a/roles/sap_swpm/tasks/swpm/detect_variables.yml
+++ b/roles/sap_swpm/tasks/swpm/detect_variables.yml
@@ -8,11 +8,13 @@
       END{print product_id}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_product_id_detect
   changed_when: false
+  when: not sap_swpm_product_catalog_id is defined
 
 # Set fact for product id
 - name: SAP SWPM - Set SAP product ID
   ansible.builtin.set_fact:
     sap_swpm_product_catalog_id: "{{ sap_swpm_inifile_product_id_detect.stdout }}"
+  when: not sap_swpm_product_catalog_id is defined
 
 - name: SAP SWPM - Display SAP product ID
   ansible.builtin.debug:
@@ -25,11 +27,13 @@
     awk '!/^#/&&/archives.downloadBasket/{print $3}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_software_path
   changed_when: false
+  when: not sap_swpm_software_path is defined
 
 # Set fact for software path
 - name: SAP SWPM - Set Software Path
   ansible.builtin.set_fact:
     sap_swpm_software_path: "{{ sap_swpm_inifile_software_path.stdout }}"
+  when: not sap_swpm_software_path is defined
 
 - name: SAP SWPM - Display Software Path
   ansible.builtin.debug:
@@ -42,11 +46,13 @@
     awk '!/^#/&&/NW_GetSidNoProfiles.sid/{print $3}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_sid
   changed_when: false
+  when: not sap_swpm_sid is defined
 
 # Set fact for SID
 - name: SAP SWPM - Set SID
   ansible.builtin.set_fact:
     sap_swpm_sid: "{{ sap_swpm_inifile_sid.stdout }}"
+  when: not sap_swpm_sid is defined
 
 - name: SAP SWPM - Display SAP SID
   ansible.builtin.debug:
@@ -59,11 +65,13 @@
     awk '!/^#/&&/NW_getFQDN.FQDN/{print $3}' {{ sap_swpm_tmpdir.path }}/inifile.params
   register: sap_swpm_inifile_fqdn
   changed_when: false
+  when: not sap_swpm_fqdn is defined
 
 # Set fact for FQDN
 - name: SAP SWPM - Set FQDN
   ansible.builtin.set_fact:
     sap_swpm_fqdn: "{{ sap_swpm_inifile_fqdn.stdout }}"
+  when: not sap_swpm_fqdn is defined
 
 - name: SAP SWPM - Display FQDN
   ansible.builtin.debug:

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -101,6 +101,7 @@
   register: sap_swpm_swpm_sar_file_name_stat
   failed_when: not sap_swpm_swpm_sar_file_name_stat.stat.exists
 
+
 - name: SAP SWPM Pre Install - Full SAP System
   when: not sap_swpm_generic | bool
   block:

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced.yml
@@ -2,16 +2,18 @@
 
 # Remove Existing inifile.params
 - name: SAP SWPM advanced mode - Ensure 'inifile.params' exists
-  ansible.builtin.file:
-    path: "{{ sap_swpm_tmpdir.path }}/inifile.params"
-    state: touch
+  ansible.builtin.copy:
+    dest: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     mode: '0640'
+    content: |
+      ### inifile.params generated for SWPM Catalog Product ID is {{ sap_swpm_product_catalog_id }}
   tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM advanced mode - Loop over the dictionary and output to file
   ansible.builtin.lineinfile:
     path: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     state: present
+    insertafter: EOF
     line: "{{ item.key }} = {{ item.value }}"
   with_dict: "{{ sap_swpm_inifile_custom_values_dictionary }}"
   tags: sap_swpm_generate_inifile
@@ -26,6 +28,7 @@
       tags: sap_swpm_generate_inifile
   tags: sap_swpm_generate_inifile
 
+# Requires variables - sap_swpm_software_path (e.g. /software/download_basket), sap_swpm_sapcar_path (e.g. /software/sapcar), sap_swpm_swpm_path (e.g. /software/swpm)
 # Prepare Software
 - name: SAP SWPM advanced mode - Prepare Software
   ansible.builtin.include_tasks: prepare_software.yml

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced_templates.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_advanced_templates.yml
@@ -15,10 +15,11 @@
 
 # Remove Existing inifile.params
 - name: SAP SWPM advanced_templates mode - Ensure 'inifile.params' exists
-  ansible.builtin.file:
-    path: "{{ sap_swpm_tmpdir.path }}/inifile.params"
-    state: touch
+  ansible.builtin.copy:
+    dest: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     mode: '0640'
+    content: |
+      ### inifile.params generated for SWPM Catalog Product ID is {{ sap_swpm_product_catalog_id }}
   tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM advanced_templates mode - Loop over the dictionary and output to file
@@ -26,7 +27,7 @@
     path: "{{ sap_swpm_tmpdir.path }}/inifile.params"
     state: present
     insertafter: EOF
-    line: "{{ item.key }}={{ item.value }}"
+    line: "{{ item.key }} = {{ item.value }}"
   with_dict: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_custom_values_dictionary'] }}"
   tags: sap_swpm_generate_inifile
 
@@ -41,6 +42,7 @@
       tags: sap_swpm_generate_inifile
   tags: sap_swpm_generate_inifile
 
+# Requires variables - sap_swpm_software_path (e.g. /software/download_basket), sap_swpm_sapcar_path (e.g. /software/sapcar), sap_swpm_swpm_path (e.g. /software/swpm)
 # Prepare Software
 - name: SAP SWPM advanced_templates mode - Prepare Software
   ansible.builtin.include_tasks: prepare_software.yml

--- a/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_inifile_reuse.yml
+++ b/roles/sap_swpm/tasks/swpm/swpm_inifile_generate_inifile_reuse.yml
@@ -32,6 +32,7 @@
       tags: sap_swpm_generate_inifile
   tags: sap_swpm_generate_inifile
 
+# Requires variables - sap_swpm_software_path (e.g. /software/download_basket), sap_swpm_sapcar_path (e.g. /software/sapcar), sap_swpm_swpm_path (e.g. /software/swpm)
 # Prepare Software
 - name: SAP SWPM inifile_reuse mode - Prepare Software
   ansible.builtin.include_tasks: prepare_software.yml

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -283,6 +283,7 @@ NW_ABAP_Import_Dialog.migmonJobNum = 3
 NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast LOAD:COMPRESS_ALL:DEF_CRT
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
+NW_getUnicode.isUnicode = true
 # db6.useMcod = true
 # db6.useBluSettings = false
 db6.allowUnsignedDatabaseSoftware = true

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -183,6 +183,7 @@ storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
 # credentials_anydb_ibmdb2
 ######
 nwUsers.db6.db2sidPassword = {{ sap_swpm_sap_sidadm_password }}
+# nwUsers.db6.db2sidUid =
 {% endif %}
 
 {% if 'credentials_anydb_oracledb' in sap_swpm_inifile_list %}
@@ -293,6 +294,10 @@ NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 NW_getUnicode.isUnicode = true
 # db6.useMcod = true
 # db6.useBluSettings = false
+# db6.gid_sysadm =
+# db6.gid_sysctrl =
+# db6.gid_sysmaint =
+# db6.gid_sysmon =
 db6.allowUnsignedDatabaseSoftware = true
 db6.cluster.ClusterType = HADR (High Availability Disaster Recovery)
 db6.createTablespacesUsingSapinst = true
@@ -302,7 +307,6 @@ db6.useAutoStorage = true
 db6.useExtraSapdataSaptmpDirLayout = false
 db6.UseStandardTablespacePool = true
 db6.usesLDAP = false
-# nwUsers.db6.db2sidUid =
 storageBasedCopy.db6.CommunicationPortNumber = 5912
 storageBasedCopy.db6.PortRangeEnd = 5917
 storageBasedCopy.db6.PortRangeStart = 5914
@@ -446,12 +450,17 @@ NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 # db_connection_nw_anydb_ibmdb2
 ######
 # db6.UseDb2SSLClientServerComm = false
-# nwUsers.db6.sapsidUid =
 nwUsers.db6.sapsidPassword = {{ sap_swpm_sapadm_password }}
+# nwUsers.db6.sapsidUid =
+
+# nwUsers.db6.sapsiddbPassword =
+# nwUsers.db6.sapsiddbUid =
 
 # Database Schema and Database Connect User for ABAP (default is sap<sapsid> and not sap<anydbsid>)
 NW_DB6_DB.db6.abap.connect.user = sap{{ sap_swpm_sid | lower }}
 NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_sid | lower }}
+# NW_DB6_DB.db6.java.connect.user =
+# NW_DB6_DB.db6.java.schema =
 {% endif %}
 
 {% if 'db_connection_nw_anydb_oracledb' in sap_swpm_inifile_list %}
@@ -836,4 +845,70 @@ InitDeclusteringForImport.decluster = false
 # DiagnosticsAgent.SolMan.PortNumber
 # DiagnosticsAgent.SolMan.UserName
 # DiagnosticsAgent.SolMan.UseSSL
+{% endif %}
+
+
+{% if 'solman_daa_swpm1' in sap_swpm_inifile_list %}
+######
+# syscopy_anydb
+# Not in use by sap_swpm Ansible Role
+######
+# InitDeclusteringForExport.decluster =
+# NW_ABAP_Export_Dialog.customPackageOrder =
+# NW_ABAP_Export_Dialog.customSortOrderFile =
+# NW_ABAP_Export_Dialog.exportTimeFile =
+# NW_ABAP_Export_Dialog.importTimeFile =
+# NW_ABAP_Export_Dialog.jobNumberGroupLarge = 7
+# NW_ABAP_Export_Dialog.jobNumberGroupSmall = 4
+# NW_ABAP_Export_Dialog.migmonComHost =
+# NW_ABAP_Export_Dialog.migmonComPort =
+# NW_ABAP_Export_Dialog.migmonComType = EXCHANGE
+# NW_ABAP_Export_Dialog.migmonDataTransferType = NET
+# NW_ABAP_Export_Dialog.migmonFtpExchangeDir =
+# NW_ABAP_Export_Dialog.migmonFtpExportDir =
+# NW_ABAP_Export_Dialog.migmonFtpHost =
+# NW_ABAP_Export_Dialog.migmonFtpPassword =
+# NW_ABAP_Export_Dialog.migmonFtpUser =
+NW_ABAP_Export_Dialog.migmonJobNum = 3
+NW_ABAP_Export_Dialog.migmonLoadArgs = -stop_on_error
+# NW_ABAP_Export_Dialog.migmonNetExchangeDir =
+# NW_ABAP_Export_Dialog.migmonTaskArgs =
+# NW_ABAP_Export_Dialog.nonStandardAbapObjectsHandlingSkip = false
+NW_ABAP_Export_Dialog.parallelR3szchkExecution = true
+NW_ABAP_Export_Dialog.r3szchkDetermineSizeValue = DB
+# NW_ABAP_Export_Dialog.r3szchkJobNum = 10
+# NW_ABAP_Export_Dialog.repeatExport = COMPLETE
+NW_ABAP_Export_Dialog.splitPackageLimitVal = 5000
+# NW_ABAP_Export_Dialog.splitMaxTableNumVal = 1000
+# NW_ABAP_Export_Dialog.splitTableFile =
+# NW_ABAP_Export_Dialog.splitTableLimitVal = 300
+# NW_ABAP_Export_Dialog.splitTableNumVal = 10
+# NW_ABAP_Export_Dialog.splitUseMaxTableNum = false
+# NW_ABAP_Export_Dialog.splitUsePackageLimit = true
+# NW_ABAP_Export_Dialog.splitUseTableFile = false
+# NW_ABAP_Export_Dialog.splitUseTableLimit = false
+# NW_ABAP_Export_Dialog.splitUseTableNum = true
+# NW_ABAP_Export_Dialog.sqlFileDir =
+NW_ABAP_Export_Dialog.targetHardwarePlatform = LITTLE_ENDIAN
+
+## Target database types for Linux are ADA, HDB, DB6, ORA, SYB
+NW_ABAP_Export_Dialog.targetDbType = {{ sap_swpm_export_target_db_type }}
+
+# NW_ABAP_Export_Dialog.useAdditionalExportHosts = false
+# NW_ABAP_Export_Dialog.useAdvancedUnloadConfig = false
+# NW_ABAP_Export_Dialog.useCustomPackageOrder = false
+# NW_ABAP_Export_Dialog.useCustomSortOrder = false
+# NW_ABAP_Export_Dialog.useMigMonConfig = false
+# NW_ABAP_Export_Dialog.useParallelExportImport = false
+# NW_ABAP_Export_Dialog.useSplit = true
+NW_ABAP_Export_Dialog.useSqlFiles = NOSQL
+# NW_ABAP_Export_Dialog.useUnicodeTargetSystem =
+NW_ABAP_Export_Dialog.useUnsortedUnload = true
+# NW_Export.accessLevel4ExportDir = DEFAULT
+# NW_Export.choiceSepKernel = false
+NW_Export.mainExportDir = {{ sap_swpm_export_files_path }}
+
+# Stop SAP System automatically before data is unloaded
+# NW_getLoadType.importManuallyExecuted: false
+NW_Export.stopRunningSystem = false
 {% endif %}

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -908,9 +908,10 @@ NW_ABAP_Export_Dialog.useUnsortedUnload = true
 # NW_Export.choiceSepKernel = false
 NW_Export.mainExportDir = {{ sap_swpm_export_files_path }}
 
-# Stop SAP System automatically before data is unloaded
+# Stop SAP System automatically before data is unloaded, not performing stop or manually importing
+# is not possible with SAP SWPM Unattended Mode and will fail on step mainExportParameters
 # NW_getLoadType.importManuallyExecuted: false
-NW_Export.stopRunningSystem = false
+NW_Export.stopRunningSystem = true
 {% endif %}
 
 {% if 'syscopy_import_anydb_ibmdb2' in sap_swpm_inifile_list %}

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -848,9 +848,9 @@ InitDeclusteringForImport.decluster = false
 {% endif %}
 
 
-{% if 'solman_daa_swpm1' in sap_swpm_inifile_list %}
+{% if 'syscopy_export_anydb' in sap_swpm_inifile_list %}
 ######
-# syscopy_anydb
+# syscopy_export_anydb
 # Not in use by sap_swpm Ansible Role
 ######
 # InitDeclusteringForExport.decluster =
@@ -911,4 +911,31 @@ NW_Export.mainExportDir = {{ sap_swpm_export_files_path }}
 # Stop SAP System automatically before data is unloaded
 # NW_getLoadType.importManuallyExecuted: false
 NW_Export.stopRunningSystem = false
+{% endif %}
+
+{% if 'syscopy_import_anydb_ibmdb2' in sap_swpm_inifile_list %}
+######
+# syscopy_import_anydb_ibmdb2
+# Not in use by sap_swpm Ansible Role
+######
+db6.usingSystemCopyBRforHADR = true
+# db6.Additional_DbServer =
+# db6.cluster.HADRPort1 =
+# db6.cluster.HADRPort2 =
+# db6.cluster.SyncMode =
+# db6.ConfigureCluster = false
+# db6.DropSchemaList =
+# db6.InstallPureScale = false
+# db6.InstallTSA = false
+# db6.minimizeDatabaseSizeCompression =
+# db6.minimizeDatabaseSizeCompressionJava =
+# db6.minimizeDatabaseSizeDeferredTable = true
+# db6.notuseMcod =
+# db6.NumAdditionalPartitions =
+# db6.useDB2ControlFiles = false
+# db6.UseDb2NativeEncryption = false
+# NW_adaptProfile.templateFiles =
+# NW_CreateDBandLoad.movePVCforUsagePiAndDi =
+# NW_getLoadType.importManuallyExecuted = false
+# storageBasedCopy.db6.db6updatedbpath =
 {% endif %}

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -164,8 +164,6 @@ NW_GetMasterPassword.masterPwd = {{ sap_swpm_master_password }}
 # '<sapsid>adm' user
 nwUsers.sidadmPassword = {{ sap_swpm_sap_sidadm_password }}
 
-NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}
-
 DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
 
 # 'sapadm' user of the SAP Host Agent
@@ -250,6 +248,16 @@ HDB_Userstore.useABAPSSFS = false
 # NW_HDB_DBClient.clientPathStrategy = LOCAL
 {% endif %}
 
+{% if 'credentials_syscopy' in sap_swpm_inifile_list %}
+######
+# credentials_syscopy
+######
+# Are the passwords for the DDIC users different from the default value?
+NW_DDIC_Password.needDDICPasswords = true
+NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}
+#NW_DDIC_Password.ddic001Password =
+{% endif %}
+
 {% if 'db_config_hana' in sap_swpm_inifile_list %}
 ######
 # db_config_hana
@@ -272,7 +280,6 @@ HDB_Schema_Check_Dialogs.validateSchemaName = false
 # db_config_anydb_all
 ######
 NW_ABAP_Import_Dialog.dbCodepage = 4103
-NW_DDIC_Password.needDDICPasswords = true
 {% endif %}
 
 {% if 'db_config_anydb_ibmdb2' in sap_swpm_inifile_list %}
@@ -441,8 +448,10 @@ NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 # db6.UseDb2SSLClientServerComm = false
 # nwUsers.db6.sapsidUid =
 nwUsers.db6.sapsidPassword = {{ sap_swpm_sapadm_password }}
-NW_DB6_DB.db6.abap.connect.user = sap{{ sap_swpm_db_sid | lower }}
-NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_db_sid | lower }}
+
+# Database Schema and Database Connect User for ABAP (default is sap<sapsid> and not sap<anydbsid>)
+NW_DB6_DB.db6.abap.connect.user = sap{{ sap_swpm_sid | lower }}
+NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_sid | lower }}
 {% endif %}
 
 {% if 'db_connection_nw_anydb_oracledb' in sap_swpm_inifile_list %}
@@ -698,17 +707,29 @@ NW_CI_Instance_ABAP_Reports.enableActivateICFService = true
 # SAP INTERNAL USE ONLY
 # NW_CI_Instance_ABAP_Reports.enableTransportsWithoutStackXml = false
 
-# Specify new password of the DDIC user in client 000, different from Master Password
-# NW_CI_Instance_ABAP_Reports.ddic000Password =
-
 # Need specific new password of the DDIC user in client 000, different from Master Password
 # NW_CI_Instance_ABAP_Reports.needNewDDIC000Password = false
+
+# Need specific new password of the DDIC user in client 001, different from Master Password
+# NW_CI_Instance_ABAP_Reports.needNewDDIC001Password = false
 
 # Need specific new password of the SAP* user in client 000, different from Master Password
 # NW_CI_Instance_ABAP_Reports.needNewSapStar000Password = false
 
+# Need specific new password of the SAP* user in client 001, different from Master Password
+# NW_CI_Instance_ABAP_Reports.needNewSapStar001Password = false
+
+# Specify new password of the DDIC user in client 000, different from Master Password
+# NW_CI_Instance_ABAP_Reports.ddic000Password =
+
+# Specify new password of the DDIC user in client 001, different from Master Password
+# NW_CI_Instance_ABAP_Reports.ddic001Password =
+
 # Specify new password of the SAP* user in client 000, different from Master Password
 # NW_CI_Instance_ABAP_Reports.sapStar000Password =
+
+# Specify new password of the SAP* user in client 001, different from Master Password
+# NW_CI_Instance_ABAP_Reports.sapStar001Password =
 {% endif %}
 
 {% if 'nw_config_livecache' in sap_swpm_inifile_list %}

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -877,7 +877,7 @@ NW_ABAP_Export_Dialog.migmonLoadArgs = -stop_on_error
 NW_ABAP_Export_Dialog.parallelR3szchkExecution = true
 NW_ABAP_Export_Dialog.r3szchkDetermineSizeValue = DB
 # NW_ABAP_Export_Dialog.r3szchkJobNum = 10
-# NW_ABAP_Export_Dialog.repeatExport = COMPLETE
+NW_ABAP_Export_Dialog.repeatExport = COMPLETE
 NW_ABAP_Export_Dialog.splitPackageLimitVal = 5000
 # NW_ABAP_Export_Dialog.splitMaxTableNumVal = 1000
 # NW_ABAP_Export_Dialog.splitTableFile =
@@ -904,22 +904,28 @@ NW_ABAP_Export_Dialog.targetDbType = {{ sap_swpm_export_target_db_type }}
 NW_ABAP_Export_Dialog.useSqlFiles = NOSQL
 # NW_ABAP_Export_Dialog.useUnicodeTargetSystem =
 NW_ABAP_Export_Dialog.useUnsortedUnload = true
-# NW_Export.accessLevel4ExportDir = DEFAULT
-# NW_Export.choiceSepKernel = false
+
+NW_Export.accessLevel4ExportDir = DEFAULT
+NW_Export.choiceSepKernel = false
 NW_Export.mainExportDir = {{ sap_swpm_export_files_path }}
 
-# Stop SAP System automatically before data is unloaded, not performing stop or manually importing
-# is not possible with SAP SWPM Unattended Mode and will fail on step mainExportParameters
-# NW_getLoadType.importManuallyExecuted: false
+# Do not stop SAP System before data is unloaded
+# SAP SWPM is unable to automatically stop the SAP System (i.e. DB, ASCS, PAS instances),
+# if stop is true then SAP SWPM Unattended will fail on step mainExportParameters
 NW_Export.stopRunningSystem = true
+
+NW_readProfileDir.profileDir = /sapmnt/{{ sap_swpm_sid | upper }}/profile
+
+NW_getLoadType.loadType = {{ sap_swpm_load_type }}
+NW_getLoadType.importManuallyExecuted = false
 {% endif %}
+
 
 {% if 'syscopy_import_anydb_ibmdb2' in sap_swpm_inifile_list %}
 ######
 # syscopy_import_anydb_ibmdb2
 # Not in use by sap_swpm Ansible Role
 ######
-db6.usingSystemCopyBRforHADR = true
 # db6.Additional_DbServer =
 # db6.cluster.HADRPort1 =
 # db6.cluster.HADRPort2 =
@@ -937,6 +943,17 @@ db6.usingSystemCopyBRforHADR = true
 # db6.UseDb2NativeEncryption = false
 # NW_adaptProfile.templateFiles =
 # NW_CreateDBandLoad.movePVCforUsagePiAndDi =
-# NW_getLoadType.importManuallyExecuted = false
+db6.allowUnsignedDatabaseSoftware = true
+db6.cluster.ClusterType = HADR (High Availability Disaster Recovery)
+db6.usingSystemCopyBRforHADR = true
+NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
+NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
+NW_getLoadType.loadType = {{ sap_swpm_load_type }}
+NW_getLoadType.importManuallyExecuted = false
+NW_getUnicode.isUnicode = true
+# NW_getDBInfoGeneric.strictDbSidCheck = true
+storageBasedCopy.db6.CommunicationPortNumber = 5912
+storageBasedCopy.db6.PortRangeEnd = 5917
+storageBasedCopy.db6.PortRangeStart = 5914
 # storageBasedCopy.db6.db6updatedbpath =
 {% endif %}


### PR DESCRIPTION
### sap_swpm: fix ibmdb2 unicode enforce

By default `#NW_getUnicode.isUnicode =` exists in inifile.params output, and defaults to true. In certain IBM Db2 executions, the automatic detection does not work and requires `NW_getUnicode.isUnicode = true` contained in the inifile.params. This value should already be true except for legacy NUC install files, which are no longer provided by SAP, therefore appending this into the default inifile block for IBM Db2 installations.


### sap_swpm: improve var handling for advanced exec

When executing advanced or inifile reuse, variable detection can fail. Added improved handling and consistent output (i.e. header of inifile.params).


### sap_swpm: improve vars for System Copy and Export activities

For future, appended System Copy and Export variables to Jinja template as reference, and fixed DDIC password parameter which was in the incorrect section and could lead to SAP ECC Installation Export file failure to import to the target SAP AnyDB.


### sap_swpm: fix IBM Db2 incorrect var population

Database Schema and Database Connect User for ABAP is default `sap<sapsid>` but previous code incorrectly used `sap<anydbsid>`.
