### PR TITLE
sap_general_preconfigure: Use the role sap_maintain_etc_hosts - RHEL systems

### DIFF
--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -146,15 +146,15 @@ sap_general_preconfigure_max_hostname_length: '13'
 # The maximum length of the hostname. See SAP note 611361.
 
 # Reason for noqa: A separate role is planned to replace the code which uses this variable.
-sap_hostname: "{{ ansible_hostname }}" # noqa var-naming[no-role-prefix]
+#sap_hostname: "{{ ansible_hostname }}" # noqa var-naming[no-role-prefix]
 # The hostname to be used for updating or checking `/etc/hosts` entries.
 
 # Reason for noqa: A separate role is planned to replace the code which uses this variable.
-sap_domain: "{{ ansible_domain }}" # noqa var-naming[no-role-prefix]
+#sap_domain: "{{ ansible_domain }}" # noqa var-naming[no-role-prefix]
 # The DNS domain name to be used for updating or checking `/etc/hosts` entries.
 
 # Reason for noqa: A separate role is planned to replace the code which uses this variable.
-sap_ip: "{{ ansible_default_ipv4.address }}" # noqa var-naming[no-role-prefix]
+#sap_ip: "{{ ansible_default_ipv4.address }}" # noqa var-naming[no-role-prefix]
 # The IPV4 address to be used for updating or checking `/etc/hosts` entries.
 
 # sap_general_preconfigure_db_group_name: (not defined by default)

--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -145,17 +145,15 @@ sap_general_preconfigure_kernel_parameters: "{{ __sap_general_preconfigure_kerne
 sap_general_preconfigure_max_hostname_length: '13'
 # The maximum length of the hostname. See SAP note 611361.
 
-# Reason for noqa: A separate role is planned to replace the code which uses this variable.
-#sap_hostname: "{{ ansible_hostname }}" # noqa var-naming[no-role-prefix]
+# If "global" variables are set, use those. If not, default to the values from gather_facts:
+sap_general_preconfigure_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
+# The IPV4 address to be used for updating or checking `/etc/hosts` entries.
+
+sap_general_preconfigure_hostname: "{{ sap_hostname | d(ansible_hostname) }}"
 # The hostname to be used for updating or checking `/etc/hosts` entries.
 
-# Reason for noqa: A separate role is planned to replace the code which uses this variable.
-#sap_domain: "{{ ansible_domain }}" # noqa var-naming[no-role-prefix]
+sap_general_preconfigure_domain: "{{ sap_domain | d(ansible_domain) }}"
 # The DNS domain name to be used for updating or checking `/etc/hosts` entries.
-
-# Reason for noqa: A separate role is planned to replace the code which uses this variable.
-#sap_ip: "{{ ansible_default_ipv4.address }}" # noqa var-naming[no-role-prefix]
-# The IPV4 address to be used for updating or checking `/etc/hosts` entries.
 
 # sap_general_preconfigure_db_group_name: (not defined by default)
 # Use this variable to specify the name of the RHEL group which is used for the database processes.

--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -310,21 +310,21 @@ argument_specs:
         required: false
         type: str
 
-      sap_hostname:
+      sap_general_preconfigure_hostname:
         default: "{{ ansible_hostname }}"
         description:
           - The hostname to be used for updating or checking `/etc/hosts` entries.
         required: false
         type: str
 
-      sap_domain:
+      sap_general_preconfigure_domain:
         default: "{{ ansible_domain }}"
         description:
           - The DNS domain name to be used for updating or checking `/etc/hosts` entries.
         required: false
         type: str
 
-      sap_ip:
+      sap_general_preconfigure_ip:
         default: "{{ ansible_default_ipv4.address }}"
         description:
           - The IPV4 address to be used for updating or checking `/etc/hosts` entries.

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -4,6 +4,21 @@
   ansible.builtin.debug:
     var: __sap_general_preconfigure_sapnotes_versions | difference([''])
 
+- name: Configure - Set sap_hostname if not defined
+  ansible.builtin.set_fact:
+    sap_hostname: "{{ ansible_hostname }}"
+  when: sap_hostname is not defined
+
+- name: Configure - Set sap_domain if not defined
+  ansible.builtin.set_fact:
+    sap_domain: "{{ ansible_domain }}"
+  when: sap_domain is not defined
+
+- name: Configure - Set sap_ip if not defined
+  ansible.builtin.set_fact:
+    sap_ip: "{{ ansible_default_ipv4.address }}"
+  when: sap_ip is not defined
+
 - name: Configure - Set directory variables for setting SELinux file contexts
   ansible.builtin.set_fact:
     sap_general_preconfigure_fact_targets_setypes: "{{ sap_general_preconfigure_fact_targets_setypes | d([]) +

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -4,21 +4,6 @@
   ansible.builtin.debug:
     var: __sap_general_preconfigure_sapnotes_versions | difference([''])
 
