### PR TITLE
collection: prepare for v1.3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ community.sap_install Release Notes
 .. contents:: Topics
 
 
+v1.3.5
+======
+
+Release Summary
+---------------
+
+| Release Date: 2024-01-31
+| sap_hypervisor_node_preconfigure: Bug fix for role name and path for included tasks
+
 v1.3.4
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -149,3 +149,10 @@ releases:
 
         '
     release_date: '2024-01-15'
+  1.3.5:
+    changes:
+      release_summary: '| Release Date: 2024-01-31
+
+        | sap_hypervisor_node_preconfigure: Bug fix for role name and path for included tasks
+        '
+    release_date: '2024-01-31'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: community
 name: sap_install
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.4
+version: 1.3.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Main changes from previous version 1.3.4:
- sap_hypervisor_node_preconfigure: Bug fix for role name and path for included tasks