### PR TITLE
sap_hypervisor_node_preconfigure: Fixed role name and path for include tasks

### DIFF
--- a/playbooks/sample-sap-hypervisor-redhat_ocp_virt-preconfigure.yml
+++ b/playbooks/sample-sap-hypervisor-redhat_ocp_virt-preconfigure.yml
@@ -4,5 +4,9 @@
   serial: 1
   vars:
     sap_hypervisor_node_platform: redhat_ocp_virt
+    sap_hypervisor_node_kubeconfig: "{{ lookup( 'ansible.builtin.env', 'KUBECONFIG') }}"
+  environment:
+    KUBECONFIG: "{{ sap_hypervisor_node_kubeconfig }}"
+    K8S_AUTH_KUBECONFIG: "{{ sap_hypervisor_node_kubeconfig }}"
   roles:
     - { role: community.sap_install.sap_hypervisor_node_preconfigure }

--- a/playbooks/sample-sap-hypervisor-redhat_ocp_virt-preconfigure.yml
+++ b/playbooks/sample-sap-hypervisor-redhat_ocp_virt-preconfigure.yml
@@ -4,8 +4,5 @@
   serial: 1
   vars:
     sap_hypervisor_node_platform: redhat_ocp_virt
-
-  tasks:
-    - name: Include Role
-      ansible.builtin.include_role:
-        name: sap_hypervisor_node_preconfigure
+  roles:
+    - { role: community.sap_install.sap_hypervisor_node_preconfigure }

--- a/playbooks/vars/sample-variables-sap-hypervisor-node-preconfigure-rh_ocp_virt.yml
+++ b/playbooks/vars/sample-variables-sap-hypervisor-node-preconfigure-rh_ocp_virt.yml
@@ -1,3 +1,8 @@
+sap_hypervisor_node_preconfigure_install_operators: true
+sap_hypervisor_node_preconfigure_install_hpp: true
+sap_hypervisor_node_preconfigure_install_trident: false
+sap_hypervisor_node_preconfigure_setup_worker_nodes: true
+
 sap_hypervisor_node_preconfigure_cluster_config:
 
   # URL under which the OCP cluster is reachable

--- a/roles/sap_hypervisor_node_preconfigure/tasks/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: SAP certified hypervisor node preconfigure - Include Vars for {{ sap_hypervisor_node_platform }}
-  ansible.builtin.include_vars: "vars/platform_defaults_{{ sap_hypervisor_node_platform }}.yml"
+  ansible.builtin.include_vars: "platform_defaults_{{ sap_hypervisor_node_platform }}.yml"
 
 - name: SAP certified hypervisor node preconfigure - Include Tasks for {{ sap_hypervisor_node_platform }}
-  ansible.builtin.include_tasks: "tasks/platform/{{ sap_hypervisor_node_platform }}/main.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/main.yml"

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/install-cnv-operator.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/install-cnv-operator.yml
@@ -38,7 +38,7 @@
 
 - name: Wait
   ansible.builtin.pause:
-    seconds: 60
+    seconds: 300
 
 - name: Get Install Plan Name
   retries: 10

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -61,22 +61,22 @@
   when: __sap_hypervisor_node_preconfigure_register_worker_memory_gib | int >= 512
 
 - name: Include prepare
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/prepare.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/prepare.yml"
 - name: Include tuned virtual host
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/tuned-virtual-host.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/tuned-virtual-host.yml"
 - name: Include install CNV operator
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-cnv-operator.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-cnv-operator.yml"
   when: sap_hypervisor_node_preconfigure_install_operators
 - name: Include install sriov operator
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-sriov-operator.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-sriov-operator.yml"
   when: sap_hypervisor_node_preconfigure_install_operators
 - name: Include install nmstate operator
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-nmstate-operator.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-nmstate-operator.yml"
   when: sap_hypervisor_node_preconfigure_install_operators
 - name: Include install virtctl
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
 - name: Include setup worker nodes
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
   when: sap_hypervisor_node_preconfigure_setup_workers
 
 # How to wait for node to be scheduleable? (NodeSchedulable)
