### PR TITLE
Code fixes for #499 and improvements for #539 and #566

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/ascertain_platform_type.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/ascertain_platform_type.yml
@@ -49,7 +49,8 @@
 - name: "SAP HA Prepare Pacemaker - Check if platform is Amazon Web Services EC2 Virtual Server"
   when:
     - '"amazon" in ansible_system_vendor | lower
-      or "amazon" in ansible_product_name | lower'
+      or "amazon" in ansible_product_name | lower
+      or "amazon" in ansible_product_version | lower'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: cloud_aws_ec2_vs
 

--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -1,13 +1,11 @@
 ---
-
-#- name: Enable Debugging
-#  debug:
-#    verbosity: "{{ debuglevel }}"
-#
-
-- name: Prepare saptune
+- name: Takover saptune and enable
   when: __sap_hana_preconfigure_run_saptune
   block:
+    - name: Make sure that sapconf and tuned are stopped and disabled
+      ansible.builtin.command: "saptune service takeover"
+      register: __sap_saptune_takeover
+      changed_when: __sap_saptune_takeover.rc == 0
 
     - name: Ensure saptune is running and enabled
       ansible.builtin.systemd:
@@ -26,19 +24,27 @@
 
     - name: Set fact for active solution
       ansible.builtin.set_fact:
-        __sap_hana_preconfigure_fact_solution_configured: "{{ (__sap_hana_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}" # Capture the first block on none whitespace
+        # Capture the first block on none whitespace
+        __sap_hana_preconfigure_fact_solution_configured:
+          "{{ (__sap_hana_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
 
     - name: Show configured solution
       ansible.builtin.debug:
         var: __sap_hana_preconfigure_fact_solution_configured
 
-- name: Ensure sapconf is running and enabled
-  ansible.builtin.systemd:
-    name: sapconf
-    state: started
-    enabled: true
-  when:
-    - not __sap_hana_preconfigure_run_saptune
+- name: Enable sapconf
+  when: not __sap_hana_preconfigure_run_saptune
+  block:
+    - name: Enable sapconf service
+      ansible.builtin.systemd:
+        name: sapconf
+        state: started
+        enabled: true
+
+    - name: Restart sapconf service
+      ansible.builtin.systemd:
+        name: sapconf
+        state: restarted
 
 # If this is a cluster node on Azure, we need to override to disable tcp timestamps, reuse and recycle.
 # This can be done by copying the sapnote file 2382421 from /usr/share/saptune/notes to /etc/saptune/override
@@ -61,42 +67,28 @@
   when:
     - sap_hana_preconfigure_saptune_azure
 
-- name: Check if saptune solution needs to be applied
-  ansible.builtin.command: "saptune solution verify {{ sap_hana_preconfigure_saptune_solution }}"
-  register: __sap_hana_preconfigure_register_saptune_verify
-  changed_when: false # We're only checking, not changing!
-  failed_when: false # We expect this to fail if it has not previously been applied
-  when:
-    - __sap_hana_preconfigure_run_saptune
-
-- name: Ensure no solution is currently applied
-  ansible.builtin.command: "saptune solution revert {{ __sap_hana_preconfigure_fact_solution_configured }}"
-  changed_when: true
-  when:
-    - __sap_hana_preconfigure_run_saptune
-    - __sap_hana_preconfigure_fact_solution_configured != 'NONE'
-    - __sap_hana_preconfigure_register_saptune_verify.rc != 0
-
-- name: Ensure saptune solution is applied
-  ansible.builtin.command: "saptune solution apply {{ sap_hana_preconfigure_saptune_solution }}"
-  #changed_when: true
-  when:
-    - __sap_hana_preconfigure_run_saptune
-    - __sap_hana_preconfigure_register_saptune_verify.rc != 0
+- name: Apply saptune solution
+  when: __sap_hana_preconfigure_run_saptune
   block:
