### PR TITLE
collection: Enforce minimum ansible version 2.12

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_general_preconfigure/meta/runtime.yml
+++ b/roles/sap_general_preconfigure/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_ha_install_hana_hsr/meta/runtime.yml
+++ b/roles/sap_ha_install_hana_hsr/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_hana_install/meta/runtime.yml
+++ b/roles/sap_hana_install/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_hana_preconfigure/meta/runtime.yml
+++ b/roles/sap_hana_preconfigure/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_hostagent/meta/runtime.yml
+++ b/roles/sap_hostagent/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_install_media_detect/meta/runtime.yml
+++ b/roles/sap_install_media_detect/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_netweaver_preconfigure/meta/runtime.yml
+++ b/roles/sap_netweaver_preconfigure/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_storage_setup/meta/runtime.yml
+++ b/roles/sap_storage_setup/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/sap_swpm/meta/runtime.yml
+++ b/roles/sap_swpm/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'


### PR DESCRIPTION
Solves issue #507.

Note: We are using version 2.12 and not 2.14 to extend the range of possible control nodes to older releases (e.g. RHEL 8.6).