-- name: Configure - Set sap_hostname if not defined
-  ansible.builtin.set_fact:
-    sap_hostname: "{{ ansible_hostname }}"
-  when: sap_hostname is not defined
-
-- name: Configure - Set sap_domain if not defined
-  ansible.builtin.set_fact:
-    sap_domain: "{{ ansible_domain }}"
-  when: sap_domain is not defined
-
-- name: Configure - Set sap_ip if not defined
-  ansible.builtin.set_fact:
-    sap_ip: "{{ ansible_default_ipv4.address }}"
-  when: sap_ip is not defined
-
 - name: Configure - Set directory variables for setting SELinux file contexts
   ansible.builtin.set_fact:
     sap_general_preconfigure_fact_targets_setypes: "{{ sap_general_preconfigure_fact_targets_setypes | d([]) +

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-dns-name-resolution.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-dns-name-resolution.yml
@@ -3,16 +3,16 @@
 - name: Assert that the DNS domain is set
   ansible.builtin.assert:
     that: not( (ansible_domain is undefined) or (ansible_domain is none) or (ansible_domain | trim == '') )
-    fail_msg: "FAIL: The DNS domain is not configured! So variable 'sap_domain' needs to be configured!"
+    fail_msg: "FAIL: The DNS domain is not configured! So variable 'sap_general_preconfigure_domain' needs to be configured!"
     success_msg: "PASS: The DNS domain is configured."
 #  ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   ignore_errors: yes
 
-- name: Assert that variable sap_domain is set
+- name: Assert that variable sap_general_preconfigure_domain is set
   ansible.builtin.assert:
-    that: not( (sap_domain is undefined) or (sap_domain is none) or (sap_domain | trim == '') )
-    fail_msg: "FAIL: The variable 'sap_domain' is not set!"
-    success_msg: "PASS: The variable 'sap_domain' is set."
+    that: not( (sap_general_preconfigure_domain is undefined) or (sap_general_preconfigure_domain is none) or (sap_general_preconfigure_domain | trim == '') )
+    fail_msg: "FAIL: The variable 'sap_general_preconfigure_domain' is not set!"
+    success_msg: "PASS: The variable 'sap_general_preconfigure_domain' is set."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: Check if the bind-utils package, which contains the dig command, is available
@@ -21,8 +21,8 @@
     fail_msg: "FAIL: The package 'bind-utils' is not installed! DNS checking not possible!"
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
-- name: Check if IP address for sap_hostname.sap_domain is resolved correctly
-  ansible.builtin.command: dig {{ sap_hostname }}.{{ sap_domain }} +short
+- name: Check if IP address for sap_general_preconfigure_hostname.sap_general_preconfigure_domain is resolved correctly
+  ansible.builtin.command: dig {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} +short
   register: __sap_general_preconfigure_register_dig_short_assert
   ignore_errors: yes
   changed_when: no
@@ -35,32 +35,32 @@
     success_msg: "PASS: The variable 'ansible_default_ipv4.address' is defined."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
-- name: Assert that sap_ip is set
+- name: Assert that sap_general_preconfigure_ip is set
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_dig_short_assert.stdout == sap_ip
-    fail_msg: "FAIL: The variable 'sap_ip' is not set!"
-    success_msg: "PASS: The variable 'sap_ip' is set."
+    that: __sap_general_preconfigure_register_dig_short_assert.stdout == sap_general_preconfigure_ip
+    fail_msg: "FAIL: The variable 'sap_general_preconfigure_ip' is not set!"
+    success_msg: "PASS: The variable 'sap_general_preconfigure_ip' is set."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   when: "'bind-utils' in ansible_facts.packages"
 
 ### BUG: dig does not use search path in resolv.con on PPCle
-- name: Check if IP address for sap_hostname with search path is resolved correctly
-  ansible.builtin.command: dig {{ sap_hostname }} +search +short
+- name: Check if IP address for sap_general_preconfigure_hostname with search path is resolved correctly
+  ansible.builtin.command: dig {{ sap_general_preconfigure_hostname }} +search +short
   register: __sap_general_preconfigure_register_dig_search_short_assert
   changed_when: false
   ignore_errors: true
   when: "'bind-utils' in ansible_facts.packages"
 
