### PR TITLE
sap_general_preconfigure: Use tags for limiting the role scope

### DIFF
--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -369,12 +369,12 @@ Sample call for performing all configuration steps except verifying and modifyin
 # ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_etc_hosts
 ```
 
-Sample call for only performing the configuration actitvities related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
+Sample call for only performing the configuration activities related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
 ```
 # ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316_02
 ```
 
-Sample call for performing all configuration actitvities except those related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
+Sample call for performing all configuration activities except those related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
 ```
 # ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_3108316_02
 ```

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -334,6 +334,36 @@ sap_general_preconfigure_db_group_name: dba
 
 <!-- END: Role Input Parameters for sap_general_preconfigure -->
 
+## Tags
+
+With the following tags, the role can be called to perform certain activities only:
+- tag `sap_general_preconfigure_installation`: Perform only the installation tasks
+- tag `sap_general_preconfigure_configuration`: Perform only the configuration tasks
+- tag `sap_general_preconfigure_configuration_all_steps`: Perform all configuration tasks
+- tag `sap_general_preconfigure_3108316_03`: Perform only the tasks(s) related to this step of the SAP note.
+- tag `sap_general_preconfigure_etc_hosts`: Perform only the tasks(s) related to this step. This step might be one of multiple
+  configuration activities of a SAP note. Also this step might be valid for multiple RHEL major releases.
+
+Sample call for only verifying and modifying the /etc/hosts file:
+```
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_etc_hosts
+```
+
+Sample call for performing all configuration steps except verifying and modifying the /etc/hosts file:
+```
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_configuration_all_steps --skip_tags=sap_general_preconfigure_etc_hosts
+```
+
+Sample call for only performing the configuration actitvities related to step 2 (SELinux settings) of SAP note 3108316:
+```
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_3108316_02
+```
+
+Sample call for performing all configuration actitvities except those related to step 2 (SELinux settings) of SAP note 3108316:
+```
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_configuration_all_steps --skip_tags=sap_general_preconfigure_3108316_02
+```
+
 ## Dependencies
 
 This role does not depend on any other role.

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -344,6 +344,24 @@ With the following tags, the role can be called to perform certain activities on
 - tag `sap_general_preconfigure_etc_hosts`: Perform only the tasks(s) related to this step. This step might be one of multiple
   configuration activities of a SAP note. Also this step might be valid for multiple RHEL major releases.
 
+Sample call for only performing all installation and configuration tasks. This is the default behavior. If no tag is specified, all
+installation and configuration tasks are enabled:
+```
+# ansible-playbook sap-general-preconfigure.yml
+```
+
+Sample call for only performing all installation tasks:
+```
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_installation
+```
+
+Sample call for only performing all configuration tasks. The tag sap_general_preconfigure_configuration is needed to only use
+the configuration tasks, and the tag sap_general_preconfigure_configuration_all_steps activates each individual configuration task. Both
+need to be enabled for running all the configuration tasks:
+```
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_configuration_all_steps
+```
+
 Sample call for only verifying and modifying the /etc/hosts file:
 ```
 # ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_etc_hosts

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -339,7 +339,8 @@ sap_general_preconfigure_db_group_name: dba
 With the following tags, the role can be called to perform certain activities only:
 - tag `sap_general_preconfigure_installation`: Perform only the installation tasks
 - tag `sap_general_preconfigure_configuration`: Perform only the configuration tasks
-- tag `sap_general_preconfigure_3108316_03`: Perform only the tasks(s) related to this step of the SAP note.
+- tag `sap_general_preconfigure_3108316`: Perform only the tasks(s) related to this SAP note.
+- tag `sap_general_preconfigure_2772999_03`: Perform only the tasks(s) related to step 3 of the SAP note.
 - tag `sap_general_preconfigure_etc_hosts`: Perform only the tasks(s) related to this step. This step might be one of multiple
   configuration activities of a SAP note. Also this step might be valid for multiple RHEL major releases.
 
@@ -369,6 +370,12 @@ Sample call for performing all configuration steps except verifying and modifyin
 # ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_etc_hosts
 ```
 
+Sample call for only performing the configuration activities related to SAP note 3108316 (RHEL 9 specific):
+```
+# ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316
+```
+
+Sample call for performing all configuration activities except those related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
 Sample call for only performing the configuration activities related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
 ```
 # ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316_02

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -334,7 +334,7 @@ sap_general_preconfigure_db_group_name: dba
 
 <!-- END: Role Input Parameters for sap_general_preconfigure -->
 
-## Tags
+## Tags (RHEL systems only)
 
 With the following tags, the role can be called to perform certain activities only:
 - tag `sap_general_preconfigure_installation`: Perform only the installation tasks

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -339,47 +339,44 @@ sap_general_preconfigure_db_group_name: dba
 With the following tags, the role can be called to perform certain activities only:
 - tag `sap_general_preconfigure_installation`: Perform only the installation tasks
 - tag `sap_general_preconfigure_configuration`: Perform only the configuration tasks
-- tag `sap_general_preconfigure_configuration_all_steps`: Perform all configuration tasks
 - tag `sap_general_preconfigure_3108316_03`: Perform only the tasks(s) related to this step of the SAP note.
 - tag `sap_general_preconfigure_etc_hosts`: Perform only the tasks(s) related to this step. This step might be one of multiple
   configuration activities of a SAP note. Also this step might be valid for multiple RHEL major releases.
 
-Sample call for only performing all installation and configuration tasks. This is the default behavior. If no tag is specified, all
-installation and configuration tasks are enabled:
+Sample call for only performing all installation and configuration tasks (sample playbook name sap.yml, see the next section for
+an example). This is the default behavior. If no tag is specified, all installation and configuration tasks are enabled:
 ```
-# ansible-playbook sap-general-preconfigure.yml
+# ansible-playbook sap.yml
 ```
 
 Sample call for only performing all installation tasks:
 ```
-# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_installation
+# ansible-playbook sap.yml --tags=sap_general_preconfigure_installation
 ```
 
-Sample call for only performing all configuration tasks. The tag sap_general_preconfigure_configuration is needed to only use
-the configuration tasks, and the tag sap_general_preconfigure_configuration_all_steps activates each individual configuration task. Both
-need to be enabled for running all the configuration tasks:
+Sample call for only performing all configuration tasks:
 ```
-# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_configuration_all_steps
+# ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration
 ```
 
 Sample call for only verifying and modifying the /etc/hosts file:
 ```
-# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_etc_hosts
+# ansible-playbook sap.yml --tags=sap_general_preconfigure_etc_hosts
 ```
 
 Sample call for performing all configuration steps except verifying and modifying the /etc/hosts file:
 ```
-# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_configuration_all_steps --skip_tags=sap_general_preconfigure_etc_hosts
+# ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_etc_hosts
 ```
 
-Sample call for only performing the configuration actitvities related to step 2 (SELinux settings) of SAP note 3108316:
+Sample call for only performing the configuration actitvities related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
 ```
-# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_3108316_02
+# ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316_02
 ```
 
-Sample call for performing all configuration actitvities except those related to step 2 (SELinux settings) of SAP note 3108316:
+Sample call for performing all configuration actitvities except those related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific):
 ```
-# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration,sap_general_preconfigure_configuration_all_steps --skip_tags=sap_general_preconfigure_3108316_02
+# ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_3108316_02
 ```
 
 ## Dependencies

--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-configuration.yml
@@ -3,12 +3,18 @@
 - name: Assert - List required SAP Notes
   ansible.builtin.debug:
     var: __sap_general_preconfigure_sapnotes_versions | difference([''])
+  tags:
+    - always
 
 - name: Gather service facts
   ansible.builtin.service_facts:
+  tags:
+    - always
 
 - name: Assert - Include configuration actions for required sapnotes
   ansible.builtin.include_tasks: "sapnote/assert-{{ sap_note_line_item.number }}.yml"
   with_items: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"
   loop_control:
     loop_var: sap_note_line_item
+  tags:
+    - always

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -3,6 +3,8 @@
 - name: Configure - List required SAP Notes
   ansible.builtin.debug:
     var: __sap_general_preconfigure_sapnotes_versions | difference([''])
+  tags:
+    - always
 
 - name: Configure - Set directory variables for setting SELinux file contexts
   ansible.builtin.set_fact:
