### PR TITLE
collection: Enforce minimum ansible version 2.12, part 2

### DIFF
--- a/roles/sap_anydb_install_oracle/meta/runtime.yml
+++ b/roles/sap_anydb_install_oracle/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.12.0'

--- a/roles/sap_ha_pacemaker_cluster/meta/runtime.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.12.0'

--- a/roles/sap_hypervisor_node_preconfigure/meta/runtime.yml
+++ b/roles/sap_hypervisor_node_preconfigure/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.12.0'

--- a/roles/sap_maintain_etc_hosts/meta/runtime.yml
+++ b/roles/sap_maintain_etc_hosts/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.12.0'

--- a/roles/sap_vm_preconfigure/meta/runtime.yml
+++ b/roles/sap_vm_preconfigure/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.12.0'


### PR DESCRIPTION
This commit adds the file `meta/runtime.yml` to all those roles for which it was missing:
- `sap_anydb_install_oracle`
- `sap_ha_pacemaker_cluster`
- `sap_hypervisor_node_preconfigure`
- `sap_maintain_etc_hosts`
- `sap_vm_preconfigure`


Finally solves issue #507.