-- name: Assert that the IP address for sap_hostname is resolved correctly
+- name: Assert that the IP address for sap_general_preconfigure_hostname is resolved correctly
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_dig_search_short_assert.stdout == sap_ip
-    fail_msg: "FAIL: The IP address for 'sap_hostname' could not be resolved!"
-    success_msg: "PASS: The IP address for 'sap_hostname' was resolved."
+    that: __sap_general_preconfigure_register_dig_search_short_assert.stdout == sap_general_preconfigure_ip
+    fail_msg: "FAIL: The IP address for 'sap_general_preconfigure_hostname' could not be resolved!"
+    success_msg: "PASS: The IP address for 'sap_general_preconfigure_hostname' was resolved."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(true) }}"
   when: "'bind-utils' in ansible_facts.packages"
 
 - name: Check if the reverse name resolution is correct
-  ansible.builtin.command: dig -x {{ sap_ip }} +short
+  ansible.builtin.command: dig -x {{ sap_general_preconfigure_ip }} +short
   register: __sap_general_preconfigure_register_dig_reverse_assert
   changed_when: false
   ignore_errors: true
@@ -68,8 +68,8 @@
 
 - name: Assert that the reverse name resolution is correct
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_dig_reverse_assert.stdout == (sap_hostname + '.' + sap_domain + '.')
-    fail_msg: "FAIL: The reverse name resolution of 'sap_ip' was not successful!"
-    success_msg: "PASS: The reverse name resolution of 'sap_ip' was successful."
+    that: __sap_general_preconfigure_register_dig_reverse_assert.stdout == (sap_general_preconfigure_hostname + '.' + sap_general_preconfigure_domain + '.')
+    fail_msg: "FAIL: The reverse name resolution of 'sap_general_preconfigure_ip' was not successful!"
+    success_msg: "PASS: The reverse name resolution of 'sap_general_preconfigure_ip' was successful."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(true) }}"
   when: "'bind-utils' in ansible_facts.packages"

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-etc-hosts.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-etc-hosts.yml
@@ -3,28 +3,12 @@
 - name: Assert - Display host and domain name, and IP address
   ansible.builtin.debug:
     msg:
-      - "sap_hostname = {{ sap_hostname }}"
-      - "sap_domain = {{ sap_domain }}"
-      - "sap_ip = {{ sap_ip }}"
-
-# Note: There is no check related to hostname aliases.
-#- name: Get all hostname aliases of {{ sap_ip }}
-#  shell: |
-#    awk '( $1 == "{{ sap_ip }}" ) {
-#      for (i=2; i<=NF; ++i) {
-#        if (( $i != "{{ sap_hostname }}" ) && ( $i != "{{ sap_hostname }}.{{ sap_domain }}" )) { printf $i" " }
-#      }
-#    }' /etc/hosts
-#  register: sap_base_settings_register_hostname_aliases
-#  changed_when: false
-#  check_mode: false
-
-#- name: Print hostname aliases
-#  debug:
-#    var=sap_hostname_aliases
+      - "sap_general_preconfigure_hostname = {{ sap_general_preconfigure_hostname }}"
+      - "sap_general_preconfigure_domain = {{ sap_general_preconfigure_domain }}"
+      - "sap_general_preconfigure_ip = {{ sap_general_preconfigure_ip }}"
 
 - name: Check if ipv4 address, FQDN, and hostname are once in /etc/hosts
-  ansible.builtin.command: awk 'BEGIN{a=0}/{{ sap_ip }}/&&/{{ sap_hostname }}.{{ sap_domain }}/&&/{{ sap_hostname }}/{a++}END{print a}' /etc/hosts
+  ansible.builtin.command: awk 'BEGIN{a=0}/{{ sap_general_preconfigure_ip }}/&&/{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}/&&/{{ sap_general_preconfigure_hostname }}/{a++}END{print a}' /etc/hosts
   register: __sap_general_preconfigure_register_ipv4_fqdn_sap_hostname_once_assert
   ignore_errors: yes
   changed_when: no
@@ -32,59 +16,51 @@
 - name: Assert that ipv4 address, FQDN, and hostname are once in /etc/hosts
   ansible.builtin.assert:
     that: __sap_general_preconfigure_register_ipv4_fqdn_sap_hostname_once_assert.stdout == '1'
