### PR TITLE
sap_ha_pacemaker_cluster: Variable changes for different os and platforms

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -30,11 +30,6 @@ sap_ha_pacemaker_cluster_create_config_dest: "review_resource_config.yml"
 # Other options are needed in the separate HSR setup role.
 sap_ha_pacemaker_cluster_cluster_nodes: "{{ sap_hana_cluster_nodes | default([]) }}"
 
-# Make sure that there is always the minimal default fed into the included role.
-# This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
-sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
-  - fence-agents-all
-
 # Resource defaults are defined differently by cluster type in different tasks, if not custom defined.
 # TODO: migrate to 'ha_cluster' native parameter combination when moving the function to be included in the role
 # (newer feature in the LSR)

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
@@ -10,7 +10,7 @@
 - name: "SAP HA Pacemaker srHook - Copy srHook to shared directory"
   ansible.builtin.copy:
     remote_src: true
-    src: /usr/share/SAPHanaSR/srHook/SAPHanaSR.py
+    src: "{{ __sap_ha_srhook_path }}"
     dest: "{{ sap_ha_pacemaker_cluster_hadr_provider_path }}/{{ sap_ha_pacemaker_cluster_hadr_provider_name }}.py"
     mode: "0755"
     owner: "{{ sap_ha_pacemaker_cluster_hana_sid | lower }}adm"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_common.yml
@@ -24,7 +24,7 @@
   vars:
     __resource_hana_topology:
       id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
-      agent: "ocf:heartbeat:SAPHanaTopology"
+      agent: "ocf:{{ __sap_ha_resource_agent_namespace }}:SAPHanaTopology"
       instance_attrs:
         - attrs:
             - name: SID
@@ -55,7 +55,7 @@
   vars:
     __resource_hana:
       id: "{{ sap_ha_pacemaker_cluster_hana_resource_name }}"
-      agent: "ocf:heartbeat:{{ sap_ha_pacemaker_cluster_ra_hana }}"
+      agent: "ocf:{{ __sap_ha_resource_agent_namespace }}:{{ sap_ha_pacemaker_cluster_ra_hana }}"
       instance_attrs:
         - attrs:
             - name: SID

--- a/roles/sap_ha_pacemaker_cluster/tasks/import_hacluster_vars_from_inventory.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/import_hacluster_vars_from_inventory.yml
@@ -63,7 +63,9 @@
 
 # ha_cluster_hacluster_password
 - name: "SAP HA Prepare Pacemaker - (ha_cluster) Register parameter 'ha_cluster_repos'"
-  when: ha_cluster_hacluster_password is defined
+  when:
+    - ha_cluster_hacluster_password is defined
+    - ha_cluster_hacluster_password | length > 0
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_hacluster_user_password: "{{ ha_cluster_hacluster_password }}"
   no_log: true  # handle credentials with care

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_common.yml
@@ -3,7 +3,7 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-__sap_ha_pacemaker_cluster_sap_extra_packages: "{{ __sap_ha_pacemaker_cluster_sap_extra_packages_dict.scaleout }}"
+__sap_ha_pacemaker_cluster_sap_extra_packages: "{{ __sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_scaleout }}"
 
 sap_ha_pacemaker_cluster_ra_hana: SAPHanaController
 sap_ha_pacemaker_cluster_hadr_provider_name: SAPHanaSR

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_common.yml
@@ -3,8 +3,7 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-__sap_ha_pacemaker_cluster_sap_extra_packages:
-  - resource-agents-sap-hana-scaleout
+__sap_ha_pacemaker_cluster_sap_extra_packages: "{{ __sap_ha_pacemaker_cluster_sap_extra_packages_dict.scaleout }}"
 
 sap_ha_pacemaker_cluster_ra_hana: SAPHanaController
 sap_ha_pacemaker_cluster_hadr_provider_name: SAPHanaSR

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_common.yml
@@ -3,7 +3,7 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-__sap_ha_pacemaker_cluster_sap_extra_packages: "{{ __sap_ha_pacemaker_cluster_sap_extra_packages_dict.scaleup }}"
+__sap_ha_pacemaker_cluster_sap_extra_packages: "{{ __sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_scaleup }}"
 
 sap_ha_pacemaker_cluster_ra_hana: SAPHana
 sap_ha_pacemaker_cluster_hadr_provider_name: SAPHanaSR

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_common.yml
@@ -3,8 +3,7 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-__sap_ha_pacemaker_cluster_sap_extra_packages:
-  - resource-agents-sap-hana
+__sap_ha_pacemaker_cluster_sap_extra_packages: "{{ __sap_ha_pacemaker_cluster_sap_extra_packages_dict.scaleup }}"
 
 sap_ha_pacemaker_cluster_ra_hana: SAPHana
 sap_ha_pacemaker_cluster_hadr_provider_name: SAPHanaSR

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
@@ -4,5 +4,5 @@
 # TODO: make sure to first respect 'ha_cluster' native variables
 
 __sap_ha_pacemaker_cluster_sap_extra_packages:
