### PR TITLE
sap_install_media_detect: Don't loop too much

### DIFF
--- a/roles/sap_install_media_detect/tasks/organize_files.yml
+++ b/roles/sap_install_media_detect/tasks/organize_files.yml
@@ -14,62 +14,43 @@
     label: "{{ line_item.file }}"
   when: sap_install_media_detect_source == 'remote_dir'
 
-- name: SAP Install Media Detect - Organize all files - Remove existing archive extraction directories
+- name: SAP Install Media Detect - Organize all files - Ensure archive extraction directories are absent
   ansible.builtin.file:
-    path: "{{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}"
+    path: "{{ line_item }}"
     state: absent
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ [__sap_install_media_detect_software_main_directory + '/'] | product(__sap_install_media_detect_fact_extraction_directories) | map('join') | list }}"
   loop_control:
     loop_var: line_item
-    label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.extract_archive == 'y'
-    - (line_item.archive_type == 'zip' or
-       line_item.archive_type == 'rarexe' or
-       line_item.archive_type == 'rar' or
-       line_item.archive_type == 'sapcar')
 
 - name: SAP Install Media Detect - Organize all files - Create archive extraction directories
   ansible.builtin.file:
-    path: "{{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}"
+    path: "{{ line_item }}"
     state: directory
     owner: root
     group: root
     mode: '0755'
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ [__sap_install_media_detect_software_main_directory + '/'] | product(__sap_install_media_detect_fact_extraction_directories) | map('join') | list }}"
   loop_control:
     loop_var: line_item
-    label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.extract_archive == 'y'
-    - (line_item.archive_type == 'zip' or
-       line_item.archive_type == 'rarexe' or
-       line_item.archive_type == 'rar' or
-       line_item.archive_type == 'sapcar')
 
-- name: SAP Install Media Detect - Organize all files - Create target directories for archive files
+- name: SAP Install Media Detect - Organize all files - Ensure target directories exist
   ansible.builtin.file:
-    path: "{{ __sap_install_media_detect_software_main_directory }}/{{ line_item.target_dir }}"
+    path: "{{ line_item }}"
     state: directory
     owner: root
     group: root
     mode: '0755'
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ [__sap_install_media_detect_software_main_directory + '/'] | product(__sap_install_media_detect_fact_target_directories) | map('join') | list }}"
   loop_control:
     loop_var: line_item
-    label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_move_or_copy_archives
-    - line_item.target_dir != 'auto'
-    - (line_item.archive_type == 'zip' or
-       line_item.archive_type == 'rarexe' or
-       line_item.archive_type == 'rar' or
-       line_item.archive_type == 'sapcar' or
-       line_item.archive_type == 'xml')
 
-- name: SAP Install Media Detect - Organize all files - Create SWPM target directories
+- name: SAP Install Media Detect - Organize all files - Ensure SWPM target directories exist
   ansible.builtin.file:
     path: "{{ line_item }}"
     state: directory
@@ -100,48 +81,43 @@
   ansible.builtin.shell: "set -o pipefail && unzip {{ line_item.file }} -d {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}/{{ (line_item.file | splitext)[0] }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results_extract_zip }}"
   loop_control:
     loop_var: line_item
     label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.archive_type == 'zip'
-    - line_item.extract_archive == 'y'
     - line_item.sap_file_type is search("export")
 
 - name: SAP Install Media Detect - Organize all files - Extract zip non-export archive files
   ansible.builtin.shell: "set -o pipefail && unzip {{ line_item.file }} -d {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results_extract_zip }}"
   loop_control:
     loop_var: line_item
     label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.archive_type == 'zip'
-    - line_item.extract_archive == 'y'
     - not line_item.sap_file_type is search("export")
 
-- name: SAP Install Media Detect - Organize all files - Extract rar archive files
+- name: SAP Install Media Detect - Organize all files - Extract rar self-extracting archive files
   ansible.builtin.shell: "set -o pipefail && {{ __sap_install_media_detect_rar_extract }} {{ line_item.file }}{{ __sap_install_media_detect_rar_extract_directory_argument }} {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}"
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results_extract_rarexe }}"
   loop_control:
     loop_var: line_item
     label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
     - line_item.archive_type == 'rarexe'
-    - line_item.extract_archive == 'y'
 
-# SAP HANA sapcar archive files have a directory structure with a single directory (e.g. SAP_HANA_DATBASE) which contains all files.
+# SAP HANA sapcar archive files have a directory structure with a single directory (e.g. SAP_HANA_DATABASE) which contains all files.
 # We want the extracted files to be placed in extraction_dir under this directory name, allowing multiple directories in extraction_dir.
 # So we create a temporary directory, move the file SIGNATURE.SMF (which the sapcar command extracts to the level above) to this directory,
 # and then move the single directory to the extraction_dir.
-- name: SAP Install Media Detect - Organize all files - Create temp dir for sapcar archive files - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
+- name: SAP Install Media Detect - Organize all files - Create temp dir for HANA archive files - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
   ansible.builtin.file:
     path: "{{ __sap_install_media_detect_software_main_directory }}/tmp_extract"
     state: directory