+    - name: Check if saptune solution needs to be applied
+      ansible.builtin.command: "saptune solution verify {{ sap_hana_preconfigure_saptune_solution }}"
+      register: __sap_hana_preconfigure_register_saptune_verify
+      changed_when: false # We're only checking, not changing!
+      failed_when: false # We expect this to fail if it has not previously been applied
+
+    - name: Ensure no solution is currently applied
+      ansible.builtin.command: "saptune solution revert {{ __sap_hana_preconfigure_fact_solution_configured }}"
+      changed_when: true
+      when:
+        - __sap_hana_preconfigure_fact_solution_configured != 'NONE'
+        - __sap_hana_preconfigure_register_saptune_verify.rc != 0
+
+    - name: Ensure saptune solution is applied
+      ansible.builtin.command: "saptune solution apply {{ sap_hana_preconfigure_saptune_solution }}"
+      changed_when: true
+      when:
+        - __sap_hana_preconfigure_register_saptune_verify.rc != 0
 
     - name: Ensure solution was successful
       ansible.builtin.command: "saptune solution verify {{ sap_hana_preconfigure_saptune_solution }}"
       changed_when: false # We're only checking, not changing!
-
-    - name: Make sure that sapconf and tuned are stopped and disabled
-      ansible.builtin.command: "saptune service takeover"
-      register: __sap_saptune_takeover
-      changed_when: __sap_saptune_takeover.rc == 0
-
-- name: Restart sapconf service
-  ansible.builtin.systemd:
-    name: sapconf
-    state: restarted
-  when:
-    not __sap_hana_preconfigure_run_saptune

--- a/roles/sap_hana_preconfigure/vars/main.yml
+++ b/roles/sap_hana_preconfigure/vars/main.yml
@@ -23,9 +23,6 @@ __sap_hana_preconfigure_kernel_parameters_default: []
 __sap_hana_preconfigure_kernel_parameters_default_ppc64le: []
 __sap_hana_preconfigure_ibm_power_repo_url: ''
 
-# for SLES saptune is only available for Sles for SAP Application, but for SLES (Standard) only sapconf is available.
-#           Pls set __sap_hana_preconfigure_run_saptune: false for "SLES" (Standard)
-#                   __sap_hana_preconfigure_run_saptune: true for "SLES for SAP Applications"
-# for RHEL saptune is available:
-#           Pls set __sap_hana_preconfigure_run_saptune: true for "RHEL"
+# SLES_SAP is using saptune, but SLES is using sapconf.
+# Default value true runs saptune, but installation.yml auto-detects base product and adjusts.
 __sap_hana_preconfigure_run_saptune: true

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -1,9 +1,11 @@
 ---
-
-- name: Configure saptune
-  when:
-    - __sap_netweaver_preconfigure_run_saptune
+- name: Takover saptune and enable
+  when: __sap_netweaver_preconfigure_run_saptune
   block:
+    - name: Make sure that sapconf and tuned are stopped and disabled
+      ansible.builtin.command: "saptune service takeover"
+      register: __sap_saptune_takeover
+      changed_when: __sap_saptune_takeover.rc == 0
 
     - name: Ensure saptune is running and enabled
       ansible.builtin.systemd:
@@ -20,14 +22,11 @@
       register: __sap_netweaver_preconfigure_register_saptune_status
       changed_when: false
 
-    - name: Make sure that sapconf and tuned are stopped and disabled
-      ansible.builtin.command: "saptune service takeover"
-      register: __sap_saptune_takeover
-      changed_when: __sap_saptune_takeover.rc == 0
-
     - name: Set fact for active solution
       ansible.builtin.set_fact:
-        __sap_netweaver_preconfigure_fact_solution_configured: "{{ (__sap_netweaver_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}" # Capture the first block on none whitespace
+        # Capture the first block on none whitespace
+        __sap_netweaver_preconfigure_fact_solution_configured:
+          "{{ (__sap_netweaver_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
 
     - name: Check if saptune solution needs to be applied
       ansible.builtin.command: "saptune solution verify {{ sap_netweaver_preconfigure_saptune_solution }}"
