### PR TITLE
sap_hana_preconfigure: Be less restrictive with new RHEL versions

### DIFF
--- a/roles/sap_hana_preconfigure/README.md
+++ b/roles/sap_hana_preconfigure/README.md
@@ -159,10 +159,11 @@ For the RHEL System Roles for SAP, or for Red Hat Automation Hub, use 'redhat.rh
 
 ### sap_hana_preconfigure_min_rhel_release_check
 - _Type:_ `bool`
-- _Default:_ `true`
+- _Default:_ `false`
 
-Check the RHEL release against a predefined list of known SAP HANA supported RHEL minor releases.<br>
-If this parameter is set to `false`, the role will *not* perform this check.<br>
+Check the RHEL release against parameter `sap_hana_preconfigure_supported_rhel_minor_releases`, which is a list of<br>
+known SAP HANA supported RHEL minor releases. By default, the role will display a message and continue running if<br>
+the RHEL release is not part of that list. If set to `true`, the role will fail in such a case.<br>
 
 ### sap_hana_preconfigure_supported_rhel_minor_releases
 - _Type:_ `list` with elements of type `str`

--- a/roles/sap_hana_preconfigure/defaults/main.yml
+++ b/roles/sap_hana_preconfigure/defaults/main.yml
@@ -34,9 +34,10 @@ sap_hana_preconfigure_system_roles_collection: 'fedora.linux_system_roles'
 # - fedora.linux_system_roles
 # - redhat.rhel_system_roles
 
-sap_hana_preconfigure_min_rhel_release_check: true
-# Check the RHEL release against a predefined list of known SAP HANA supported RHEL minor releases.
-# If this parameter is set to `false`, the role will *not* perform this check.
+sap_hana_preconfigure_min_rhel_release_check: false
+# Check the RHEL release against parameter `sap_hana_preconfigure_supported_rhel_minor_releases`, which is a list of
+# known SAP HANA supported RHEL minor releases. By default, the role will display a message and continue running if
+# the RHEL release is not part of that list. If set to `true`, the role will fail in such a case.
 
 sap_hana_preconfigure_supported_rhel_minor_releases: "{{ __sap_hana_preconfigure_supported_rhel_minor_releases }}"
 # Use this parameter to set your own list of SAP HANA supported RHEL minor releases.

--- a/roles/sap_hana_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_hana_preconfigure/meta/argument_specs.yml
@@ -83,10 +83,11 @@ argument_specs:
         type: str
 
       sap_hana_preconfigure_min_rhel_release_check:
-        default: true
+        default: false
         description:
-          - Check the RHEL release against a predefined list of known SAP HANA supported RHEL minor releases.
-          - If this parameter is set to `false`, the role will *not* perform this check.
+          - Check the RHEL release against parameter `sap_hana_preconfigure_supported_rhel_minor_releases`, which is a list of
+          - known SAP HANA supported RHEL minor releases. By default, the role will display a message and continue running if
+          - the RHEL release is not part of that list. If set to `true`, the role will fail in such a case.
         required: false
         type: bool
 

--- a/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
@@ -4,10 +4,12 @@
   ansible.builtin.setup:
     gather_subset: distribution_version
 
-- name: Ensure that the system is running a RHEL release which is supported for SAP HANA
+- name: Report if the system is running a RHEL release which is supported for SAP HANA
   ansible.builtin.assert:
     that: ansible_distribution_version in "{{ sap_hana_preconfigure_supported_rhel_minor_releases }}"
-    fail_msg: "The RHEL release {{ ansible_distribution_version }} is not supported for SAP HANA!"
+    fail_msg:
+      - "The RHEL release {{ ansible_distribution_version }} might not be supported for SAP HANA. Please check SAP note 2235581!"
+      - "If necessary, adapt role parameter `sap_hana_preconfigure_supported_rhel_minor_releases` accordingly."
     success_msg: "The RHEL release {{ ansible_distribution_version }} is supported for SAP HANA."
   ignore_errors: "{{ not sap_hana_preconfigure_min_rhel_release_check }}"
 


### PR DESCRIPTION
Let's not fail the role by default if the RHEL release is not contained in variable `sap_hana_preconfigure_supported_rhel_minor_releases`. Instead, display a failing assertion message but ignore the failure with the `ignore_errors` parameter, thus continue with the role.

Solves issue #500.