@@ -16,11 +18,19 @@
       target: "{{ line_item }}(/.*)?"
       setype: 'usr_t'
   when: sap_general_preconfigure_modify_selinux_labels
+  tags:
+    - sap_general_preconfigure_3108316_02
+    - sap_general_preconfigure_2772999_02
+    - sap_general_preconfigure_selinux
 
 - name: Configure - Display directory variable
   ansible.builtin.debug:
     var: sap_general_preconfigure_fact_targets_setypes
   when: sap_general_preconfigure_modify_selinux_labels
+  tags:
+    - sap_general_preconfigure_3108316_02
+    - sap_general_preconfigure_2772999_02
+    - sap_general_preconfigure_selinux
 
 - name: Configure - Create directories
   ansible.builtin.file:
@@ -33,6 +43,11 @@
   loop_control:
     loop_var: line_item
   when: sap_general_preconfigure_create_directories or sap_general_preconfigure_modify_selinux_labels
+  tags:
+    - sap_general_preconfigure_create_directories
+    - sap_general_preconfigure_3108316_02
+    - sap_general_preconfigure_2772999_02
+    - sap_general_preconfigure_selinux
 
 - name: Configure - Include configuration actions for required sapnotes
   ansible.builtin.include_tasks:
@@ -41,5 +56,4 @@
   loop_control:
     loop_var: sap_note_line_item
   tags:
-    - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
+    - always

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -35,7 +35,8 @@
   when: sap_general_preconfigure_create_directories or sap_general_preconfigure_modify_selinux_labels
 
 - name: Configure - Include configuration actions for required sapnotes
-  ansible.builtin.include_tasks: "sapnote/{{ sap_note_line_item.number }}.yml"
+  ansible.builtin.include_tasks:
+    file: "sapnote/{{ sap_note_line_item.number }}.yml"
   with_items: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"
   loop_control:
     loop_var: sap_note_line_item

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -39,3 +39,6 @@
   with_items: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"
   loop_control:
     loop_var: sap_note_line_item
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps

--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -3,6 +3,9 @@
 - name: Display the role path
   ansible.builtin.debug:
     var: role_path
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Include OS specific vars, specific
   ansible.builtin.include_vars: '{{ item }}'
@@ -10,6 +13,9 @@
     - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_version }}.yml'
     - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_os_family }}.yml'
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Rename user sap_preconfigure variables if found, generic
   ansible.builtin.set_fact:
@@ -31,6 +37,9 @@
     sap_general_preconfigure_modify_etc_hosts: "{{ sap_preconfigure_modify_etc_hosts | d(sap_general_preconfigure_modify_etc_hosts) }}"
     sap_general_preconfigure_kernel_parameters: "{{ sap_preconfigure_kernel_parameters | d(sap_general_preconfigure_kernel_parameters) }}"
     sap_general_preconfigure_max_hostname_length: "{{ sap_preconfigure_max_hostname_length | d(sap_general_preconfigure_max_hostname_length) }}"
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Rename user sap_preconfigure variables if found, RHEL only
   ansible.builtin.set_fact:
@@ -52,25 +61,39 @@
     sap_general_preconfigure_2772999_09: "{{ (sap_preconfigure_2772999_09 | d(sap_general_preconfigure_2772999_09)) | d(false) }}"
     sap_general_preconfigure_2772999_10: "{{ (sap_preconfigure_2772999_10 | d(sap_general_preconfigure_2772999_10)) | d(false) }}"
   when: ansible_facts['distribution'] in ['RedHat']
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Rename sap_preconfigure_db_group_name if defined
   ansible.builtin.set_fact:
     sap_general_preconfigure_db_group_name: "{{ sap_preconfigure_db_group_name | d(sap_general_preconfigure_db_group_name) }}"
   when: sap_preconfigure_db_group_name is defined or sap_general_preconfigure_db_group_name is defined
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Set filename prefix to empty string if role is run in normal mode
   ansible.builtin.set_fact:
     __sap_general_preconfigure_fact_assert_filename_prefix: ""
   when: not sap_general_preconfigure_assert | d(false)
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Prepend filename with assert string if role is run in assert mode
   ansible.builtin.set_fact:
     __sap_general_preconfigure_fact_assert_filename_prefix: "assert-"
   when: sap_general_preconfigure_assert | d(false)
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 # required for installation and configuration tasks:
 - name: Gather package facts
   ansible.builtin.package_facts:
+  tags:
+    - sap_general_preconfigure_installation
 
 - name: Include tasks from 'installation.yml'
   ansible.builtin.include_tasks: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}installation.yml'
@@ -79,9 +102,14 @@
     - '{{ ansible_distribution.split("_")[0] }}'
     - '{{ ansible_distribution }}'
     - '{{ ansible_os_family }}.yml'
+  tags:
+    - sap_general_preconfigure_installation
 
 - name: Gather package facts again after the installation phase
   ansible.builtin.package_facts:
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration
 
 - name: Include tasks from 'configuration.yml'
   ansible.builtin.include_tasks: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}configuration.yml'
@@ -90,7 +118,12 @@
     - '{{ ansible_distribution.split("_")[0] }}'
     - '{{ ansible_distribution }}'
     - '{{ ansible_os_family }}.yml'
+  tags:
+    - sap_general_preconfigure_configuration
 
 # allow a reboot at the end of the preconfigure role
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+  tags:
+    - sap_general_preconfigure_installation
+    - sap_general_preconfigure_configuration

--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -4,8 +4,7 @@
   ansible.builtin.debug:
     var: role_path
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Include OS specific vars, specific
   ansible.builtin.include_vars: '{{ item }}'
@@ -14,8 +13,7 @@
     - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_os_family }}.yml'
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Rename user sap_preconfigure variables if found, generic
   ansible.builtin.set_fact:
@@ -38,8 +36,7 @@
     sap_general_preconfigure_kernel_parameters: "{{ sap_preconfigure_kernel_parameters | d(sap_general_preconfigure_kernel_parameters) }}"
     sap_general_preconfigure_max_hostname_length: "{{ sap_preconfigure_max_hostname_length | d(sap_general_preconfigure_max_hostname_length) }}"
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Rename user sap_preconfigure variables if found, RHEL only
   ansible.builtin.set_fact:
@@ -62,32 +59,28 @@
     sap_general_preconfigure_2772999_10: "{{ (sap_preconfigure_2772999_10 | d(sap_general_preconfigure_2772999_10)) | d(false) }}"
   when: ansible_facts['distribution'] in ['RedHat']
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Rename sap_preconfigure_db_group_name if defined
   ansible.builtin.set_fact:
     sap_general_preconfigure_db_group_name: "{{ sap_preconfigure_db_group_name | d(sap_general_preconfigure_db_group_name) }}"
   when: sap_preconfigure_db_group_name is defined or sap_general_preconfigure_db_group_name is defined
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Set filename prefix to empty string if role is run in normal mode
   ansible.builtin.set_fact:
     __sap_general_preconfigure_fact_assert_filename_prefix: ""
   when: not sap_general_preconfigure_assert | d(false)
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Prepend filename with assert string if role is run in assert mode
   ansible.builtin.set_fact:
     __sap_general_preconfigure_fact_assert_filename_prefix: "assert-"
   when: sap_general_preconfigure_assert | d(false)
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 # required for installation and configuration tasks:
 - name: Gather package facts
@@ -111,25 +104,23 @@
 - name: Gather package facts again after the installation phase
   ansible.builtin.package_facts:
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Include tasks from 'configuration.yml'
   ansible.builtin.include_tasks:
     file: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}configuration.yml'
     apply:
-      tags: sap_general_preconfigure_configuration_all_steps
+      tags: sap_general_preconfigure_configuration
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_configuration | d(false)
   with_first_found:
     - '{{ ansible_distribution.split("_")[0] }}'
     - '{{ ansible_distribution }}'
     - '{{ ansible_os_family }}.yml'
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 # allow a reboot at the end of the preconfigure role
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
   tags:
-    - sap_general_preconfigure_installation
-    - sap_general_preconfigure_configuration
+    - always

--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -96,7 +96,10 @@
     - sap_general_preconfigure_installation
 
 - name: Include tasks from 'installation.yml'