@@ -90,9 +90,9 @@
     var: __sap_hypervisor_node_preconfigure_register_nodes_ready.stdout_lines
 
 - name: Include Trident installation
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-trident.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-trident.yml"
   when: sap_hypervisor_node_preconfigure_install_trident
 
 - name: Include local storage creation (HPP)
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-hpp.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/install-hpp.yml"
   when: sap_hypervisor_node_preconfigure_install_hpp

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/main.yml
@@ -61,22 +61,22 @@
   when: __sap_hypervisor_node_preconfigure_register_worker_memory_gib | int >= 512
 
 - name: Include prepare
-  ansible.builtin.include_tasks: prepare.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/prepare.yml"
 - name: Include tuned virtual host
-  ansible.builtin.include_tasks: tuned-virtual-host.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/tuned-virtual-host.yml"
 - name: Include install CNV operator
-  ansible.builtin.include_tasks: install-cnv-operator.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-cnv-operator.yml"
   when: sap_hypervisor_node_preconfigure_install_operators
 - name: Include install sriov operator
-  ansible.builtin.include_tasks: install-sriov-operator.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-sriov-operator.yml"
   when: sap_hypervisor_node_preconfigure_install_operators
 - name: Include install nmstate operator
-  ansible.builtin.include_tasks: install-nmstate-operator.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-nmstate-operator.yml"
   when: sap_hypervisor_node_preconfigure_install_operators
 - name: Include install virtctl
-  ansible.builtin.include_tasks: install-virtctl.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-virtctl.yml"
 - name: Include setup worker nodes
-  ansible.builtin.include_tasks: setup-worker-nodes.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/setup-worker-nodes.yml"
   when: sap_hypervisor_node_preconfigure_setup_workers
 
 # How to wait for node to be scheduleable? (NodeSchedulable)
@@ -90,9 +90,9 @@
     var: __sap_hypervisor_node_preconfigure_register_nodes_ready.stdout_lines
 
 - name: Include Trident installation
-  ansible.builtin.include_tasks: install-trident.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-trident.yml"
   when: sap_hypervisor_node_preconfigure_install_trident
 
 - name: Include local storage creation (HPP)
-  ansible.builtin.include_tasks: install-hpp.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/install-hpp.yml"
   when: sap_hypervisor_node_preconfigure_install_hpp

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/setup-worker-nodes.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/setup-worker-nodes.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include configure worker
-  ansible.builtin.include_tasks: configure-worker-node.yml
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/configure-worker-node.yml"
   with_items: "{{ sap_hypervisor_node_preconfigure_cluster_config.workers }}"
   loop_control:
     loop_var: __sap_hypervisor_node_preconfigure_register_worker

--- a/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/setup-worker-nodes.yml
+++ b/roles/sap_hypervisor_node_preconfigure/tasks/platform/redhat_ocp_virt/setup-worker-nodes.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include configure worker
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/platform/{{ sap_hypervisor_node_platform }}/configure-worker-node.yml"
+  ansible.builtin.include_tasks: "platform/{{ sap_hypervisor_node_platform }}/configure-worker-node.yml"
   with_items: "{{ sap_hypervisor_node_preconfigure_cluster_config.workers }}"
   loop_control:
     loop_var: __sap_hypervisor_node_preconfigure_register_worker


### PR DESCRIPTION
When testing the ansibe-galaxy community version, a couple of issues occurred that are fixed with this PR.

1. Role name is community.sap_install.sap_hypervisor_node_preconfigure (adjusted in example playbook)
2. When doing include_tasks, the path has to be relative to the role top tasks directory.
3. Reads the KUBECONFIG environment variable and sets the environment for the playbook accordingly.