-    fail_msg: "FAIL: The line '{{ sap_ip }} {{ sap_hostname }}.{{ sap_domain }} {{ sap_hostname }}' needs to be once in /etc/hosts!"
-    success_msg: "PASS: The line '{{ sap_ip }} {{ sap_hostname }}.{{ sap_domain }} {{ sap_hostname }}' is once in /etc/hosts."
+    fail_msg: "FAIL: The line '{{ sap_general_preconfigure_ip }} {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} {{ sap_general_preconfigure_hostname }}' needs to be once in /etc/hosts!"
+    success_msg: "PASS: The line '{{ sap_general_preconfigure_ip }} {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} {{ sap_general_preconfigure_hostname }}' is once in /etc/hosts."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
-#- name: Ensure that the entry in /etc/hosts is correct
-#  ansible.builtin.lineinfile:
-#    path: /etc/hosts
-#    regexp: '^{{ sap_ip }}\s'
-#    line: "{{ sap_ip }} {{ sap_hostname }}.{{ sap_domain }} {{ sap_hostname }} {{ sap_base_settings_register_hostname_aliases.stdout }}"
-#  when:
-#    - sap_general_preconfigure_assert_modify_etc_hosts | bool
-
-- name: Count the number of sap_ip ({{ sap_ip }}) entries in /etc/hosts
-  ansible.builtin.command: awk 'BEGIN{a=0}/{{ sap_ip }}/{a++}END{print a}' /etc/hosts
+- name: Count the number of sap_general_preconfigure_ip ({{ sap_general_preconfigure_ip }}) entries in /etc/hosts
+  ansible.builtin.command: awk 'BEGIN{a=0}/{{ sap_general_preconfigure_ip }}/{a++}END{print a}' /etc/hosts
   register: __sap_general_preconfigure_register_sap_ip_once_assert
   ignore_errors: yes
   changed_when: no
 
-- name: Assert that there is just one line containing {{ sap_ip }} in /etc/hosts
+- name: Assert that there is just one line containing {{ sap_general_preconfigure_ip }} in /etc/hosts
   ansible.builtin.assert:
     that: __sap_general_preconfigure_register_sap_ip_once_assert.stdout == '1'
-    fail_msg: "FAIL: There is no line, or more than one line, containing '{{ sap_ip }}' in /etc/hosts!"
-    success_msg: "PASS: There is only one line containing '{{ sap_ip }}' in /etc/hosts."
+    fail_msg: "FAIL: There is no line, or more than one line, containing '{{ sap_general_preconfigure_ip }}' in /etc/hosts!"
+    success_msg: "PASS: There is only one line containing '{{ sap_general_preconfigure_ip }}' in /etc/hosts."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
-- name: Check for duplicate or missing entries of {{ sap_hostname }}.{{ sap_domain }} in /etc/hosts
-  ansible.builtin.command: awk 'BEGIN{a=0}/^{{ sap_hostname }}.{{ sap_domain }}\s/||
-                /\s{{ sap_hostname }}.{{ sap_domain }}\s/||
-                /\s{{ sap_hostname }}.{{ sap_domain }}$/{a++}END{print a}' /etc/hosts
+- name: Check for duplicate or missing entries of {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} in /etc/hosts
+  ansible.builtin.command: awk 'BEGIN{a=0}/^{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}\s/||
+                /\s{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}\s/||
+                /\s{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}$/{a++}END{print a}' /etc/hosts
   register: __sap_general_preconfigure_register_fqdn_once_assert
   ignore_errors: yes
   changed_when: no
 
-- name: Assert that there is just one line containing {{ sap_hostname }}.{{ sap_domain }} in /etc/hosts
+- name: Assert that there is just one line containing {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} in /etc/hosts
   ansible.builtin.assert:
     that: __sap_general_preconfigure_register_fqdn_once_assert.stdout == '1'
-    fail_msg: "FAIL: There is no line, or more than one line, containing '{{ sap_hostname }}.{{ sap_domain }}' in /etc/hosts!"
-    success_msg: "PASS: There is only one line containing '{{ sap_hostname }}.{{ sap_domain }}' in /etc/hosts."
+    fail_msg: "FAIL: There is no line, or more than one line, containing '{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}' in /etc/hosts!"
+    success_msg: "PASS: There is only one line containing '{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}' in /etc/hosts."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
-- name: Check for duplicate or missing entries of {{ sap_hostname }} in /etc/hosts
-  ansible.builtin.command: awk 'BEGIN{a=0}/^{{ sap_hostname }}\s/||
-                /\s{{ sap_hostname }}\s/||
-                /\s{{ sap_hostname }}$/{a++}END{print a}' /etc/hosts
+- name: Check for duplicate or missing entries of {{ sap_general_preconfigure_hostname }} in /etc/hosts
+  ansible.builtin.command: awk 'BEGIN{a=0}/^{{ sap_general_preconfigure_hostname }}\s/||
+                /\s{{ sap_general_preconfigure_hostname }}\s/||
+                /\s{{ sap_general_preconfigure_hostname }}$/{a++}END{print a}' /etc/hosts
   register: __sap_general_preconfigure_register_sap_hostname_once_assert
   ignore_errors: yes
   changed_when: no
 