-  ansible.builtin.include_tasks: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}installation.yml'
+  ansible.builtin.include_tasks:
+    file: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}installation.yml'
+    apply:
+      tags: sap_general_preconfigure_installation
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_installation | d(false)
   with_first_found:
     - '{{ ansible_distribution.split("_")[0] }}'
@@ -112,7 +115,10 @@
     - sap_general_preconfigure_configuration
 
 - name: Include tasks from 'configuration.yml'
-  ansible.builtin.include_tasks: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}configuration.yml'
+  ansible.builtin.include_tasks:
+    file: '{{ item }}/{{ __sap_general_preconfigure_fact_assert_filename_prefix }}configuration.yml'
+    apply:
+      tags: sap_general_preconfigure_configuration_all_steps
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_configuration | d(false)
   with_first_found:
     - '{{ ansible_distribution.split("_")[0] }}'
@@ -120,6 +126,7 @@
     - '{{ ansible_os_family }}.yml'
   tags:
     - sap_general_preconfigure_configuration
+#    - sap_general_preconfigure_configuration_all_steps
 
 # allow a reboot at the end of the preconfigure role
 - name: Flush handlers

--- a/roles/sap_general_preconfigure/tasks/main.yml
+++ b/roles/sap_general_preconfigure/tasks/main.yml
@@ -126,7 +126,6 @@
     - '{{ ansible_os_family }}.yml'
   tags:
     - sap_general_preconfigure_configuration
-#    - sap_general_preconfigure_configuration_all_steps
 
 # allow a reboot at the end of the preconfigure role
 - name: Flush handlers

--- a/roles/sap_general_preconfigure/tasks/sapnote/0941735.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/0941735.yml
@@ -9,7 +9,7 @@
           swaptotal_mb = {{ ansible_swaptotal_mb }};
           sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '../RedHat/generic/configure-tmpfs.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/configure-tmpfs.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/0941735.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/0941735.yml
@@ -10,12 +10,10 @@
           sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/configure-tmpfs.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_0941735 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_0941735
     - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/0941735.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/0941735.yml
@@ -8,7 +8,14 @@
           memtotal_mb = {{ ansible_memtotal_mb }};
           swaptotal_mb = {{ ansible_swaptotal_mb }};
           sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/configure-tmpfs.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_0941735 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_0941735
+    - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/1391070.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/1391070.yml
@@ -7,12 +7,10 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).version }}): Configure uuidd"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/configure-uuidd.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1391070 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_1391070
     - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/1391070.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/1391070.yml
@@ -5,7 +5,14 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).version }}): Configure uuidd"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/configure-uuidd.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1391070 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_1391070
+    - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/1391070.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/1391070.yml
@@ -6,7 +6,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).version }}): Configure uuidd"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '../RedHat/generic/configure-uuidd.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/configure-uuidd.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/1771258.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/1771258.yml
@@ -7,12 +7,10 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).version }}): User and system resource limits"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/increase-nofile-limits.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/increase-nofile-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1771258 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_1771258
     - sap_general_preconfigure_nofile_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/1771258.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/1771258.yml
@@ -6,7 +6,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).version }}): User and system resource limits"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '../RedHat/generic/increase-nofile-limits.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/increase-nofile-limits.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/1771258.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/1771258.yml
@@ -5,7 +5,14 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).version }}): User and system resource limits"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/increase-nofile-limits.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/increase-nofile-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1771258 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_1771258
+    - sap_general_preconfigure_nofile_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
@@ -6,44 +6,33 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).version }}): Configure RHEL 7"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '2002167/02-configuration-changes.yml'
   ansible.builtin.import_tasks: 2002167/02-configuration-changes.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_02 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_02
 
 - name: Import tasks from '2002167/03-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-setting-the-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_03 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_03
 
 - name: Import tasks from '2002167/04-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_04 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_04
-#    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2002167/05-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_05 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_05
-#    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2002167/06-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-additional-notes-for-installing-sap-systems.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_06 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_06
-#    - sap_general_preconfigure_libldap
-#    - sap_general_preconfigure_liblber
-#    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
@@ -11,28 +11,33 @@
   ansible.builtin.import_tasks: 2002167/02-configuration-changes.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_02 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_02
 
 - name: Import tasks from '2002167/03-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-setting-the-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_03 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_03
 
 - name: Import tasks from '2002167/04-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_04 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_04
 
 - name: Import tasks from '2002167/05-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_05 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_05
 
 - name: Import tasks from '2002167/06-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-additional-notes-for-installing-sap-systems.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_06 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_06

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
@@ -14,8 +14,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_02
-    - sap_general_preconfigure_firewall
-    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2002167/03-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-setting-the-hostname.yml
@@ -23,9 +21,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_03
-    - sap_general_preconfigure_hostname
-    - sap_general_preconfigure_etc_hosts
-    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2002167/04-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-linux-kernel-parameters.yml
@@ -33,7 +28,7 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_04
-    - sap_general_preconfigure_kernel_parameters
+#    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2002167/05-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-process-resource-limits.yml
@@ -41,7 +36,7 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_05
-    - sap_general_preconfigure_nproc_limits
+#    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2002167/06-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-additional-notes-for-installing-sap-systems.yml
@@ -49,6 +44,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_06
-    - sap_general_preconfigure_libldap
-    - sap_general_preconfigure_liblber
-    - sap_general_preconfigure_systemd_tmpfiles
+#    - sap_general_preconfigure_libldap
+#    - sap_general_preconfigure_liblber
+#    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
@@ -4,23 +4,51 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).version }}): Configure RHEL 7"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '2002167/02-configuration-changes.yml'
   ansible.builtin.import_tasks: 2002167/02-configuration-changes.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_02 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_02
+    - sap_general_preconfigure_firewall
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2002167/03-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-setting-the-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_03 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_03
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2002167/04-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_04 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_04
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2002167/05-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_05 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_05
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2002167/06-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-additional-notes-for-installing-sap-systems.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_06 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_06
+    - sap_general_preconfigure_libldap
+    - sap_general_preconfigure_liblber
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167.yml
@@ -5,7 +5,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).version }}): Configure RHEL 7"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '2002167/02-configuration-changes.yml'
   ansible.builtin.import_tasks: 2002167/02-configuration-changes.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/02-assert-configuration-changes.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/02-assert-configuration-changes.yml
@@ -3,13 +3,21 @@
 - name: Assert 2002167-2a
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 2a: Configure the Firewall"
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '../../RedHat/generic/assert-firewall.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-firewall.yml
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Assert 2002167-2b
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 2b: Configure SELinux"
+  tags:
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '../../RedHat/generic/assert-selinux.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-selinux.yml
+  tags:
+    - sap_general_preconfigure_selinux

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/02-configuration-changes.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/02-configuration-changes.yml
@@ -3,9 +3,14 @@
 - name: Configure 2002167-2a
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 2a: Configure the Firewall"
+  tags:
+    - sap_general_preconfigure_firewall
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '../../RedHat/generic/configure-firewall.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-firewall.yml
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Configure 2002167-2b
   ansible.builtin.debug:
@@ -13,3 +18,5 @@
 
 - name: Import tasks from '../../RedHat/generic/configure-selinux.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-selinux.yml
+  tags:
+    - sap_general_preconfigure_selinux

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-assert-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-assert-setting-the-hostname.yml
@@ -3,12 +3,22 @@
 - name: Assert 2002167-3
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 3: Setting the Hostname"
+  tags:
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns_name_resolution
 
 - name: Import tasks from '../../RedHat/generic/assert-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-hostname.yml
+  tags:
+    - sap_general_preconfigure_hostname
 
 - name: Import tasks from '../../RedHat/generic/assert-etc-hosts.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-etc-hosts.yml
+  tags:
+    - sap_general_preconfigure_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/assert-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-dns-name-resolution.yml
+  tags:
+    - sap_general_preconfigure_dns_name_resolution

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -3,12 +3,22 @@
 - name: Configure 2002167-3
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 3: Setting the Hostname"
+  tags:
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns_name_resolution
 
 - name: Import tasks from '../../RedHat/generic/configure-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-hostname.yml
+  tags:
+    - sap_general_preconfigure_hostname
 
 - name: Import tasks from '../../RedHat/generic/configure-etc-hosts.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-etc-hosts.yml
