### PR TITLE
various roles: Fix issue sap-linuxlab#556 for non-assert runs

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-hostname.yml
@@ -50,5 +50,5 @@
 
 - name: "Ensure that the length of the hostname is not longer than 'sap_general_preconfigure_max_hostname_length'"
   ansible.builtin.assert:
-    that: "{{ sap_hostname | length | int }} <= {{ sap_general_preconfigure_max_hostname_length | int }}"
+    that: (sap_hostname | length | int) <= (sap_general_preconfigure_max_hostname_length | int)
     msg: "The length of the hostname is {{ sap_hostname | length | int }} but must be less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')!"

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -40,7 +40,7 @@
 
     - name: SAP HANA Add Hosts - Assert that the additional hosts are not shown in hdblcm --list_systems
       ansible.builtin.assert:
-        that: "'{{ line_item }}' not in __sap_hana_install_register_hdblcm_list_systems.stdout"
+        that: line_item not in __sap_hana_install_register_hdblcm_list_systems.stdout
         fail_msg:
           - "FAIL: Host '{{ line_item }}' is already part of system '{{ sap_hana_install_sid }}'"
           - "Because of this, the addhost operation will not be performed."

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -140,9 +140,14 @@
       changed_when: no
       failed_when: no
 
+    - name: SAP HANA Checks - Define new variable for the assertion
+      ansible.builtin.set_fact:
+        __sap_hana_install_existing_sapsys_gid: "{{ __sap_hana_install_register_getent_group_sapsys.stdout.split(':')[2] }}"
+      when: __sap_hana_install_register_getent_group_sapsys.rc == 0
+
     - name: SAP HANA Checks - In case there is a group 'sapsys', assert that its group ID is identical to 'sap_hana_install_groupid'
       ansible.builtin.assert:
-        that: "{{ __sap_hana_install_register_getent_group_sapsys.stdout.split(':')[2] }} == {{ sap_hana_install_groupid }}"
+        that: (__sap_hana_install_existing_sapsys_gid | int) == (sap_hana_install_groupid | int)
         success_msg: "PASS: The group ID of 'sapsys' is identical to the value of variable
                       sap_hana_install_groupid, which is '{{ sap_hana_install_groupid }}'"
         fail_msg: "FAIL: Group 'sapsys' exists but with a different group ID than '{{ sap_hana_install_groupid }}'

--- a/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure that the system is running a RHEL release which is supported for SAP HANA
   ansible.builtin.assert:
-    that: ansible_distribution_version in "{{ sap_hana_preconfigure_supported_rhel_minor_releases }}"
+    that: ansible_distribution_version in sap_hana_preconfigure_supported_rhel_minor_releases
     fail_msg: "The RHEL release {{ ansible_distribution_version }} is not supported for SAP HANA!"
     success_msg: "The RHEL release {{ ansible_distribution_version }} is supported for SAP HANA."
   ignore_errors: "{{ not sap_hana_preconfigure_min_rhel_release_check }}"


### PR DESCRIPTION
This commit makes the roles compatible with the following versions of `ansible-core`:
- 2.16.1
- 2.15.8
- 2.14.12 when running in normal (=non-assert) mode.

The preconfigure roles also support an extended check mode, called assert mode, in which the roles do not change anything but verify if all settings are correct. This commit will not cover the assert mode. So several tasks of the preconfigure roles in assert mode will fail. By using the `_assert_ignore_errors` role parameters in assert mode, the roles will not fail but the affected tasks will not be executed so those settings will not be validated.

Relates to issues #555 and #556.