-- name: Assert that there is just one line containing {{ sap_hostname }} in /etc/hosts
+- name: Assert that there is just one line containing {{ sap_general_preconfigure_hostname }} in /etc/hosts
   ansible.builtin.assert:
     that: __sap_general_preconfigure_register_sap_hostname_once_assert.stdout == '1'
-    fail_msg: "FAIL: There is no line, or more than one line, containing '{{ sap_hostname }}' in /etc/hosts!"
-    success_msg: "PASS: There is only one line containing '{{ sap_hostname }}' in /etc/hosts."
+    fail_msg: "FAIL: There is no line, or more than one line, containing '{{ sap_general_preconfigure_hostname }}' in /etc/hosts!"
+    success_msg: "PASS: There is only one line containing '{{ sap_general_preconfigure_hostname }}' in /etc/hosts."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: Check hostname -s

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-hostname.yml
@@ -6,16 +6,16 @@
   ignore_errors: yes
   changed_when: no
 
-- name: Assert that the output of hostname matches the content of variable sap_hostname
+- name: Assert that the output of hostname matches the content of variable sap_general_preconfigure_hostname
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_hostname_assert.stdout == sap_hostname
-    fail_msg: "FAIL: The output of 'hostname' does not match the content of variable 'sap_hostname'!"
-    success_msg: "PASS: The output of 'hostname' matches the content of variable 'sap_hostname'."
+    that: __sap_general_preconfigure_register_hostname_assert.stdout == sap_general_preconfigure_hostname
+    fail_msg: "FAIL: The output of 'hostname' does not match the content of variable 'sap_general_preconfigure_hostname'!"
+    success_msg: "PASS: The output of 'hostname' matches the content of variable 'sap_general_preconfigure_hostname'."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: "Assert that the length of the hostname is not longer than 'sap_general_preconfigure_max_hostname_length'"
   ansible.builtin.assert:
-    that: (sap_hostname | length | int) <= (sap_general_preconfigure_max_hostname_length | int)
-    fail_msg: "FAIL: The length of the hostname is {{ sap_hostname | length | int }} but must be less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')!"
-    success_msg: "PASS: The length of the hostname is {{ sap_hostname | length | int }}, which is less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')."
+    that: (sap_general_preconfigure_hostname | length | int) <= (sap_general_preconfigure_max_hostname_length | int)
+    fail_msg: "FAIL: The length of the hostname is {{ sap_general_preconfigure_hostname | length | int }} but must be less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')!"
+    success_msg: "PASS: The length of the hostname is {{ sap_general_preconfigure_hostname | length | int }}, which is less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')."
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/check-dns-name-resolution.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/check-dns-name-resolution.yml
@@ -1,17 +1,17 @@
 ---
 
 - name: Check dns forwarding settings
-  ansible.builtin.shell: test "$(dig {{ sap_hostname }}.{{ sap_domain }} +short)" = "{{ sap_ip }}"
+  ansible.builtin.shell: test "$(dig {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} +short)" = "{{ sap_general_preconfigure_ip }}"
   changed_when: false
   ignore_errors: true
 
 ### BUG: dig does not use search path in resolv.con on PPCle
 - name: Check resolv.conf settings
-  ansible.builtin.shell: test "$(dig {{ sap_hostname }} +search +short)" = "{{ sap_ip }}"
+  ansible.builtin.shell: test "$(dig {{ sap_general_preconfigure_hostname }} +search +short)" = "{{ sap_general_preconfigure_ip }}"
   changed_when: false
   ignore_errors: true
 
 - name: Check dns reverse settings
-  ansible.builtin.shell: test "$(dig -x {{ sap_ip }} +short)" = "{{ sap_hostname }}.{{ sap_domain }}."
+  ansible.builtin.shell: test "$(dig -x {{ sap_general_preconfigure_ip }} +short)" = "{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}."
   changed_when: false
   ignore_errors: true

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-etc-hosts.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-etc-hosts.yml
@@ -3,15 +3,16 @@
 - name: Display host and domain name, and IP address before the modification
   ansible.builtin.debug:
     msg:
-      - "sap_hostname = {{ sap_hostname }}"
-      - "sap_domain = {{ sap_domain }}"
-      - "sap_ip = {{ sap_ip }}"
+      - "sap_general_preconfigure_hostname = {{ sap_general_preconfigure_hostname }}"
+      - "sap_general_preconfigure_domain = {{ sap_general_preconfigure_domain }}"
+      - "sap_general_preconfigure_ip = {{ sap_general_preconfigure_ip }}"
 
-- name: Get all hostname aliases of {{ sap_ip }}
+- name: Get all hostname aliases of {{ sap_general_preconfigure_ip }}
   ansible.builtin.shell: |
-    awk '( $1 == "{{ sap_ip }}" ) {
+    awk '( $1 == "{{ sap_general_preconfigure_ip }}" ) {
       for (i=2; i<=NF; ++i) {
-        if (( $i != "{{ sap_hostname }}" ) && ( $i != "{{ sap_hostname }}.{{ sap_domain }}" )) { printf " "$i }
+        if (( $i != "{{ sap_general_preconfigure_hostname }}" ) &&
+           ( $i != "{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}" )) { printf " "$i }
       }
     }' /etc/hosts
   register: __sap_general_preconfigure_register_sap_hostname_aliases
@@ -26,7 +27,7 @@
   block:
 
     - name: Perform the /etc/hosts completeness check
-      ansible.builtin.command: awk 'BEGIN{a=0}/{{ sap_ip }}/&&/{{ sap_hostname }}.{{ sap_domain }}/&&/{{ sap_hostname }}/{a++}END{print a}' /etc/hosts
+      ansible.builtin.command: awk 'BEGIN{a=0}/{{ sap_general_preconfigure_ip }}/&&/{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}/&&/{{ sap_general_preconfigure_hostname }}/{a++}END{print a}' /etc/hosts
       register: __sap_general_preconfigure_register_ipv4_fqdn_sap_hostname_once_check
       changed_when: false
 
@@ -39,7 +40,7 @@
       ansible.builtin.debug:
         msg:
           - "Expected:"
-          - "{{ sap_ip }} {{ sap_hostname }}.{{ sap_domain }} {{ sap_hostname }}"
+          - "{{ sap_general_preconfigure_ip }} {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} {{ sap_general_preconfigure_hostname }}"
       when:
         - __sap_general_preconfigure_register_ipv4_fqdn_sap_hostname_once_check.stdout != "1"
 
@@ -48,15 +49,15 @@
         msg:
           - "Server's ip4 address, FQDN, or hostname are not in /etc/hosts!"
           - "Expected:"
-          - "{{ sap_ip }} {{ sap_hostname }}.{{ sap_domain }} {{ sap_hostname }}"
+          - "{{ sap_general_preconfigure_ip }} {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} {{ sap_general_preconfigure_hostname }}"
       when:
         - __sap_general_preconfigure_register_ipv4_fqdn_sap_hostname_once_check.stdout != "1"
       ignore_errors: "{{ ansible_check_mode }}"
 
-# We allow more than one line containing sap_ip:
-- name: Check for duplicate entries of {{ sap_ip }} in /etc/hosts
+# We allow more than one line containing sap_general_preconfigure_ip:
+- name: Check for duplicate entries of {{ sap_general_preconfigure_ip }} in /etc/hosts
   ansible.builtin.shell: |
-    n=$(grep "^{{ sap_ip }}\s" /etc/hosts | wc -l)
+    n=$(grep "^{{ sap_general_preconfigure_ip }}\s" /etc/hosts | wc -l)
     if [ $n -gt 1 ]; then
       echo "Duplicate IP entry in /etc/hosts!"
       exit 1
@@ -68,15 +69,15 @@
   ignore_errors: yes
   when: not ansible_check_mode
 
-- name: Verify that variable sap_domain is set
+- name: Verify that variable sap_general_preconfigure_domain is set
   ansible.builtin.assert:
-    that: not( (sap_domain is undefined) or (sap_domain is none) or (sap_domain | trim == '') )
-    msg: "Variable 'sap_domain' is undefined or empty. Please define it in defaults/main.yml or via --extra-vars!"
+    that: not( (sap_general_preconfigure_domain is undefined) or (sap_general_preconfigure_domain is none) or (sap_general_preconfigure_domain | trim == '') )
+    msg: "Variable 'sap_general_preconfigure_domain' is undefined or empty. Please set it in your playbook or inventory!"
 
 - name: Report if there is more than one line with the IP address
   ansible.builtin.debug:
     msg:
-      - "More than one line containing {{ sap_ip }}. File /etc/hosts will not be modified."
+      - "More than one line containing {{ sap_general_preconfigure_ip }}. File /etc/hosts will not be modified."
   when:
     - not ansible_check_mode
     - __sap_general_preconfigure_register_duplicate_ip_check.stdout == 'Duplicate IP entry in /etc/hosts!'
@@ -85,12 +86,12 @@
 - name: Ensure that the entry in /etc/hosts is correct
   ansible.builtin.lineinfile:
     path: /etc/hosts
-    regexp: '^{{ sap_ip }}\s'
-    line: "{{ sap_ip }} {{ sap_hostname }}.{{ sap_domain }} {{ sap_hostname }}{{ __sap_general_preconfigure_register_sap_hostname_aliases.stdout }}"
+    regexp: '^{{ sap_general_preconfigure_ip }}\s'
+    line: "{{ sap_general_preconfigure_ip }} {{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }} {{ sap_general_preconfigure_hostname }}{{ __sap_general_preconfigure_register_sap_hostname_aliases.stdout }}"
     backup: yes
   when:
     - not ansible_check_mode
-    - sap_domain | length > 0
+    - sap_general_preconfigure_domain | length > 0
     - __sap_general_preconfigure_register_duplicate_ip_check.stdout != 'Duplicate IP entry in /etc/hosts!'
     - sap_general_preconfigure_modify_etc_hosts | bool
 
@@ -103,8 +104,8 @@
       exit 1
     fi
   with_items:
-    - '{{ sap_hostname }}.{{ sap_domain }}'
-    - '{{ sap_hostname }}'
+    - '{{ sap_general_preconfigure_hostname }}.{{ sap_general_preconfigure_domain }}'
+    - '{{ sap_general_preconfigure_hostname }}'
   changed_when: false
   loop_control:
     loop_var: line_item

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-hostname.yml
@@ -46,9 +46,9 @@
 
 - name: Ensure that the short hostname is set
   ansible.builtin.hostname:
-    name: "{{ sap_hostname }}"
+    name: "{{ sap_general_preconfigure_hostname }}"
 
 - name: "Ensure that the length of the hostname is not longer than 'sap_general_preconfigure_max_hostname_length'"
   ansible.builtin.assert:
-    that: (sap_hostname | length | int) <= (sap_general_preconfigure_max_hostname_length | int)
-    msg: "The length of the hostname is {{ sap_hostname | length | int }} but must be less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')!"
+    that: (sap_general_preconfigure_hostname | length | int) <= (sap_general_preconfigure_max_hostname_length | int)
+    msg: "The length of the hostname is {{ sap_general_preconfigure_hostname | length | int }} but must be less or equal to {{ sap_general_preconfigure_max_hostname_length }} (variable 'sap_general_preconfigure_max_hostname_length')!"

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -36,4 +36,3 @@
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml
   tags:
     - sap_general_preconfigure_dns_name_resolution
-    

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -12,9 +12,9 @@
     name: sap_maintain_etc_hosts
   vars:
     sap_maintain_etc_hosts_list:
-      - node_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
-        node_name: "{{ sap_hostname | d(ansible_hostname) }}"
-        node_domain: "{{ sap_domain | d(ansible_domain) }}"
+      - node_ip: "{{ sap_general_preconfigure_ip }}"
+        node_name: "{{ sap_general_preconfigure_hostname }}"
+        node_domain: "{{ sap_general_preconfigure_domain }}"
         state: present
   when: sap_general_preconfigure_modify_etc_hosts
 

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -36,3 +36,4 @@
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml
   tags:
     - sap_general_preconfigure_dns_name_resolution
+    

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -7,8 +7,20 @@
 - name: Import tasks from '../../RedHat/generic/configure-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-hostname.yml
 