+  tags:
+    - sap_general_preconfigure_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/check-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml
+  tags:
+    - sap_general_preconfigure_dns_name_resolution

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/04-assert-linux-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/04-assert-linux-kernel-parameters.yml
@@ -3,6 +3,10 @@
 - name: Assert 2002167-4
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 4: Linux Kernel Parameters"
+  tags:
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '../../RedHat/generic/assert-kernel-parameters.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-kernel-parameters.yml
+  tags:
+    - sap_general_preconfigure_kernel_parameters

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/04-linux-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/04-linux-kernel-parameters.yml
@@ -3,6 +3,10 @@
 - name: Configure 2002167-4
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 4: Linux Kernel Parameters"
+  tags:
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '../../RedHat/generic/configure-kernel-parameters.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-kernel-parameters.yml
+  tags:
+    - sap_general_preconfigure_kernel_parameters

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/05-assert-process-resource-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/05-assert-process-resource-limits.yml
@@ -3,9 +3,15 @@
 - name: Assert 2002167-5
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 5: Process Resource Limits"
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/assert-limits-conf-file.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-limits-conf-file.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/assert-nproc-limits.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-nproc-limits.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/05-process-resource-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/05-process-resource-limits.yml
@@ -3,6 +3,10 @@
 - name: Configure 2002167-5
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 5: Process Resource Limits"
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/increase-nproc-limits.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/increase-nproc-limits.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/06-additional-notes-for-installing-sap-systems.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/06-additional-notes-for-installing-sap-systems.yml
@@ -3,18 +3,28 @@
 - name: Configure 2002167-6
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 6: Additional notes for installing SAP systems"
+  tags:
+    - sap_general_preconfigure_libldap
+    - sap_general_preconfigure_liblber
+    - sap_general_preconfigure_systemd_tmpfiles
 
 - name: Link LDAP library libldap
   ansible.builtin.file:
     src: /usr/lib64/libldap-2.3.so.0
     dest: /usr/lib64/libldap.so.199
     state: link
+  tags:
+    - sap_general_preconfigure_libldap
 
 - name: Link LDAP library liblber
   ansible.builtin.file:
     src: /usr/lib64/liblber-2.3.so.0
     dest: /usr/lib64/liblber.so.199
     state: link
+  tags:
+    - sap_general_preconfigure_liblber
 
 - name: Import tasks from '../../RedHat/generic/configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-systemd-tmpfiles.yml
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/06-assert-additional-notes-for-installing-sap-systems.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/06-assert-additional-notes-for-installing-sap-systems.yml
@@ -3,11 +3,17 @@
 - name: Assert 2002167-6
   ansible.builtin.debug:
     msg: "SAP note 2002167 Step 6: Additional notes for installing SAP systems"
+  tags:
+    - sap_general_preconfigure_libldap
+    - sap_general_preconfigure_liblber
+    - sap_general_preconfigure_systemd_tmpfiles
 
 - name: Get info about file /usr/lib64/libldap.so.199
   ansible.builtin.stat:
     path: /usr/lib64/libldap.so.199
   register: __sap_general_preconfigure_register_stat_libldap_assert
+  tags:
+    - sap_general_preconfigure_libldap
 
 - name: Assert that file /usr/lib64/libldap.so.199 exists
   ansible.builtin.assert:
@@ -15,6 +21,8 @@
     fail_msg: "FAIL: File /usr/lib64/libldap.so.199 does not exist!"
     success_msg: "PASS: File /usr/lib64/libldap.so.199 exist."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+  tags:
+    - sap_general_preconfigure_libldap
 
 - name: Assert that file /usr/lib64/libldap.so.199 is a link
   ansible.builtin.assert:
@@ -23,6 +31,8 @@
     success_msg: "PASS: File /usr/lib64/libldap.so.199 is a link."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   when: __sap_general_preconfigure_register_stat_libldap_assert.stat.exists
+  tags:
+    - sap_general_preconfigure_libldap
 
 - name: Assert that file /usr/lib64/libldap.so.199 is a link to /usr/lib64/libldap-2.3.so.0
   ansible.builtin.assert:
@@ -31,11 +41,15 @@
     success_msg: "PASS: File /usr/lib64/libldap.so.199 is a link to /usr/lib64/libldap-2.3.so.0."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   when: __sap_general_preconfigure_register_stat_libldap_assert.stat.exists
+  tags:
+    - sap_general_preconfigure_libldap
 
 - name: Get info about file /usr/lib64/liblber.so.199
   ansible.builtin.stat:
     path: /usr/lib64/liblber.so.199
   register: __sap_general_preconfigure_register_stat_liblber_assert
+  tags:
+    - sap_general_preconfigure_liblber
 
 - name: Assert that file /usr/lib64/liblber.so.199 exists
   ansible.builtin.assert:
@@ -43,6 +57,8 @@
     fail_msg: "FAIL: File /usr/lib64/liblber.so.199 does not exist!"
     success_msg: "PASS: File /usr/lib64/liblber.so.199 exist."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+  tags:
+    - sap_general_preconfigure_liblber
 
 - name: Assert that file /usr/lib64/liblber.so.199 exists and is a link
   ansible.builtin.assert:
@@ -51,6 +67,8 @@
     success_msg: "PASS: File /usr/lib64/liblber.so.199 is a link."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   when: __sap_general_preconfigure_register_stat_liblber_assert.stat.exists
+  tags:
+    - sap_general_preconfigure_liblber
 
 - name: Assert that file /usr/lib64/liblber.so.199 is a link to /usr/lib64/liblber-2.3.so.0
   ansible.builtin.assert:
@@ -59,6 +77,10 @@
     success_msg: "PASS: File /usr/lib64/liblber.so.199 is a link to /usr/lib64/liblber-2.3.so.0."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   when: __sap_general_preconfigure_register_stat_liblber_assert.stat.exists
+  tags:
+    - sap_general_preconfigure_liblber
 
 - name: Import tasks from '../../RedHat/generic/assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-systemd-tmpfiles.yml
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
@@ -14,7 +14,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_02
-    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2772999/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-configure-hostname.yml
@@ -22,9 +21,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_03
-    - sap_general_preconfigure_hostname
-    - sap_general_preconfigure_etc_hosts
-    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2772999/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-configure-network-time-and-date.yml
@@ -32,7 +28,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_04
-    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '2772999/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-configure-firewall.yml
@@ -40,7 +35,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_05
-    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '2772999/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-configure-uuidd.yml
@@ -48,7 +42,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_06
-    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '2772999/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-configure-tmpfs.yml
@@ -56,7 +49,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_07
-    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '2772999/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-configure-linux-kernel-parameters.yml
@@ -64,7 +56,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_08
-    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2772999/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-configure-process-resource-limits.yml
@@ -72,7 +63,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_09
-    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2772999/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-configure-systemd-tmpfiles.yml
@@ -80,4 +70,3 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_10
-    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
@@ -4,39 +4,80 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).version }}): Configure RHEL 8"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '2772999/02-configure-selinux.yml'
   ansible.builtin.import_tasks: 2772999/02-configure-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_02 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_02
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2772999/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-configure-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_03 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_03
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2772999/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-configure-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_04 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_04
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '2772999/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-configure-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_05 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_05
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '2772999/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_06 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_06
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '2772999/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_07 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_07
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '2772999/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-configure-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_08 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_08
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2772999/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-configure-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_09
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2772999/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-configure-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_10 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_10
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
@@ -5,7 +5,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).version }}): Configure RHEL 8"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '2772999/02-configure-selinux.yml'
   ansible.builtin.import_tasks: 2772999/02-configure-selinux.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
@@ -11,52 +11,61 @@
   ansible.builtin.import_tasks: 2772999/02-configure-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_02 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_02
 
 - name: Import tasks from '2772999/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-configure-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_03 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_03
 
 - name: Import tasks from '2772999/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-configure-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_04 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_04
 
 - name: Import tasks from '2772999/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-configure-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_05 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_05
 
 - name: Import tasks from '2772999/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_06 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_06
 
 - name: Import tasks from '2772999/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_07 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_07
 
 - name: Import tasks from '2772999/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-configure-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_08 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_08
 
 - name: Import tasks from '2772999/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-configure-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_09
 
 - name: Import tasks from '2772999/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-configure-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_10 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999.yml
