### PR TITLE
sap_install_media_detect: Handle missing SAPCAR

### DIFF
--- a/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_1.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_1.yml
@@ -35,6 +35,11 @@
     loop_var: line_item
   when: line_item is search("SAPCAR")
 
+- name: SAP Install Media Detect - Prepare - Assert the presence of SAPCAR
+  ansible.builtin.assert:
+    that: __sap_install_media_detect_fact_sapcar_path | d('') | length > 0
+    fail_msg: "There is no file with file name pattern '*SAPCAR*' in '{{ sap_install_media_detect_source_directory }}'."
+
 - name: SAP Install Media Detect - Prepare - Ensure sapcar is executable
   ansible.builtin.file:
     path: "{{ __sap_install_media_detect_fact_sapcar_path }}"


### PR DESCRIPTION
We add a task which asserts that a file with file name pattern `*SAPCAR*` has been found before. So the following task `SAP Install Media Detect - Prepare - Ensure sapcar is executable` will not failed because a variable has not been defined.

Solves #530.