@@ -161,15 +137,12 @@
     && mv $extracted_dir {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}/
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}/tmp_extract"
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results_extract_sapcar_hana }}"
   loop_control:
     loop_var: line_item
     label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.extract_archive == 'y'
-    - line_item.archive_type == 'sapcar'
-    - line_item.sap_file_type is search('saphana')
 
 - name: SAP Install Media Detect - Organize all files - Remove temp dir - {{ __sap_install_media_detect_software_main_directory }}/tmp_extract
   ansible.builtin.file:
@@ -187,15 +160,12 @@
     -manifest SIGNATURE.SMF
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}/{{ line_item.extraction_dir }}"
-  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
+  loop: "{{ __sap_install_media_detect_fact_files_sapfile_results_extract_sapcar_nonhana }}"
   loop_control:
     loop_var: line_item
     label: "{{ line_item.file }}"
   when:
     - sap_install_media_detect_extract_archives
-    - line_item.extract_archive == 'y'
-    - line_item.archive_type == 'sapcar'
-    - not line_item.sap_file_type is search('saphana')
 
 - name: SAP Install Media Detect - Organize all files - Copy certain files to 'sap_hana' directory
   ansible.builtin.copy:
@@ -248,7 +218,7 @@
     - line_item.sap_file_type != 'saphana_client'
     - line_item.sap_file_type != 'sap_hostagent'
 
-- name: SAP Install Media Detect - Organize all files - Move archive files into subdirectories
+- name: SAP Install Media Detect - Organize all files - Move archive files into subdirectories if not already present
   ansible.builtin.shell: "set -o pipefail && mv {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.file }} {{ __sap_install_media_detect_software_main_directory }}/{{ line_item.target_dir }}/{{ line_item.file }}"
   loop: "{{ __sap_install_media_detect_fact_files_sapfile_results }}"
   loop_control:

--- a/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
@@ -89,6 +89,15 @@
     (sap_install_media_detect_export == 'sapecc' and item.stdout.split(';')[1] == 'sap_export_ecc') or
     (sap_install_media_detect_export == 'sapecc_ides' and item.stdout.split(';')[1] == 'sap_export_ecc_ides')
 
+- name: SAP Install Media Detect - Prepare - Set fact for subsets of the sapfile results
+  ansible.builtin.set_fact:
+    __sap_install_media_detect_fact_target_directories: "{{ __sap_install_media_detect_fact_files_sapfile_results | map(attribute='target_dir') | unique | reject('equalto', 'auto')}}"
+    __sap_install_media_detect_fact_extraction_directories: "{{ __sap_install_media_detect_fact_files_sapfile_results | map(attribute='extraction_dir') | unique | reject('equalto', 'none')}}"
+    __sap_install_media_detect_fact_files_sapfile_results_extract_zip: "{{ __sap_install_media_detect_fact_files_sapfile_results | selectattr('archive_type', 'search', 'zip') | selectattr('extract_archive', 'search', 'y') }}"
+    __sap_install_media_detect_fact_files_sapfile_results_extract_rarexe: "{{ __sap_install_media_detect_fact_files_sapfile_results | selectattr('archive_type', 'search', 'rarexe') | selectattr('extract_archive', 'search', 'y') }}"
+    __sap_install_media_detect_fact_files_sapfile_results_extract_sapcar_hana: "{{ __sap_install_media_detect_fact_files_sapfile_results | selectattr('archive_type', 'search', 'sapcar') | selectattr('extract_archive', 'search', 'y') | selectattr('sap_file_type', 'search', 'saphana') }}"
+    __sap_install_media_detect_fact_files_sapfile_results_extract_sapcar_nonhana: "{{ __sap_install_media_detect_fact_files_sapfile_results | selectattr('archive_type', 'search', 'sapcar') | selectattr('extract_archive', 'search', 'y') | rejectattr('sap_file_type', 'search', 'saphana') }}"
+
 - name: SAP Install Media Detect - Prepare - Asserts
   when:
     - sap_install_media_detect_assert_after_sapfile | d(true)

--- a/roles/sap_install_media_detect/tasks/prepare/provide_sapfile_utility.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/provide_sapfile_utility.yml
@@ -6,7 +6,7 @@
     suffix: media_detect
   register: __sap_install_media_detect_tmpdir
 
-- name: SAP Install Media Detect - Prepare - Copy file sapfile utility to '{{ __sap_install_media_detect_tmpdir.path }}'
+- name: SAP Install Media Detect - Prepare - Copy the sapfile utility to '{{ __sap_install_media_detect_tmpdir.path }}'
   ansible.builtin.copy:
     src: tmp/sapfile
     dest: "{{ __sap_install_media_detect_tmpdir.path }}/sapfile"
@@ -14,6 +14,6 @@
     group: root
     mode: '0755'
 
-- name: SAP Install Media Detect - Prepare - Set fact for sapfile utility
+- name: SAP Install Media Detect - Prepare - Set fact for the sapfile utility
   ansible.builtin.set_fact:
     __sap_install_media_detect_sapfile_path: "{{ __sap_install_media_detect_tmpdir.path }}/sapfile"


### PR DESCRIPTION
By defining variables for useful subsets of the sapfile results, we can use those variables for looping, thus limiting the output for several tasks significantly, especially in those cases where there are many SAP archive files in the software directory.

Solves issue #525.