@@ -6,67 +6,57 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).version }}): Configure RHEL 8"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '2772999/02-configure-selinux.yml'
   ansible.builtin.import_tasks: 2772999/02-configure-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_02 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_02
 
 - name: Import tasks from '2772999/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-configure-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_03 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_03
 
 - name: Import tasks from '2772999/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-configure-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_04 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_04
 
 - name: Import tasks from '2772999/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-configure-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_05 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_05
 
 - name: Import tasks from '2772999/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_06 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_06
 
 - name: Import tasks from '2772999/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_07 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_07
 
 - name: Import tasks from '2772999/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-configure-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_08 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_08
 
 - name: Import tasks from '2772999/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-configure-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_09
 
 - name: Import tasks from '2772999/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-configure-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_10 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/02-assert-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/02-assert-selinux.yml
@@ -3,6 +3,10 @@
 - name: Assert 2772999-2
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 2: Configure SELinux"
+  tags:
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '../../RedHat/generic/assert-selinux.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-selinux.yml
+  tags:
+    - sap_general_preconfigure_selinux

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/02-configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/02-configure-selinux.yml
@@ -3,6 +3,10 @@
 - name: Configure 2772999-2
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 2: Configure SELinux"
+  tags:
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '../../RedHat/generic/configure-selinux.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-selinux.yml
+  tags:
+    - sap_general_preconfigure_selinux

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-assert-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-assert-hostname.yml
@@ -3,12 +3,22 @@
 - name: Assert 2772999-3
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 3: Configure Hostname"
+  tags:
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns_name_resolution
 
 - name: Import tasks from '../../RedHat/generic/assert-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-hostname.yml
+  tags:
+    - sap_general_preconfigure_hostname
 
 - name: Import tasks from '../../RedHat/generic/assert-etc-hosts.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-etc-hosts.yml
+  tags:
+    - sap_general_preconfigure_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/assert-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-dns-name-resolution.yml
+  tags:
+    - sap_general_preconfigure_dns_name_resolution

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
@@ -3,12 +3,22 @@
 - name: Configure 2772999-3
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 3: Configure Hostname"
+  tags:
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns_name_resolution
 
 - name: Import tasks from '../../RedHat/generic/configure-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-hostname.yml
+  tags:
+    - sap_general_preconfigure_hostname
 
 - name: Import tasks from '../../RedHat/generic/configure-etc-hosts.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-etc-hosts.yml
+  tags:
+    - sap_general_preconfigure_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/check-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml
+  tags:
+    - sap_general_preconfigure_dns_name_resolution

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/04-assert-network-time-and-date.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/04-assert-network-time-and-date.yml
@@ -3,6 +3,8 @@
 - name: Assert 2772999-4
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 4: Configure Network Time and Date"
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 # Reason for noqa: We need to get the current status only
 - name: Get status of chronyd # noqa command-instead-of-module
@@ -10,6 +12,8 @@
   register: __sap_general_preconfigure_register_chronyd_status_assert
   ignore_errors: yes
   changed_when: no
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Assert that chronyd is enabled
   ansible.builtin.assert:
@@ -17,6 +21,8 @@
     fail_msg: "FAIL: Service 'chronyd' is not enabled!"
     success_msg: "PASS: Service 'chronyd' is enabled."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Assert that chronyd is active
   ansible.builtin.assert:
@@ -24,3 +30,5 @@
     fail_msg: "FAIL: Service 'chronyd' is not active!"
     success_msg: "PASS: Service 'chronyd' is active."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+  tags:
+    - sap_general_preconfigure_network_time_and_date

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/04-configure-network-time-and-date.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/04-configure-network-time-and-date.yml
@@ -3,9 +3,13 @@
 - name: Configure 2772999-4
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 4: Configure Network Time and Date"
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Start and enable service chronyd
   ansible.builtin.systemd:
     name: chronyd
     state: started
     enabled: yes
+  tags:
+    - sap_general_preconfigure_network_time_and_date

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/05-assert-firewall.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/05-assert-firewall.yml
@@ -3,6 +3,10 @@
 - name: Assert 2772999-5
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 5: Configure the Firewall"
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '../../RedHat/generic/assert-firewall.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-firewall.yml
+  tags:
+    - sap_general_preconfigure_firewall

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/05-configure-firewall.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/05-configure-firewall.yml
@@ -3,6 +3,10 @@
 - name: Configure 2772999-5
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 5: Configure the Firewall"
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '../../RedHat/generic/configure-firewall.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-firewall.yml
+  tags:
+    - sap_general_preconfigure_firewall

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/06-assert-uuidd.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/06-assert-uuidd.yml
@@ -3,6 +3,10 @@
 - name: Assert 2772999-6
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 6: Configure uuidd"
+  tags:
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '../../RedHat/generic/assert-uuidd.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-uuidd.yml
+  tags:
+    - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/06-configure-uuidd.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/06-configure-uuidd.yml
@@ -3,6 +3,10 @@
 - name: Configure 2772999-6
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 6: Configure uuidd"
+  tags:
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '../../RedHat/generic/configure-uuidd.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-uuidd.yml
+  tags:
+    - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/07-assert-tmpfs.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/07-assert-tmpfs.yml
@@ -6,6 +6,10 @@
     memtotal_mb = {{ ansible_memtotal_mb }};
     swaptotal_mb = {{ ansible_swaptotal_mb }};
     sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
+  tags:
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '../../RedHat/generic/assert-tmpfs.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-tmpfs.yml
+  tags:
+    - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/07-configure-tmpfs.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/07-configure-tmpfs.yml
@@ -6,6 +6,10 @@
     memtotal_mb = {{ ansible_memtotal_mb }};
     swaptotal_mb = {{ ansible_swaptotal_mb }};
     sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
+  tags:
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '../../RedHat/generic/configure-tmpfs.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-tmpfs.yml
+  tags:
+    - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/08-assert-linux-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/08-assert-linux-kernel-parameters.yml
@@ -3,6 +3,10 @@
 - name: Assert 2772999-8
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 8: Configure Linux Kernel Parameters"
+  tags:
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '../../RedHat/generic/assert-kernel-parameters.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-kernel-parameters.yml
+  tags:
+    - sap_general_preconfigure_kernel_parameters

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/08-configure-linux-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/08-configure-linux-kernel-parameters.yml
@@ -3,6 +3,10 @@
 - name: Configure 2772999-8
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 8: Configure Linux Kernel Parameters"
+  tags:
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '../../RedHat/generic/configure-kernel-parameters.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-kernel-parameters.yml
+  tags:
+    - sap_general_preconfigure_kernel_parameters

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/09-assert-process-resource-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/09-assert-process-resource-limits.yml
@@ -3,9 +3,15 @@
 - name: Assert 2772999-9
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 9: Configure Process Resource Limits"
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/assert-limits-conf-file.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-limits-conf-file.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/assert-nproc-limits.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-nproc-limits.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/09-configure-process-resource-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/09-configure-process-resource-limits.yml
@@ -3,6 +3,10 @@
 - name: Configure 2772999-9
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 9: Configure Process Resource Limits"
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/increase-nproc-limits.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/increase-nproc-limits.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/10-assert-systemd-tmpfiles.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/10-assert-systemd-tmpfiles.yml
@@ -3,6 +3,10 @@
 - name: Assert 2772999-10
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 10: Configure systemd-tmpfiles"
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles
 
 - name: Import tasks from '../../RedHat/generic/assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-systemd-tmpfiles.yml
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/10-configure-systemd-tmpfiles.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/10-configure-systemd-tmpfiles.yml
@@ -3,6 +3,10 @@
 - name: Configure 2772999-10
   ansible.builtin.debug:
     msg: "SAP note 2772999 Step 10: Configure systemd-tmpfiles"
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles
 
 - name: Import tasks from '../../RedHat/generic/configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-systemd-tmpfiles.yml
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
@@ -14,7 +14,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_02
-    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '3108316/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-configure-hostname.yml
@@ -22,9 +21,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_03
-    - sap_general_preconfigure_hostname
-    - sap_general_preconfigure_etc_hosts
-    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '3108316/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-configure-network-time-and-date.yml
@@ -32,7 +28,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_04
-    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '3108316/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-configure-firewall.yml
@@ -40,7 +35,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_05
-    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '3108316/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-configure-uuidd.yml
@@ -48,7 +42,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_06
-    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '3108316/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-configure-tmpfs.yml
@@ -56,7 +49,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_07
-    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '3108316/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-configure-linux-kernel-parameters.yml
@@ -64,7 +56,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_08
-    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '3108316/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-configure-process-resource-limits.yml
@@ -72,7 +63,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_09
-    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '3108316/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-configure-systemd-tmpfiles.yml
@@ -80,4 +70,3 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_10
-    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
@@ -11,52 +11,61 @@
   ansible.builtin.import_tasks: 3108316/02-configure-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_02 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_02
 
 - name: Import tasks from '3108316/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-configure-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_03 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_03
 
 - name: Import tasks from '3108316/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-configure-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_04 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_04
 
 - name: Import tasks from '3108316/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-configure-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_05 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_05
 
 - name: Import tasks from '3108316/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_06 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_06
 
 - name: Import tasks from '3108316/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_07 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_07
 
 - name: Import tasks from '3108316/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-configure-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_08 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_08
 
 - name: Import tasks from '3108316/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-configure-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_09 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_09
 
 - name: Import tasks from '3108316/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-configure-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_10 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