-  - resource-agents-sap
-  - "{% if sap_ha_pacemaker_cluster_enable_cluster_connector %}{{ __sap_ha_pacemaker_cluster_halib_package }}{% endif %}"
+  "{{ ( __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas + __sap_ha_pacemaker_cluster_halib_package
+   if sap_ha_pacemaker_cluster_enable_cluster_connector else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas ) unique }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
@@ -4,5 +4,6 @@
 # TODO: make sure to first respect 'ha_cluster' native variables
 
 __sap_ha_pacemaker_cluster_sap_extra_packages:
-  "{{ ( __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas + __sap_ha_pacemaker_cluster_halib_package
-   if sap_ha_pacemaker_cluster_enable_cluster_connector else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas ) unique }}"
+  "{{ ( __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas +
+  [ __sap_ha_pacemaker_cluster_halib_package ] if sap_ha_pacemaker_cluster_enable_cluster_connector
+  else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas ) | unique }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -3,11 +3,9 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  - fence-agents-aws
+sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages:
-  - awscli
+__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
@@ -21,7 +19,7 @@ __sap_ha_pacemaker_cluster_aws_instances: []
 # The aws cli is currently configured anyway for the standard AWS VIP resource.
 sap_ha_pacemaker_cluster_stonith_default:
   id: "res_fence_aws"
-  agent: "stonith:fence_aws"
+  agent: "{{ sap_ha_pacemaker_cluster_stonith_agent_dict.cloud_aws }}"
 #  options:
 #    access_key: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
 #    secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -3,9 +3,11 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws }}"
+sap_ha_pacemaker_cluster_fence_agent_packages:
+  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws | default([]) }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws }}"
+__sap_ha_pacemaker_cluster_platform_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -3,9 +3,11 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp }}"
+sap_ha_pacemaker_cluster_fence_agent_packages:
+  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp | default([]) }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp }}"
+__sap_ha_pacemaker_cluster_platform_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -3,11 +3,9 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  - fence-agents-gce
+sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages:
-  - resource-agents-gcp
+__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -3,9 +3,11 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs }}"
+sap_ha_pacemaker_cluster_fence_agent_packages:
+  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_powervs }}"
+__sap_ha_pacemaker_cluster_platform_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -3,11 +3,9 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  - fence-agents-ibm-powervs
+sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs }}"
 
-# __sap_ha_pacemaker_cluster_platform_extra_packages:
-#   -
+__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_powervs }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -3,9 +3,11 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs }}"
+sap_ha_pacemaker_cluster_fence_agent_packages:
+  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs | default([]) }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_vs }}"
+__sap_ha_pacemaker_cluster_platform_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_vs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -3,11 +3,9 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  - fence-agents-ibm-vpc
+sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs }}"
 
