### PR TITLE
sap_hana_preconfigure: Implement RHEL 9.2 requirements

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -3,6 +3,7 @@
 # supported RHEL 9 minor releases for SAP HANA:
 __sap_hana_preconfigure_supported_rhel_minor_releases:
   - "9.0"
+  - "9.2"
 
 # required repos for RHEL 9:
 __sap_hana_preconfigure_req_repos_redhat_9_0_x86_64:
@@ -117,14 +118,14 @@ __sap_hana_preconfigure_req_repos_redhat_9_10_ppc64le:
 
 # required SAP notes for RHEL 9:
 __sap_hana_preconfigure_sapnotes_versions_x86_64:
-  - { number: '3108302', version: '3' }
-  - { number: '2382421', version: '40' }
+  - { number: '3108302', version: '8' }
+  - { number: '2382421', version: '45' }
   - { number: '3024346', version: '3' }
 
 __sap_hana_preconfigure_sapnotes_versions_ppc64le:
-  - { number: '2055470', version: '87' }
-  - { number: '3108302', version: '3' }
-  - { number: '2382421', version: '40' }
+  - { number: '2055470', version: '90' }
+  - { number: '3108302', version: '8' }
+  - { number: '2382421', version: '45' }
   - { number: '3024346', version: '3' }
 
 __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_preconfigure_sapnotes_versions_' + ansible_architecture) }}"
@@ -147,8 +148,10 @@ __sap_hana_preconfigure_min_packages_9_1_x86_64:
 __sap_hana_preconfigure_min_packages_9_1_ppc64le:
 
 __sap_hana_preconfigure_min_packages_9_2_x86_64:
+  - [ 'kernel', '5.14.0-284.25.1.el9_2' ]
 
 __sap_hana_preconfigure_min_packages_9_2_ppc64le:
+  - [ 'kernel', '5.14.0-284.25.1.el9_2' ]
 
 __sap_hana_preconfigure_min_packages_9_3_x86_64:
 


### PR DESCRIPTION
I also updated most of the SAP note versions. There was no need for any change due to the updated content.

Solves issue #549.