@@ -3,40 +3,81 @@
 - name: Configure - Display SAP note number 3108316 and its version
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).number }}
-          (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 8"
+          (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 9"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '3108316/02-configure-selinux.yml'
   ansible.builtin.import_tasks: 3108316/02-configure-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_02 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_02
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '3108316/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-configure-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_03 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_03
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '3108316/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-configure-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_04 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_04
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '3108316/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-configure-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_05 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_05
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '3108316/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_06 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_06
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '3108316/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_07 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_07
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '3108316/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-configure-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_08 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_08
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '3108316/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-configure-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_09 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_09
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '3108316/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-configure-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_10 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_10
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
@@ -6,67 +6,57 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 9"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '3108316/02-configure-selinux.yml'
   ansible.builtin.import_tasks: 3108316/02-configure-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_02 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_02
 
 - name: Import tasks from '3108316/03-configure-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-configure-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_03 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_03
 
 - name: Import tasks from '3108316/04-configure-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-configure-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_04 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_04
 
 - name: Import tasks from '3108316/05-configure-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-configure-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_05 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_05
 
 - name: Import tasks from '3108316/06-configure-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-configure-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_06 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_06
 
 - name: Import tasks from '3108316/07-configure-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-configure-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_07 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_07
 
 - name: Import tasks from '3108316/08-configure-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-configure-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_08 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_08
 
 - name: Import tasks from '3108316/09-configure-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-configure-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_09 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_09
 
 - name: Import tasks from '3108316/10-configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-configure-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_10 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316.yml
@@ -5,7 +5,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 9"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '3108316/02-configure-selinux.yml'
   ansible.builtin.import_tasks: 3108316/02-configure-selinux.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/02-assert-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/02-assert-selinux.yml
@@ -3,6 +3,10 @@
 - name: Assert 3108316-2
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 2: Configure SELinux"
+  tags:
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '../../RedHat/generic/assert-selinux.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-selinux.yml
+  tags:
+    - sap_general_preconfigure_selinux

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/02-configure-selinux.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/02-configure-selinux.yml
@@ -3,6 +3,10 @@
 - name: Configure 3108316-2
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 2: Configure SELinux"
+  tags:
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '../../RedHat/generic/configure-selinux.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-selinux.yml
+  tags:
+    - sap_general_preconfigure_selinux

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-assert-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-assert-hostname.yml
@@ -3,12 +3,22 @@
 - name: Assert 3108316-3
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 3: Configure Hostname"
+  tags:
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns_name_resolution
 
 - name: Import tasks from '../../RedHat/generic/assert-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-hostname.yml
+  tags:
+    - sap_general_preconfigure_hostname
 
 - name: Import tasks from '../../RedHat/generic/assert-etc-hosts.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-etc-hosts.yml
+  tags:
+    - sap_general_preconfigure_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/assert-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-dns-name-resolution.yml
+  tags:
+    - sap_general_preconfigure_dns_name_resolution

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
@@ -3,12 +3,22 @@
 - name: Configure 3108316-3
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 3: Configure Hostname"
+  tags:
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns_name_resolution
 
 - name: Import tasks from '../../RedHat/generic/configure-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-hostname.yml
+  tags:
+    - sap_general_preconfigure_hostname
 
 - name: Import tasks from '../../RedHat/generic/configure-etc-hosts.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-etc-hosts.yml
+  tags:
+    - sap_general_preconfigure_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/check-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml
+  tags:
+    - sap_general_preconfigure_dns_name_resolution

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/04-assert-network-time-and-date.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/04-assert-network-time-and-date.yml
@@ -3,6 +3,8 @@
 - name: Assert 3108316-4
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 4: Configure Network Time and Date"
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 # Reason for noqa: We need to get the current status only
 - name: Get status of chronyd # noqa command-instead-of-module
@@ -10,6 +12,8 @@
   register: __sap_general_preconfigure_register_chronyd_status_assert
   ignore_errors: yes
   changed_when: no
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Assert that chronyd is enabled
   ansible.builtin.assert:
@@ -17,6 +21,8 @@
     fail_msg: "FAIL: Service 'chronyd' is not enabled!"
     success_msg: "PASS: Service 'chronyd' is enabled."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Assert that chronyd is active
   ansible.builtin.assert:
@@ -24,3 +30,5 @@
     fail_msg: "FAIL: Service 'chronyd' is not active!"
     success_msg: "PASS: Service 'chronyd' is active."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+  tags:
+    - sap_general_preconfigure_network_time_and_date

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/04-configure-network-time-and-date.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/04-configure-network-time-and-date.yml
@@ -3,9 +3,13 @@
 - name: Configure 3108316-4
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 4: Configure Network Time and Date"
+  tags:
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Start and enable service chronyd
   ansible.builtin.systemd:
     name: chronyd
     state: started
     enabled: yes
+  tags:
+    - sap_general_preconfigure_network_time_and_date

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/05-assert-firewall.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/05-assert-firewall.yml
@@ -3,6 +3,10 @@
 - name: Assert 3108316-5
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 5: Configure the Firewall"
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '../../RedHat/generic/assert-firewall.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-firewall.yml
+  tags:
+    - sap_general_preconfigure_firewall

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/05-configure-firewall.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/05-configure-firewall.yml
@@ -3,6 +3,10 @@
 - name: Configure 3108316-5
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 5: Configure the Firewall"
+  tags:
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '../../RedHat/generic/configure-firewall.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-firewall.yml
+  tags:
+    - sap_general_preconfigure_firewall

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/06-assert-uuidd.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/06-assert-uuidd.yml
@@ -3,6 +3,10 @@
 - name: Assert 3108316-6
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 6: Configure uuidd"
+  tags:
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '../../RedHat/generic/assert-uuidd.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-uuidd.yml
+  tags:
+    - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/06-configure-uuidd.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/06-configure-uuidd.yml
@@ -3,6 +3,10 @@
 - name: Configure 3108316-6
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 6: Configure uuidd"
+  tags:
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '../../RedHat/generic/configure-uuidd.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-uuidd.yml
+  tags:
+    - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/07-assert-tmpfs.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/07-assert-tmpfs.yml
@@ -6,6 +6,10 @@
     memtotal_mb = {{ ansible_memtotal_mb }};
     swaptotal_mb = {{ ansible_swaptotal_mb }};
     sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
+  tags:
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '../../RedHat/generic/assert-tmpfs.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-tmpfs.yml
+  tags:
+    - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/07-configure-tmpfs.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/07-configure-tmpfs.yml
@@ -6,6 +6,10 @@
     memtotal_mb = {{ ansible_memtotal_mb }};
     swaptotal_mb = {{ ansible_swaptotal_mb }};
     sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
+  tags:
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '../../RedHat/generic/configure-tmpfs.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-tmpfs.yml
+  tags:
+    - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/08-assert-linux-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/08-assert-linux-kernel-parameters.yml
@@ -3,6 +3,10 @@
 - name: Assert 3108316-8
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 8: Configure Linux Kernel Parameters"
+  tags:
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '../../RedHat/generic/assert-kernel-parameters.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-kernel-parameters.yml
+  tags:
+    - sap_general_preconfigure_kernel_parameters

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/08-configure-linux-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/08-configure-linux-kernel-parameters.yml
@@ -3,6 +3,10 @@
 - name: Configure 3108316-8
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 8: Configure Linux Kernel Parameters"
+  tags:
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '../../RedHat/generic/configure-kernel-parameters.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-kernel-parameters.yml
+  tags:
+    - sap_general_preconfigure_kernel_parameters

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/09-assert-process-resource-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/09-assert-process-resource-limits.yml
@@ -3,9 +3,15 @@
 - name: Assert 3108316-9
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 9: Configure Process Resource Limits"
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/assert-limits-conf-file.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-limits-conf-file.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/assert-nproc-limits.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-nproc-limits.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/09-configure-process-resource-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/09-configure-process-resource-limits.yml
@@ -3,6 +3,10 @@
 - name: Configure 3108316-9
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 9: Configure Process Resource Limits"
+  tags:
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '../../RedHat/generic/increase-nproc-limits.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/increase-nproc-limits.yml
+  tags:
+    - sap_general_preconfigure_nproc_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/10-assert-systemd-tmpfiles.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/10-assert-systemd-tmpfiles.yml
@@ -3,6 +3,10 @@
 - name: Assert 3108316-10
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 10: Configure systemd-tmpfiles"
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles
 
 - name: Import tasks from '../../RedHat/generic/assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/assert-systemd-tmpfiles.yml
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/10-configure-systemd-tmpfiles.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/10-configure-systemd-tmpfiles.yml
@@ -3,6 +3,10 @@
 - name: Configure 3108316-10
   ansible.builtin.debug:
     msg: "SAP note 3108316 Step 10: Configure systemd-tmpfiles"
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles
 
 - name: Import tasks from '../../RedHat/generic/configure-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-systemd-tmpfiles.yml
+  tags:
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-0941735.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-0941735.yml
@@ -9,7 +9,7 @@
           swaptotal_mb = {{ ansible_swaptotal_mb }};
           sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '../RedHat/generic/assert-tmpfs.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-tmpfs.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-0941735.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-0941735.yml
@@ -8,7 +8,14 @@
           memtotal_mb = {{ ansible_memtotal_mb }};
           swaptotal_mb = {{ ansible_swaptotal_mb }};
           sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/assert-tmpfs.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_0941735 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_0941735
+    - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-0941735.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-0941735.yml
@@ -10,12 +10,10 @@
           sap_general_preconfigure_size_of_tmpfs_gb = {{ sap_general_preconfigure_size_of_tmpfs_gb }}"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/assert-tmpfs.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_0941735 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_0941735
     - sap_general_preconfigure_configure_tmpfs

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-1391070.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-1391070.yml
@@ -7,12 +7,10 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).version }}): Configure uuidd"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/assert-uuidd.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1391070 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_1391070
     - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-1391070.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-1391070.yml