-# __sap_ha_pacemaker_cluster_platform_extra_packages:
-#   -
+__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_vs }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -6,11 +6,9 @@
 # The packages of the following lists will be installed by the 'ha_cluster' Linux System Role.
 # Any packages that are pre-requisites for variable construction must be installed before, e.g.
 # in the preconfigure-* tasks.
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  - fence-agents-azure-arm
+sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages:
-  - socat
+__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_msazure_vm }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -6,9 +6,11 @@
 # The packages of the following lists will be installed by the 'ha_cluster' Linux System Role.
 # Any packages that are pre-requisites for variable construction must be installed before, e.g.
 # in the preconfigure-* tasks.
-sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm }}"
+sap_ha_pacemaker_cluster_fence_agent_packages:
+  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm | default([]) }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_msazure_vm }}"
+__sap_ha_pacemaker_cluster_platform_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_msazure_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -3,9 +3,11 @@
 # TODO: rename this file to match the actual "chassis_asset_tag" output
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm }}"
+sap_ha_pacemaker_cluster_fence_agent_packages:
+  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm | default([]) }}"
 
-__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.hyp_ibmpower_vm }}"
+__sap_ha_pacemaker_cluster_platform_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.hyp_ibmpower_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -3,11 +3,9 @@
 # TODO: rename this file to match the actual "chassis_asset_tag" output
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  - fence-agents-lpar
+sap_ha_pacemaker_cluster_fence_agent_packages: "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm }}"
 
-# __sap_ha_pacemaker_cluster_platform_extra_packages:
-#   -
+__sap_ha_pacemaker_cluster_platform_extra_packages: "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.hyp_ibmpower_vm }}"
 
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -19,3 +19,55 @@ __sap_ha_pacemaker_cluster_command:
   resource_start: "pcs resource enable"
   resource_defaults_show: "pcs resource defaults config"
   resource_defaults_update: "pcs resource defaults update"
+
+# Make sure that there is always the minimal default fed into the included role.
+# This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
+sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
+  - fence-agents-all
+
+# Dictionary with fence packages for each platform
+sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+  cloud_aws:
+    - fence-agents-aws
+  cloud_gcp:
+    - fence-agents-gce
+  cloud_ibmcloud_powervs:
+    - fence-agents-ibm-powervs
+  cloud_ibmcloud_vs:
+    - fence-agents-ibm-vpc
+  cloud_msazure_vm:
+    - fence-agents-azure-arm
+  hyp_ibmpower_vm:
+    - fence-agents-lpar
+
+# Dictionary with extra platform specific packages
+__sap_ha_pacemaker_cluster_platform_extra_packages_dict:
+  cloud_aws:
+    - awscli
+  cloud_gcp:
+    - resource-agents-gcp
+  cloud_ibmcloud_powervs: []
+  cloud_ibmcloud_vs: []
+  cloud_msazure_vm:
+    - socat
+  hyp_ibmpower_vm: []
+
+# Dictionary with additional cluster packages for specific scenarios
+__sap_ha_pacemaker_cluster_sap_extra_packages_dict:
+  scaleout:
+    - resource-agents-sap-hana-scaleout
+  scaleup:
+    - resource-agents-sap-hana
+  nwas:
+    - resource-agents-sap
+
+# Dictionary for platform specific Stonith agents
+# This is required only if there are differences between os_family
+sap_ha_pacemaker_cluster_stonith_agent_dict:
+  cloud_aws: 'stonith:fence_aws'
+
+# SAP HANA Resource agent namespace
+__sap_ha_resource_agent_namespace: heartbeat
+
+# Location of HANA SRHook binaries
+__sap_ha_srhook_path: '/usr/share/SAPHanaSR/srHook/SAPHanaSR.py'

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -54,9 +54,9 @@ __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
 
 # Dictionary with additional cluster packages for specific scenarios
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
-  scaleout:
+  hana_scaleout:
     - resource-agents-sap-hana-scaleout
-  scaleup:
+  hana_scaleup:
     - resource-agents-sap-hana
   nwas:
     - resource-agents-sap

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -46,11 +46,8 @@ __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
     - awscli
   cloud_gcp:
     - resource-agents-gcp
-  cloud_ibmcloud_powervs: []
-  cloud_ibmcloud_vs: []
   cloud_msazure_vm:
     - socat