-- name: Import tasks from '../../RedHat/generic/configure-etc-hosts.yml'
-  ansible.builtin.import_tasks: ../../RedHat/generic/configure-etc-hosts.yml
+- name: Import role sap_maintain_etc_hosts
+  ansible.builtin.import_role:
+    name: sap_maintain_etc_hosts
+  vars:
+    sap_maintain_etc_hosts_list:
+      - node_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
+        node_name: "{{ sap_hostname | d(ansible_hostname) }}"
+        node_domain: "{{ sap_domain | d(ansible_domain) }}"
+        state: present
+  when: sap_general_preconfigure_modify_etc_hosts
+
+- name: Import tasks from '../../RedHat/generic/assert-etc-hosts.yml'
+  ansible.builtin.import_tasks: ../../RedHat/generic/assert-etc-hosts.yml
+  when: not sap_general_preconfigure_modify_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/check-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
@@ -12,9 +12,9 @@
     name: sap_maintain_etc_hosts
   vars:
     sap_maintain_etc_hosts_list:
-      - node_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
-        node_name: "{{ sap_hostname | d(ansible_hostname) }}"
-        node_domain: "{{ sap_domain | d(ansible_domain) }}"
+      - node_ip: "{{ sap_general_preconfigure_ip }}"
+        node_name: "{{ sap_general_preconfigure_hostname }}"
+        node_domain: "{{ sap_general_preconfigure_domain }}"
         state: present
   when: sap_general_preconfigure_modify_etc_hosts
 

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
@@ -7,8 +7,20 @@
 - name: Import tasks from '../../RedHat/generic/configure-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-hostname.yml
 
-- name: Import tasks from '../../RedHat/generic/configure-etc-hosts.yml'
-  ansible.builtin.import_tasks: ../../RedHat/generic/configure-etc-hosts.yml
+- name: Import role sap_maintain_etc_hosts
+  ansible.builtin.import_role:
+    name: sap_maintain_etc_hosts
+  vars:
+    sap_maintain_etc_hosts_list:
+      - node_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
+        node_name: "{{ sap_hostname | d(ansible_hostname) }}"
+        node_domain: "{{ sap_domain | d(ansible_domain) }}"
+        state: present
+  when: sap_general_preconfigure_modify_etc_hosts
+
+- name: Import tasks from '../../RedHat/generic/assert-etc-hosts.yml'
+  ansible.builtin.import_tasks: ../../RedHat/generic/assert-etc-hosts.yml
+  when: not sap_general_preconfigure_modify_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/check-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
@@ -12,9 +12,9 @@
     name: sap_maintain_etc_hosts
   vars:
     sap_maintain_etc_hosts_list:
-      - node_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
-        node_name: "{{ sap_hostname | d(ansible_hostname) }}"
-        node_domain: "{{ sap_domain | d(ansible_domain) }}"
+      - node_ip: "{{ sap_general_preconfigure_ip }}"
+        node_name: "{{ sap_general_preconfigure_hostname }}"
+        node_domain: "{{ sap_general_preconfigure_domain }}"
         state: present
   when: sap_general_preconfigure_modify_etc_hosts
 

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
@@ -7,8 +7,20 @@
 - name: Import tasks from '../../RedHat/generic/configure-hostname.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/configure-hostname.yml
 
-- name: Import tasks from '../../RedHat/generic/configure-etc-hosts.yml'
-  ansible.builtin.import_tasks: ../../RedHat/generic/configure-etc-hosts.yml
+- name: Import role sap_maintain_etc_hosts
+  ansible.builtin.import_role:
+    name: sap_maintain_etc_hosts
+  vars:
+    sap_maintain_etc_hosts_list:
+      - node_ip: "{{ sap_ip | d(ansible_default_ipv4.address) }}"
+        node_name: "{{ sap_hostname | d(ansible_hostname) }}"
+        node_domain: "{{ sap_domain | d(ansible_domain) }}"
+        state: present
+  when: sap_general_preconfigure_modify_etc_hosts
+
+- name: Import tasks from '../../RedHat/generic/assert-etc-hosts.yml'
+  ansible.builtin.import_tasks: ../../RedHat/generic/assert-etc-hosts.yml
+  when: not sap_general_preconfigure_modify_etc_hosts
 
 - name: Import tasks from '../../RedHat/generic/check-dns-name-resolution.yml'
   ansible.builtin.import_tasks: ../../RedHat/generic/check-dns-name-resolution.yml


### PR DESCRIPTION
We want to use a central role for all `/etc/hosts` related manipulation (it is part of this collection already), so let's start with `sap_general_preconfigure`.

At the same time, we can use new role variables which include the role prefix, replacing the previous "global" variables `sap_ip`, `sap_hostname`, and `sap_domain` in `defaults/main.yml` (while still being compatible).

I expect merge conflicts with https://github.com/sap-linuxlab/community.sap_install/pull/653 but it should not be too difficult to solve them, just annoying.