@@ -5,7 +5,14 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).version }}): Configure uuidd"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/assert-uuidd.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1391070 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_1391070
+    - sap_general_preconfigure_configure_uuidd

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-1391070.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-1391070.yml
@@ -6,7 +6,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1391070$') | first).version }}): Configure uuidd"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '../RedHat/generic/assert-uuidd.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-uuidd.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-1771258.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-1771258.yml
@@ -5,7 +5,14 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).version }}): User and system resource limits"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/assert-nofile-limits.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-nofile-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1771258 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_1771258
+    - sap_general_preconfigure_nofile_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-1771258.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-1771258.yml
@@ -6,7 +6,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).version }}): User and system resource limits"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '../RedHat/generic/assert-nofile-limits.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-nofile-limits.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-1771258.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-1771258.yml
@@ -7,12 +7,10 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^1771258$') | first).version }}): User and system resource limits"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '../RedHat/generic/assert-nofile-limits.yml'
   ansible.builtin.import_tasks: ../RedHat/generic/assert-nofile-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_1771258 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_1771258
     - sap_general_preconfigure_nofile_limits

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
@@ -11,28 +11,33 @@
   ansible.builtin.import_tasks: 2002167/02-assert-configuration-changes.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_02 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_02
 
 - name: Import tasks from '2002167/03-assert-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-assert-setting-the-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_03 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_03
 
 - name: Import tasks from '2002167/04-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_04 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_04
 
 - name: Import tasks from '2002167/05-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_05 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_05
 
 - name: Import tasks from '2002167/06-assert-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-assert-additional-notes-for-installing-sap-systems.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_06 | d(false)
   tags:
+    - sap_general_preconfigure_2002167
     - sap_general_preconfigure_2002167_06

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
@@ -4,6 +4,8 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2002167$') | first).version }}): Configure RHEL 7"
+  tags:
+    - always
 
 - name: Import tasks from '2002167/02-assert-configuration-changes.yml'
   ansible.builtin.import_tasks: 2002167/02-assert-configuration-changes.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
@@ -8,19 +8,44 @@
 - name: Import tasks from '2002167/02-assert-configuration-changes.yml'
   ansible.builtin.import_tasks: 2002167/02-assert-configuration-changes.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_02 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_02
+    - sap_general_preconfigure_firewall
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2002167/03-assert-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-assert-setting-the-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_03 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_03
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2002167/04-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_04 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_04
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2002167/05-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_05 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_05
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2002167/06-assert-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-assert-additional-notes-for-installing-sap-systems.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_06 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2002167_06
+    - sap_general_preconfigure_libldap
+    - sap_general_preconfigure_liblber
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
@@ -11,8 +11,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_02
-    - sap_general_preconfigure_firewall
-    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2002167/03-assert-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-assert-setting-the-hostname.yml
@@ -20,9 +18,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_03
-    - sap_general_preconfigure_hostname
-    - sap_general_preconfigure_etc_hosts
-    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2002167/04-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-assert-linux-kernel-parameters.yml
@@ -30,7 +25,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_04
-    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2002167/05-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-assert-process-resource-limits.yml
@@ -38,7 +32,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_05
-    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2002167/06-assert-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-assert-additional-notes-for-installing-sap-systems.yml
@@ -46,6 +39,3 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_06
-    - sap_general_preconfigure_libldap
-    - sap_general_preconfigure_liblber
-    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2002167.yml
@@ -9,33 +9,28 @@
   ansible.builtin.import_tasks: 2002167/02-assert-configuration-changes.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_02 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_02
 
 - name: Import tasks from '2002167/03-assert-setting-the-hostname.yml'
   ansible.builtin.import_tasks: 2002167/03-assert-setting-the-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_03 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_03
 
 - name: Import tasks from '2002167/04-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2002167/04-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_04 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_04
 
 - name: Import tasks from '2002167/05-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2002167/05-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_05 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_05
 
 - name: Import tasks from '2002167/06-assert-additional-notes-for-installing-sap-systems.yml'
   ansible.builtin.import_tasks: 2002167/06-assert-additional-notes-for-installing-sap-systems.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2002167_06 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2002167_06

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
@@ -5,7 +5,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).version }}): Configure RHEL 8"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '2772999/02-assert-selinux.yml'
   ansible.builtin.import_tasks: 2772999/02-assert-selinux.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
@@ -14,7 +14,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_02
-    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2772999/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-assert-hostname.yml
@@ -22,9 +21,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_03
-    - sap_general_preconfigure_hostname
-    - sap_general_preconfigure_etc_hosts
-    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2772999/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-assert-network-time-and-date.yml
@@ -32,7 +28,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_04
-    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '2772999/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-assert-firewall.yml
@@ -40,7 +35,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_05
-    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '2772999/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-assert-uuidd.yml
@@ -48,7 +42,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_06
-    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '2772999/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-assert-tmpfs.yml
@@ -56,7 +49,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_07
-    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '2772999/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-assert-linux-kernel-parameters.yml
@@ -64,14 +56,12 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_08
-    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2772999/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
   tags:
     - sap_general_preconfigure_configuration_all_steps
-    - sap_general_preconfigure_2772999_09
     - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2772999/10-assert-systemd-tmpfiles.yml'
@@ -80,4 +70,3 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_10
-    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
@@ -53,7 +53,7 @@
   ansible.builtin.import_tasks: 2772999/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
   tags:
-    - sap_general_preconfigure_nproc_limits
+    - sap_general_preconfigure_2772999_09
 
 - name: Import tasks from '2772999/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-assert-systemd-tmpfiles.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
