### PR TITLE
sap_ha_pacemaker_cluster: fix: bad var reference - issue #512

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_resources_default.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_resources_default.yml
@@ -16,5 +16,5 @@
             - name: nic
               value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
   when:
-    - __sap_ha_pacemaker_cluster_vip_resource_id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
+    - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - '"IPaddr2" in sap_ha_pacemaker_cluster_vip_resource_agent'


### PR DESCRIPTION
Fixes issue #512 - bad reference from previous VIP resource logic adjustments.