@@ -35,35 +34,36 @@
       changed_when: false # We're only checking, not changing!
       failed_when: false # We expect this to fail if it has not previously been applied
 
+    - name: Ensure no solution is currently applied
+      ansible.builtin.command: "saptune solution revert {{ __sap_netweaver_preconfigure_fact_solution_configured }}"
+      changed_when: true
+      when:
+        - __sap_netweaver_preconfigure_fact_solution_configured != 'NONE'
+        - __sap_netweaver_preconfigure_register_saptune_verify.rc != 0
 
-- name: Ensure no solution is currently applied
-  ansible.builtin.command: "saptune solution revert {{ __sap_netweaver_preconfigure_fact_solution_configured }}"
-  changed_when: true
-  when:
-    - __sap_netweaver_preconfigure_run_saptune
-    - __sap_netweaver_preconfigure_fact_solution_configured != 'NONE'
-    - __sap_netweaver_preconfigure_register_saptune_verify.rc != 0
+    - name: Ensure saptune solution is applied
+      ansible.builtin.command: "saptune solution apply {{ sap_netweaver_preconfigure_saptune_solution }}"
+      changed_when: true
+      when:
+        - __sap_netweaver_preconfigure_register_saptune_verify.rc != 0
 
-- name: Ensure saptune solution is applied
-  ansible.builtin.command: "saptune solution apply {{ sap_netweaver_preconfigure_saptune_solution }}"
-  #changed_when: true
-  when:
-    - __sap_netweaver_preconfigure_run_saptune
-    - __sap_netweaver_preconfigure_register_saptune_verify.rc != 0
+    - name: Ensure solution was successful
+      ansible.builtin.command: "saptune solution verify {{ sap_netweaver_preconfigure_saptune_solution }}"
+      changed_when: false # We're only checking, not changing!
 
-- name: Ensure solution was successful
-  ansible.builtin.command: "saptune solution verify {{ sap_netweaver_preconfigure_saptune_solution }}"
-  changed_when: false # We're only checking, not changing!
-  when:
-    - __sap_netweaver_preconfigure_run_saptune
+- name: Enable sapconf
+  when: not __sap_netweaver_preconfigure_run_saptune
+  block:
+    - name: Enable sapconf service
+      ansible.builtin.systemd:
+        name: sapconf
+        state: started
+        enabled: true
 
-# restart sapconf service
-- name: Restart sapconf service
-  ansible.builtin.systemd:
-    name: sapconf
-    state: restarted
-  when:
-    - not __sap_netweaver_preconfigure_run_saptune
+    - name: Restart sapconf service
+      ansible.builtin.systemd:
+        name: sapconf
+        state: restarted
 
 - name: Warn if not enough swap space is configured
   ansible.builtin.fail:

--- a/roles/sap_netweaver_preconfigure/vars/main.yml
+++ b/roles/sap_netweaver_preconfigure/vars/main.yml
@@ -3,3 +3,7 @@
 # define variables here that will not change
 # Those are valid for all OS
 #
+
+# SLES_SAP is using saptune, but SLES is using sapconf.
+# Default value true runs saptune, but installation.yml auto-detects base product and adjusts.
+__sap_netweaver_preconfigure_run_saptune: true


### PR DESCRIPTION
#499 Has introduced sapconf steps but they were incomplete and missing. Invalid block was stopping role from working altogether.
- invalid block and command in same step:
```
The error appears to be in '/scripts/community.sap_install/roles/sap_hana_preconfigure/tasks/SLES/config                                               uration.yml': line 80, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Ensure saptune solution is applied
  ^ here
```
- Linting errors fixed
- Missing variable __sap_netweaver_preconfigure_run_saptune defined in default vars.

#539 saptune steps reordering included

#566 improvements are included in this commit, so other dedicated PR was cancelled.