@@ -11,52 +11,61 @@
   ansible.builtin.import_tasks: 2772999/02-assert-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_02 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_02
 
 - name: Import tasks from '2772999/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-assert-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_03 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_03
 
 - name: Import tasks from '2772999/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-assert-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_04 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_04
 
 - name: Import tasks from '2772999/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-assert-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_05 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_05
 
 - name: Import tasks from '2772999/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_06 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_06
 
 - name: Import tasks from '2772999/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_07 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_07
 
 - name: Import tasks from '2772999/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_08 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_08
 
 - name: Import tasks from '2772999/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_09
 
 - name: Import tasks from '2772999/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-assert-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_10 | d(false)
   tags:
+    - sap_general_preconfigure_2772999
     - sap_general_preconfigure_2772999_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
@@ -6,67 +6,57 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).version }}): Configure RHEL 8"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '2772999/02-assert-selinux.yml'
   ansible.builtin.import_tasks: 2772999/02-assert-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_02 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_02
 
 - name: Import tasks from '2772999/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-assert-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_03 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_03
 
 - name: Import tasks from '2772999/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-assert-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_04 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_04
 
 - name: Import tasks from '2772999/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-assert-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_05 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_05
 
 - name: Import tasks from '2772999/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_06 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_06
 
 - name: Import tasks from '2772999/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_07 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_07
 
 - name: Import tasks from '2772999/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_08 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_08
 
 - name: Import tasks from '2772999/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2772999/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-assert-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_10 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_2772999_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-2772999.yml
@@ -4,39 +4,80 @@
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^2772999$') | first).version }}): Configure RHEL 8"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '2772999/02-assert-selinux.yml'
   ansible.builtin.import_tasks: 2772999/02-assert-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_02 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_02
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '2772999/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 2772999/03-assert-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_03 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_03
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '2772999/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 2772999/04-assert-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_04 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_04
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '2772999/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 2772999/05-assert-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_05 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_05
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '2772999/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 2772999/06-assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_06 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_06
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '2772999/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 2772999/07-assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_07 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_07
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '2772999/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 2772999/08-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_08 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_08
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '2772999/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 2772999/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_09 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_09
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '2772999/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 2772999/10-assert-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_2772999_10 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_2772999_10
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
@@ -3,40 +3,81 @@
 - name: Assert - Display SAP note number 3108316 and its version
   ansible.builtin.debug:
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).number }}
-          (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 8"
+          (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 9"
+  tags:
+    - sap_general_preconfigure_configuration
+    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '3108316/02-assert-selinux.yml'
   ansible.builtin.import_tasks: 3108316/02-assert-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_02 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_02
+    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '3108316/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-assert-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_03 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_03
+    - sap_general_preconfigure_hostname
+    - sap_general_preconfigure_etc_hosts
+    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '3108316/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-assert-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_04 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_04
+    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '3108316/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-assert-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_05 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_05
+    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '3108316/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_06 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_06
+    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '3108316/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_07 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_07
+    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '3108316/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_08 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_08
+    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '3108316/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_09 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_09
+    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '3108316/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-assert-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_10 | d(false)
+  tags:
+    - sap_general_preconfigure_configuration_all_steps
+    - sap_general_preconfigure_3108316_10
+    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
@@ -11,52 +11,61 @@
   ansible.builtin.import_tasks: 3108316/02-assert-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_02 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_02
 
 - name: Import tasks from '3108316/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-assert-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_03 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_03
 
 - name: Import tasks from '3108316/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-assert-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_04 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_04
 
 - name: Import tasks from '3108316/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-assert-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_05 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_05
 
 - name: Import tasks from '3108316/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_06 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_06
 
 - name: Import tasks from '3108316/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_07 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_07
 
 - name: Import tasks from '3108316/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_08 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_08
 
 - name: Import tasks from '3108316/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_09 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_09
 
 - name: Import tasks from '3108316/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-assert-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_10 | d(false)
   tags:
+    - sap_general_preconfigure_3108316
     - sap_general_preconfigure_3108316_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
@@ -6,67 +6,57 @@
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 9"
   tags:
     - sap_general_preconfigure_configuration
-    - sap_general_preconfigure_configuration_all_steps
 
 - name: Import tasks from '3108316/02-assert-selinux.yml'
   ansible.builtin.import_tasks: 3108316/02-assert-selinux.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_02 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_02
 
 - name: Import tasks from '3108316/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-assert-hostname.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_03 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_03
 
 - name: Import tasks from '3108316/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-assert-network-time-and-date.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_04 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_04
 
 - name: Import tasks from '3108316/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-assert-firewall.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_05 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_05
 
 - name: Import tasks from '3108316/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-assert-uuidd.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_06 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_06
 
 - name: Import tasks from '3108316/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-assert-tmpfs.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_07 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_07
 
 - name: Import tasks from '3108316/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-assert-linux-kernel-parameters.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_08 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_08
 
 - name: Import tasks from '3108316/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-assert-process-resource-limits.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_09 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_09
 
 - name: Import tasks from '3108316/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-assert-systemd-tmpfiles.yml
   when: sap_general_preconfigure_config_all | d(true) or sap_general_preconfigure_3108316_10 | d(false)
   tags:
-    - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_10

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
@@ -14,7 +14,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_02
-    - sap_general_preconfigure_selinux
 
 - name: Import tasks from '3108316/03-assert-hostname.yml'
   ansible.builtin.import_tasks: 3108316/03-assert-hostname.yml
@@ -22,9 +21,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_03
-    - sap_general_preconfigure_hostname
-    - sap_general_preconfigure_etc_hosts
-    - sap_general_preconfigure_dns-name-resolution
 
 - name: Import tasks from '3108316/04-assert-network-time-and-date.yml'
   ansible.builtin.import_tasks: 3108316/04-assert-network-time-and-date.yml
@@ -32,7 +28,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_04
-    - sap_general_preconfigure_network_time_and_date
 
 - name: Import tasks from '3108316/05-assert-firewall.yml'
   ansible.builtin.import_tasks: 3108316/05-assert-firewall.yml
@@ -40,7 +35,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_05
-    - sap_general_preconfigure_firewall
 
 - name: Import tasks from '3108316/06-assert-uuidd.yml'
   ansible.builtin.import_tasks: 3108316/06-assert-uuidd.yml
@@ -48,7 +42,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_06
-    - sap_general_preconfigure_configure_uuidd
 
 - name: Import tasks from '3108316/07-assert-tmpfs.yml'
   ansible.builtin.import_tasks: 3108316/07-assert-tmpfs.yml
@@ -56,7 +49,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_07
-    - sap_general_preconfigure_configure_tmpfs
 
 - name: Import tasks from '3108316/08-assert-linux-kernel-parameters.yml'
   ansible.builtin.import_tasks: 3108316/08-assert-linux-kernel-parameters.yml
@@ -64,7 +56,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_08
-    - sap_general_preconfigure_kernel_parameters
 
 - name: Import tasks from '3108316/09-assert-process-resource-limits.yml'
   ansible.builtin.import_tasks: 3108316/09-assert-process-resource-limits.yml
@@ -72,7 +63,6 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_09
-    - sap_general_preconfigure_nproc_limits
 
 - name: Import tasks from '3108316/10-assert-systemd-tmpfiles.yml'
   ansible.builtin.import_tasks: 3108316/10-assert-systemd-tmpfiles.yml
@@ -80,4 +70,3 @@
   tags:
     - sap_general_preconfigure_configuration_all_steps
     - sap_general_preconfigure_3108316_10
-    - sap_general_preconfigure_systemd_tmpfiles

--- a/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/assert-3108316.yml
@@ -5,7 +5,7 @@
     msg: "SAP note {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).number }}
           (version {{ (__sap_general_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3108316$') | first).version }}): Configure RHEL 9"
   tags:
-    - sap_general_preconfigure_configuration
+    - always
 
 - name: Import tasks from '3108316/02-assert-selinux.yml'
   ansible.builtin.import_tasks: 3108316/02-assert-selinux.yml


### PR DESCRIPTION
Please see the updates of the `README.md` file for examples for using tags with this role (currently only for RHEL systems).
Solves #342 but leaves the related role parameters (e.g. `sap_general_preconfigure_configuration`, `sap_general_preconfigure_2772999_02`) in place and functional because no deprecation note has been published yet.