### PR TITLE
sap_general_preconfigure: skip var-naming[no-role-prefix]

### DIFF
--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -145,13 +145,16 @@ sap_general_preconfigure_kernel_parameters: "{{ __sap_general_preconfigure_kerne
 sap_general_preconfigure_max_hostname_length: '13'
 # The maximum length of the hostname. See SAP note 611361.
 
-sap_hostname: "{{ ansible_hostname }}"
+# Reason for noqa: A separate role is planned to replace the code which uses this variable.
+sap_hostname: "{{ ansible_hostname }}" # noqa var-naming[no-role-prefix]
 # The hostname to be used for updating or checking `/etc/hosts` entries.
 
-sap_domain: "{{ ansible_domain }}"
+# Reason for noqa: A separate role is planned to replace the code which uses this variable.
+sap_domain: "{{ ansible_domain }}" # noqa var-naming[no-role-prefix]
 # The DNS domain name to be used for updating or checking `/etc/hosts` entries.
 
-sap_ip: "{{ ansible_default_ipv4.address }}"
+# Reason for noqa: A separate role is planned to replace the code which uses this variable.
+sap_ip: "{{ ansible_default_ipv4.address }}" # noqa var-naming[no-role-prefix]
 # The IPV4 address to be used for updating or checking `/etc/hosts` entries.
 
 # sap_general_preconfigure_db_group_name: (not defined by default)


### PR DESCRIPTION
... for the three variables sap_hostname, sap_domain, sap_ip.

Those are used in many places in the role and the effort for changing and testing the code is too high given that we plan to replace this part of the role by the new role sap_maintain_etc_hosts.

Relates to #589.