-  hyp_ibmpower_vm: []
 
 # Dictionary with additional cluster packages for specific scenarios
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -21,24 +21,14 @@ sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
 
 # Dictionary with fence packages for each platform
 # SUSE does not use platform specific fence agents, just fence-agents
-sap_ha_pacemaker_cluster_fence_agent_packages_dict:
-  cloud_aws: []
-  cloud_gcp: []
-  cloud_ibmcloud_powervs: []
-  cloud_ibmcloud_vs: []
-  cloud_msazure_vm: []
-  hyp_ibmpower_vm: []
+# sap_ha_pacemaker_cluster_fence_agent_packages_dict:
 
 # Dictionary with extra platform specific packages
 __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
   cloud_aws:
     - awscli
-  cloud_gcp: []
-  cloud_ibmcloud_powervs: []
-  cloud_ibmcloud_vs: []
   cloud_msazure_vm:
     - socat
-  hyp_ibmpower_vm: []
 
 # Dictionary with additional cluster packages for specific scenarios
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -42,14 +42,19 @@ __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
 
 # Dictionary with additional cluster packages for specific scenarios
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
-  scaleout:
+  hana_scaleout:
     - resource-agents
     - SAPHanaSR-ScaleOut
-  scaleup:
+    - ClusterTools2
+  hana_scaleup:
     - resource-agents
     - SAPHanaSR
+    - ClusterTools2
   nwas:
     - resource-agents
+    - ClusterTools2
+    - sap-suse-cluster-connector
+    - sapstartsrv-resource-agents
 
 # Dictionary for platform specific Stonith agents
 # This is required only if there are differences between os_family

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -13,3 +13,51 @@ __sap_ha_pacemaker_cluster_command:
   resource_start: "crm resource start"
   resource_defaults_show: "crm configure show type:rsc_defaults"
   resource_defaults_update: "crm configure rsc_defaults"
+
+# Make sure that there is always the minimal default fed into the included role.
+# This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
+sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
+  - fence-agents
+
+# Dictionary with fence packages for each platform
+# SUSE does not use platform specific fence agents, just fence-agents
+sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+  cloud_aws: []
+  cloud_gcp: []
+  cloud_ibmcloud_powervs: []
+  cloud_ibmcloud_vs: []
+  cloud_msazure_vm: []
+  hyp_ibmpower_vm: []
+
+# Dictionary with extra platform specific packages
+__sap_ha_pacemaker_cluster_platform_extra_packages_dict:
+  cloud_aws:
+    - awscli
+  cloud_gcp: []
+  cloud_ibmcloud_powervs: []
+  cloud_ibmcloud_vs: []
+  cloud_msazure_vm:
+    - socat
+  hyp_ibmpower_vm: []
+
+# Dictionary with additional cluster packages for specific scenarios
+__sap_ha_pacemaker_cluster_sap_extra_packages_dict:
+  scaleout:
+    - resource-agents
+    - SAPHanaSR-ScaleOut
+  scaleup:
+    - resource-agents
+    - SAPHanaSR
+  nwas:
+    - resource-agents
+
+# Dictionary for platform specific Stonith agents
+# This is required only if there are differences between os_family
+sap_ha_pacemaker_cluster_stonith_agent_dict:
+  cloud_aws: 'stonith:external/ec2'
+
+# SAP HANA Resource agent namespace
+__sap_ha_resource_agent_namespace: suse
+
+# Location of HANA SRHook binaries
+__sap_ha_srhook_path: '/usr/share/SAPHanaSR/SAPHanaSR.py'


### PR DESCRIPTION
This PR changes:
1. Platform vars are now using variable dictionaries sourced from os_family vars for easier control from each of them.
2. New variables implemented to cover os_family differences:
- aws fence agent
- SRhook path
- ocf SAP agents namespace
3. nwas_common.yml was adjusted to be more dynamic and source from dictionary

I have tested this code on SLES for SAP SP5 and RHEL9.2 along with changes in ha_cluster.

@sean-freeman Thank you for call yesterday to double check contents with me.