### PR TITLE
sap_general_preconfigure: Cleanup for ansible-lint 6.22.0, part 1

### DIFF
--- a/roles/sap_general_preconfigure/handlers/main.yml
+++ b/roles/sap_general_preconfigure/handlers/main.yml
@@ -24,14 +24,17 @@
     - not sap_general_preconfigure_fail_if_reboot_required|d(true)
     - not sap_general_preconfigure_reboot_ok|d(false)
 
-# Reason for noqa: We want to avoid non-ansible.builtin modules where possible
-- name: Remount /dev/shm # noqa command-instead-of-module
+# Reasons for noqa:
+# - command-instead-of-module: We want to avoid non-ansible.builtin modules where possible
+# - no-changed-when: Remounting does not do any harm and does not affect idempotency.
+- name: Remount /dev/shm # noqa command-instead-of-module no-changed-when
   ansible.builtin.command: mount -o remount /dev/shm
   listen: __sap_general_preconfigure_mount_tmpfs_handler
 
 - name: Check if /dev/shm is available
   ansible.builtin.command: df -h /dev/shm
   register: __sap_general_preconfigure_command_df_shm_result
+  changed_when: false
   listen: __sap_general_preconfigure_mount_tmpfs_handler
 
 - name: Show the result of df -h /dev/shm

--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -181,7 +181,8 @@
     - sap_general_preconfigure_min_package_check|bool
     - __sap_general_preconfigure_min_pkgs | d([])
   block:
-    - name: Assert - Create a list of minimum required package versions to be installed
+# Reason for noqa: We can safely fail at the last command in the pipeline.
+    - name: Assert - Create a list of minimum required package versions to be installed # noqa risky-shell-pipe
 # How does it work?
 # 1 - Print the required package name and version with a prefix "1" followed by a space.
 # 2 - In the same output sequence, list all installed versions of this package with a prefix "2" followed by a space.

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-selinux.yml
@@ -39,6 +39,7 @@
 - name: SELinux - Call Reboot handler if necessary
   ansible.builtin.command: /bin/true
   notify: __sap_general_preconfigure_reboot_handler
+  changed_when: false
   when: __sap_general_preconfigure_fact_selinux_mode != sap_general_preconfigure_selinux_state
 
 - name: Set or unset SELinux kernel parameter, RHEL 8 and RHEL 9
@@ -50,7 +51,7 @@
   block:
 
     - name: SELinux - Examine grub entries
-      ansible.builtin.shell: grubby --info=ALL | awk 'BEGIN{a=0;b=0}/^args/{a++}/selinux=0/{b++}END{print a, b}'
+      ansible.builtin.shell: set -o pipefail && grubby --info=ALL | awk 'BEGIN{a=0;b=0}/^args/{a++}/selinux=0/{b++}END{print a, b}'
       register: __sap_general_preconfigure_register_grubby_info_all_selinux
       check_mode: no
       changed_when: false

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-tmpfs.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-tmpfs.yml
@@ -20,4 +20,5 @@
 - name: Trigger remounting if /dev/shm has not the expected size
   ansible.builtin.command: /bin/true
   notify: __sap_general_preconfigure_mount_tmpfs_handler
+  changed_when: false
   when: __sap_general_preconfigure_register_df_shm.stdout != sap_general_preconfigure_size_of_tmpfs_gb

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -97,7 +97,8 @@
     - sap_general_preconfigure_set_minor_release
     - __sap_general_preconfigure_register_subscription_manager_release.stdout == ansible_distribution_version
 
-- name: Set the minor RHEL release
+# Reason for noqa: Finding out if the minor release has already been set would require one more task.
+- name: Set the minor RHEL release # noqa no-changed-when
   ansible.builtin.command: subscription-manager release --set="{{ ansible_distribution_version }}"
   when:
     - sap_general_preconfigure_set_minor_release
@@ -113,7 +114,8 @@
 #       Because the installation of an environment or package group is not guaranteed to avoid package updates,
 #       and because of bug 2011426 (for which the fix is not available in the RHEL 8.1 ISO image), a RHEL 8.1
 #       system might not boot after installing environment group Server.
-- name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9 # noqa command-instead-of-module
+# Reason for noqa: Finding out if packages already are installed would require one more task.
+- name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9 # noqa command-instead-of-module no-changed-when
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
@@ -144,6 +146,7 @@
 
 - name: Accept the license for the IBM Service and Productivity Tools
   ansible.builtin.shell: LESS=+q /opt/ibm/lop/configure <<<'y'
+  changed_when: true
   when:
     - ansible_architecture == "ppc64le"
     - sap_general_preconfigure_install_ibm_power_tools | d(true)
@@ -164,7 +167,8 @@
     - __sap_general_preconfigure_min_pkgs | d([])
   block:
 
-    - name: Create a list of minimum required package versions to be installed
+# Reason for noqa: We can safely fail at the last command in the pipeline.
+    - name: Create a list of minimum required package versions to be installed  # noqa risky-shell-pipe
 # How does it work?
 # 1 - Print the required package name and version with a prefix "1" followed by a space.
 # 2 - In the same output sequence, list all installed versions of this package with a prefix "2" followed by a space.
@@ -275,4 +279,5 @@
 - name: Call Reboot handler if necessary
   ansible.builtin.command: /bin/true
   notify: __sap_general_preconfigure_reboot_handler
+  changed_when: false
   when: __sap_general_preconfigure_register_needs_restarting is failed

--- a/roles/sap_general_preconfigure/tests/sap_general_preconfigure-default-settings.yml
+++ b/roles/sap_general_preconfigure/tests/sap_general_preconfigure-default-settings.yml
@@ -1,6 +1,8 @@
 ---
-- hosts: all
-  collections:
-    - community.sap_install
-  roles:
-    - sap_general_preconfigure
+- name: Play for testing the role sap_general_preconfigure
+  hosts: all
+
+  tasks:
+    - name: Import the role sap_general_preconfigure
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_general_preconfigure


### PR DESCRIPTION
Fixes ansible-lint errors in the generic and RHEL parts Related issue: #535.