### PR TITLE
sap_install_media_detect: Leave non-role directories untouched

### DIFF
--- a/roles/sap_install_media_detect/files/tmp/sapfile
+++ b/roles/sap_install_media_detect/files/tmp/sapfile
@@ -18,7 +18,7 @@
 set -o nounset
 set -o pipefail
 
-usage () {
+usage() {
    echo "sapfile: Determine and display SAP file type. If unknown, call the file command."
    echo "Usage: sapfile [OPTION...] [FILE...]"
    echo "Determine and display type of SAP FILEs, optionally followed by additional information."
@@ -26,6 +26,7 @@ usage () {
    echo "  -H|--header                display a column header"
    echo "  -l|--long                  long listing: also display the file type, taken from the output of the file command"
    echo "  -e|--extra-long            extra long listing: display all information required by role sap_install_media_detect"
+   echo "  -s|--show-file-types       show all supported file types"
    echo "  --lsar_file=<FILE>         the name of the program to list the content of a RAR file, if different from 'lsar',"
    echo "                               either as the name of a file in one of the PATH directories or as an FQPN."
    echo "                               When specifying the 'unrar' program, it will be called with option 'lb'."
@@ -36,6 +37,11 @@ usage () {
    echo "- lsar (program to list the content of a RAR package, e.g. as part of the 'unar' package from the EPEL RHEL repo)"
    echo "- zipinfo (contained in the unzip RHEL package)"
    echo "- sapcar (SAP program to handle sapcar files; typical filename: SAPCAR_1115-70006178.EXE)"
+}
+
+show_file_types() {
+   awk '!/BEGIN/&&!/END/&&/_sap_file_type=/{gsub (" ", ""); gsub ("\\{_sap_file_type=\"", ": "); gsub ("\"\\}", ""); print $NF}' $0 | \
+     sort | uniq
 }
 
 # defaults:
@@ -53,7 +59,7 @@ if [[ ${#} == 0 ]]; then
    exit 1
 fi
 
-options=":leHh-:"
+options=":leHsh-:"
 while getopts "$options" opt; do
    case ${opt} in
       -)
@@ -63,6 +69,10 @@ while getopts "$options" opt; do
                ;;
             extra-long)
                _DISPLAY_ALL_INFO="y"
+               ;;
+            show-file-types)
+               show_file_types
+               exit 0
                ;;
             header)
                _DISPLAY_HEADER="y"
@@ -108,6 +118,10 @@ while getopts "$options" opt; do
          ;;
       e)
          _DISPLAY_ALL_INFO="y"
+         ;;
+      s)
+         show_file_types
+         exit 0
          ;;
       H)
          _DISPLAY_HEADER="y"

--- a/roles/sap_install_media_detect/tasks/prepare/move_files_to_main_directory.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/move_files_to_main_directory.yml
@@ -8,7 +8,9 @@
 # Reason for noqa: When using pipefail and there is no result from the grep -v, this tail will fail but it should never fail
 - name: SAP Install Media Detect - Prepare - Find the relevant non-extract subdirectories # noqa risky-shell-pipe
   ansible.builtin.shell:
-    cmd: ls -d sap_hana sap_swpm_download_basket $({{ __sap_install_media_detect_sapfile_path }} -s) 2>/dev/null | awk '{print ("'{{ __sap_install_media_detect_software_main_directory }}'/"$0"/")}'
+    cmd: >
+      ls -d sap_hana sap_swpm_download_basket $({{ __sap_install_media_detect_sapfile_path }} -s) 2>/dev/null |
+      awk '{print ("'{{ __sap_install_media_detect_software_main_directory }}'/"$0"/")}'
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   register: __sap_install_media_detect_register_subdirectories_phase_1b
   changed_when: false

--- a/roles/sap_install_media_detect/tasks/prepare/move_files_to_main_directory.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/move_files_to_main_directory.yml
@@ -6,11 +6,28 @@
 
 # If any files have been moved to non-extract subdirectories already, move them back to the top level, making the role idempotent
 # Reason for noqa: When using pipefail and there is no result from the grep -v, this tail will fail but it should never fail
-- name: SAP Install Media Detect - Prepare - Find existing non-extract subdirectories # noqa risky-shell-pipe
-  ansible.builtin.shell: ls -d {{ __sap_install_media_detect_software_main_directory }}/*/ | grep -v '_extracted'
+- name: SAP Install Media Detect - Prepare - Find the relevant non-extract subdirectories # noqa risky-shell-pipe
+  ansible.builtin.shell:
+    cmd: ls -d sap_hana sap_swpm_download_basket $({{ __sap_install_media_detect_sapfile_path }} -s) 2>/dev/null | awk '{print ("'{{ __sap_install_media_detect_software_main_directory }}'/"$0"/")}'
+    chdir: "{{ __sap_install_media_detect_software_main_directory }}"
   register: __sap_install_media_detect_register_subdirectories_phase_1b
   changed_when: false
   failed_when: false
+
+# Reason for noqa: When using pipefail and there is no result from the grep -v, this tail will fail but it should never fail
+- name: SAP Install Media Detect - Prepare - Find existing extract subdirectories # noqa risky-shell-pipe
+  ansible.builtin.shell: ls -d {{ __sap_install_media_detect_software_main_directory }}/*/ | grep '_extracted/$'
+  register: __sap_install_media_detect_register_subdirectories_phase_1b_extracted
+  changed_when: false
+  failed_when: false
+
+- name: SAP Install Media Detect - Prepare - Display the relevant non-extract subdirectories
+  ansible.builtin.debug:
+    var: __sap_install_media_detect_register_subdirectories_phase_1b.stdout_lines
+
+- name: SAP Install Media Detect - Prepare - Display existing extract subdirectories
+  ansible.builtin.debug:
+    var: __sap_install_media_detect_register_subdirectories_phase_1b_extracted.stdout_lines
 
 - name: SAP Install Media Detect - Prepare - Create list of all files one level below '{{ __sap_install_media_detect_software_main_directory }}'
   ansible.builtin.find:
@@ -38,10 +55,18 @@
   loop_control:
     loop_var: line_item
 
-- name: SAP Install Media Detect - Prepare - Remove the subdirectories
+- name: SAP Install Media Detect - Prepare - Remove the relevant non-extract subdirectories
   ansible.builtin.file:
     path: "{{ line_item }}"
     state: absent
   loop: "{{ __sap_install_media_detect_register_subdirectories_phase_1b.stdout_lines }}"
+  loop_control:
+    loop_var: line_item
+
+- name: SAP Install Media Detect - Prepare - Remove the extract subdirectories
+  ansible.builtin.file:
+    path: "{{ line_item }}"
+    state: absent
+  loop: "{{ __sap_install_media_detect_register_subdirectories_phase_1b_extracted.stdout_lines }}"
   loop_control:
     loop_var: line_item


### PR DESCRIPTION
At the beginning, we currently need to move files from lower level directories to the top level so that all SAP archive files are in the same directory and the role always starts file handling at the same status (future versions might support using also the desired file location in separate subdirectories).
We want the role to only move files from directories the role is able to create, and leave all other directories in place, including their contents. This is the purpose of this PR.
Solves issue #523 .