### PR TITLE
sap_swpm: optionally skip setting file permissions

### DIFF
--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -20,6 +20,12 @@ sap_swpm_ansible_role_mode: "default"
 # The default is true.
 sap_swpm_set_file_permissions: true
 #
+# The following 9 parameters define the default permission and ownership settings as per the
+# Installation of SAP ABAP Systems on UNIX : SAP HANA 2.0 Database - Using Software Provisioning Manager 2.0 guide
+# https://help.sap.com/docs/SLTOOLSET/39c32e9783f6439e871410848f61544c/c1f95d30d0ba4335919bf6e6f44263b2.html?version=CURRENT_VERSION_SWPM20
+# The guide mentions 755 as the minimum permission for the SPWM download directory and a umask setting of 022 for the user
+# which downloads the SAP software.
+#
 # Access permissions and ownership for all directories in sap_swpm_software_path, for sap_swpm_sapcar_path, and for sap_swpm_swpm_path:
 sap_swpm_software_directory_mode: '0755'
 sap_swpm_software_directory_owner: root
@@ -31,7 +37,7 @@ sap_swpm_files_sapcar_owner: root
 sap_swpm_files_sapcar_group: root
 #
 # Access permissions and ownership for all non-SAPCAR*EXE files in sap_swpm_software_path and for SWPM*.SAR in sap_swpm_swpm_path:
-sap_swpm_files_non_sapcar_mode: '0664'
+sap_swpm_files_non_sapcar_mode: '0644'
 sap_swpm_files_non_sapcar_owner: root
 sap_swpm_files_non_sapcar_group: root
 

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -11,6 +11,30 @@ sap_swpm_ansible_role_mode: "default"
 # advanced_templates
 # inifile_reuse
 
+########################################
+#   SWPM Ansible Role variables
+#   for setting owner, group, and permissions for the SAP files in sap_swpm_software_path
+########################################
+#
+# Set the following parameter to false to not change the owner, group, and permissions of the files in sap_swpm_software_path.
+# The default is true.
+sap_swpm_set_file_permissions: true
+#
+# Access permissions and ownership for all directories in sap_swpm_software_path, for sap_swpm_sapcar_path, and for sap_swpm_swpm_path:
+sap_swpm_software_directory_mode: '0755'
+sap_swpm_software_directory_owner: root
+sap_swpm_software_directory_group: root
+#
+# Access permissions and ownership for the SAPCAR*EXE file in sap_swpm_sapcar_path:
+sap_swpm_files_sapcar_mode: '0755'
+sap_swpm_files_sapcar_owner: root
+sap_swpm_files_sapcar_group: root
+#
+# Access permissions and ownership for all non-SAPCAR*EXE files in sap_swpm_software_path and for SWPM*.SAR in sap_swpm_swpm_path:
+sap_swpm_files_non_sapcar_mode: '0664'
+sap_swpm_files_non_sapcar_owner: root
+sap_swpm_files_non_sapcar_group: root
+
 
 ########################################
 #   SWPM Ansible Role variables

--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -126,10 +126,12 @@
   register: swpm_output_sapcontrol_files
 
 - name: SAP SWPM - Get sapcontrol file/s
-  ansible.builtin.command: awk -v RS='(^|\n)GetInstanceProperties\n' 'END{printf "%s", $0}' {{ item }}
+  ansible.builtin.command: awk -v RS='(^|\n)GetInstanceProperties\n' 'END{printf "%s", $0}' {{ line_item }}
   register: swpm_sapcontrol_file_contents
   changed_when: false
   loop: "{{ swpm_output_sapcontrol_files.files | map(attribute='path') | list | unique }}"
+  loop_control:
+    loop_var: line_item
 
 - name: SAP SWPM - Display installation finished from success file
   ansible.builtin.debug:

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -32,14 +32,18 @@
 
     - name: SAP SWPM Pre Install - Create list of absolute directory names from the find result
       ansible.builtin.set_fact:
-        __sap_swpm_fact_directories: "{{ __sap_swpm_fact_directories | d([]) + [item.path] }}"
+        __sap_swpm_fact_directories: "{{ __sap_swpm_fact_directories | d([]) + [line_item.path] }}"
       loop: "{{ __sap_swpm_register_find_result_directories.files }}"
+      loop_control:
+        loop_var: line_item
       when: __sap_swpm_register_find_result_directories is defined
 
     - name: SAP SWPM Pre Install - Create list of absolute file names for non-SAPCAR files from the find result
       ansible.builtin.set_fact:
-        __sap_swpm_fact_files_non_sapcar: "{{ __sap_swpm_fact_files_non_sapcar | d([]) + [item.path] }}"
+        __sap_swpm_fact_files_non_sapcar: "{{ __sap_swpm_fact_files_non_sapcar | d([]) + [line_item.path] }}"
       loop: "{{ __sap_swpm_register_find_result_files_non_sapcar.files }}"
+      loop_control:
+        loop_var: line_item
       when: __sap_swpm_register_find_result_files_non_sapcar is defined
 
     - name: SAP SWPM Pre Install - Ensure correct permissions and ownership of all directories

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -32,13 +32,13 @@
 
     - name: SAP SWPM Pre Install - Create list of absolute directory names from the find result
       ansible.builtin.set_fact:
-        __sap_swpm_fact_directories: "{{ __sap_swpm_fact_directories|d([]) + [ item.path ] }}"
+        __sap_swpm_fact_directories: "{{ __sap_swpm_fact_directories | d([]) + [item.path] }}"
       loop: "{{ __sap_swpm_register_find_result_directories.files }}"
       when: __sap_swpm_register_find_result_directories is defined
 
     - name: SAP SWPM Pre Install - Create list of absolute file names for non-SAPCAR files from the find result
       ansible.builtin.set_fact:
-        __sap_swpm_fact_files_non_sapcar: "{{ __sap_swpm_fact_files_non_sapcar|d([]) + [ item.path ] }}"
+        __sap_swpm_fact_files_non_sapcar: "{{ __sap_swpm_fact_files_non_sapcar | d([]) + [item.path] }}"
       loop: "{{ __sap_swpm_register_find_result_files_non_sapcar.files }}"
       when: __sap_swpm_register_find_result_files_non_sapcar is defined
 

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -56,7 +56,7 @@
         - __sap_swpm_fact_directories is defined
         - __sap_swpm_register_find_result_directories is defined
 
-    - name: SAP SWPM Pre Install - Create argument list for chmod of non-SAPCAR*EXE files
+    - name: SAP SWPM Pre Install - Create argument list for chown and chmod of non-SAPCAR*EXE files
       ansible.builtin.set_fact:
         __sap_swpm_fact_files_non_sapcar_chown_arg_list: "{{ __sap_swpm_fact_files_non_sapcar | map('quote') | join(' ') }}"
 

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -69,7 +69,7 @@
 # - no-changed-when: Not worth checking permissions and ownership before this task and comparing afterwards
     - name: SAP SWPM Pre Install - Ensure correct permissions and ownership of all non-SAPCAR files # noqa command-instead-of-module no-changed-when
       ansible.builtin.shell: >
-         set -o pipefail && chown {{ sap_swpm_files_non_sapcar_owner }}:{{ sap_swpm_files_non_sapcar_group }} \
+         chown {{ sap_swpm_files_non_sapcar_owner }}:{{ sap_swpm_files_non_sapcar_group }} \
          {{ __sap_swpm_fact_files_non_sapcar_chown_arg_list }} &&
          chmod {{ sap_swpm_files_non_sapcar_mode }} \
          {{ __sap_swpm_fact_files_non_sapcar_chown_arg_list }}

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -12,21 +12,73 @@
   register: sap_swpm_software_path_stat
   failed_when: not sap_swpm_software_path_stat.stat.exists
 
-- name: SAP SWPM Pre Install - Change ownership of software path - {{ sap_swpm_software_path }}
-  ansible.builtin.file:
-    path: "{{ sap_swpm_software_path }}"
-    state: directory
-    recurse: yes
-    mode: '0755'
-    owner: root
-    group: root
+- name: SAP SWPM Pre Install - Set directory and file permissions
+  when: sap_swpm_set_file_permissions
+  block:
+
+    - name: SAP SWPM Pre Install - Find directories
+      ansible.builtin.find:
+        path: "{{ sap_swpm_software_path }}"
+        file_type: directory
+      register: __sap_swpm_register_find_result_directories
+
+    - name: SAP SWPM Pre Install - Find non-SAPCAR files
+      ansible.builtin.find:
+        path: "{{ sap_swpm_software_path }}"
+        file_type: file
+        recurse: true
+        excludes: "SAPCAR*EXE"
+      register: __sap_swpm_register_find_result_files_non_sapcar
+
+    - name: SAP SWPM Pre Install - Create list of absolute directory names from the find result
+      ansible.builtin.set_fact:
+        __sap_swpm_fact_directories: "{{ __sap_swpm_fact_directories|d([]) + [ item.path ] }}"
+      loop: "{{ __sap_swpm_register_find_result_directories.files }}"
+      when: __sap_swpm_register_find_result_directories is defined
+
+    - name: SAP SWPM Pre Install - Create list of absolute file names for non-SAPCAR files from the find result
+      ansible.builtin.set_fact:
+        __sap_swpm_fact_files_non_sapcar: "{{ __sap_swpm_fact_files_non_sapcar|d([]) + [ item.path ] }}"
+      loop: "{{ __sap_swpm_register_find_result_files_non_sapcar.files }}"
+      when: __sap_swpm_register_find_result_files_non_sapcar is defined
+
+    - name: SAP SWPM Pre Install - Ensure correct permissions and ownership of all directories
+      ansible.builtin.file:
+        path: "{{ line_item }}"
+        recurse: no
+        mode: "{{ sap_swpm_software_directory_mode }}"
+        owner: "{{ sap_swpm_software_directory_owner }}"
+        group: "{{ sap_swpm_software_directory_group }}"
+      loop: "{{ __sap_swpm_fact_directories }}"
+      loop_control:
+        loop_var: line_item
+      when:
+        - __sap_swpm_fact_directories is defined
+        - __sap_swpm_register_find_result_directories is defined
+
+    - name: SAP SWPM Pre Install - Create argument list for chmod of non-SAPCAR*EXE files
+      ansible.builtin.set_fact:
+        __sap_swpm_fact_files_non_sapcar_chown_arg_list: "{{ __sap_swpm_fact_files_non_sapcar | map('quote') | join(' ') }}"
+
+# Reasons for noqa:
+# - command-instead-of-module: Shorter execution time compared to looping over a list when using the file module
+# - no-changed-when: Not worth checking permissions and ownership before this task and comparing afterwards
+    - name: SAP SWPM Pre Install - Ensure correct permissions and ownership of all non-SAPCAR files # noqa command-instead-of-module no-changed-when
+      ansible.builtin.shell: >
+         set -o pipefail && chown {{ sap_swpm_files_non_sapcar_owner }}:{{ sap_swpm_files_non_sapcar_group }} \
+         {{ __sap_swpm_fact_files_non_sapcar_chown_arg_list }} &&
+         chmod {{ sap_swpm_files_non_sapcar_mode }} \
+         {{ __sap_swpm_fact_files_non_sapcar_chown_arg_list }}
+      when:
+        - __sap_swpm_fact_files_non_sapcar is defined
+        - __sap_swpm_register_find_result_files_non_sapcar is defined
 
 
 # SAPCAR Path
 
 - name: SAP SWPM Pre Install - Check availability of SAPCAR path - {{ sap_swpm_sapcar_path }}
   ansible.builtin.stat:
-    path: "{{ sap_swpm_sapcar_path }}"
+    path: "{{ sap_swpm_sapcar_path | d(sap_swpm_software_path) }}"
   register: sap_swpm_sapcar_path_stat
   failed_when: not sap_swpm_sapcar_path_stat.stat.exists
 
@@ -34,16 +86,17 @@
   ansible.builtin.file:
     path: "{{ sap_swpm_sapcar_path }}"
     state: directory
-    recurse: yes
-    mode: '0755'
-    owner: root
-    group: root
+    recurse: no
+    mode: "{{ sap_swpm_software_directory_mode }}"
+    owner: "{{ sap_swpm_software_directory_owner }}"
+    group: "{{ sap_swpm_software_directory_group }}"
+  when: sap_swpm_set_file_permissions
 
 # SWPM Path
 
 - name: SAP SWPM Pre Install - Check availability of SWPM path - {{ sap_swpm_swpm_path }}
   ansible.builtin.stat:
-    path: "{{ sap_swpm_swpm_path }}"
+    path: "{{ sap_swpm_swpm_path | d(sap_swpm_software_path) }}"
   register: sap_swpm_swpm_path_stat
   failed_when: not sap_swpm_swpm_path_stat.stat.exists
 
@@ -51,10 +104,13 @@
   ansible.builtin.file:
     path: "{{ sap_swpm_swpm_path }}"
     state: directory
-    recurse: yes
-    mode: '0755'
-    owner: root
-    group: root
+    recurse: no
+    mode: "{{ sap_swpm_software_directory_mode }}"
+    owner: "{{ sap_swpm_software_directory_owner }}"
+    group: "{{ sap_swpm_software_directory_group }}"
+  when:
+    - sap_swpm_swpm_path != sap_swpm_software_path
+    - sap_swpm_set_file_permissions
 
 
 ################
@@ -81,6 +137,15 @@
   register: sap_swpm_sapcar_file_name_stat
   failed_when: not sap_swpm_sapcar_file_name_stat.stat.exists
 
+- name: SAP SWPM Pre Install - Ensure correct permissions and ownership of the SAPCAR*EXE file
+  ansible.builtin.file:
+    path: "{{ sap_swpm_sapcar_path }}/{{ sap_swpm_sapcar_file_name }}"
+    recurse: no
+    mode: "{{ sap_swpm_files_sapcar_mode }}"
+    owner: "{{ sap_swpm_files_sapcar_owner }}"
+    group: "{{ sap_swpm_files_sapcar_group }}"
+  when: sap_swpm_set_file_permissions
+
 # 2. SWPM
 
 - name: SAP SWPM Pre Install - Get SWPM from {{ sap_swpm_swpm_path }}
@@ -101,6 +166,17 @@
   register: sap_swpm_swpm_sar_file_name_stat
   failed_when: not sap_swpm_swpm_sar_file_name_stat.stat.exists
 
+# Note: We use the permissions and ownership settings for non-SAPCAR*EXE files:
+- name: SAP SWPM Pre Install - Ensure correct permissions and ownership of the SWPM*SAR file
+  ansible.builtin.file:
+    path: "{{ sap_swpm_swpm_path }}/{{ sap_swpm_swpm_sar_file_name }}"
+    recurse: no
+    mode: "{{ sap_swpm_files_non_sapcar_mode }}"
+    owner: "{{ sap_swpm_files_non_sapcar_owner }}"
+    group: "{{ sap_swpm_files_non_sapcar_group }}"
+  when:
+    - sap_swpm_swpm_path != sap_swpm_software_path
+    - sap_swpm_set_file_permissions
 
 - name: SAP SWPM Pre Install - Full SAP System
   when: not sap_swpm_generic | bool

--- a/roles/sap_swpm/tasks/swpm/prepare_software.yml
+++ b/roles/sap_swpm/tasks/swpm/prepare_software.yml
@@ -36,6 +36,7 @@
       loop: "{{ __sap_swpm_register_find_result_directories.files }}"
       loop_control:
         loop_var: line_item
+        label: "{{ line_item.path }}"
       when: __sap_swpm_register_find_result_directories is defined
 
     - name: SAP SWPM Pre Install - Create list of absolute file names for non-SAPCAR files from the find result
@@ -44,6 +45,7 @@
       loop: "{{ __sap_swpm_register_find_result_files_non_sapcar.files }}"
       loop_control:
         loop_var: line_item
+        label: "{{ line_item.path }}"
       when: __sap_swpm_register_find_result_files_non_sapcar is defined
 
     - name: SAP SWPM Pre Install - Ensure correct permissions and ownership of all directories


### PR DESCRIPTION
This PR supports optionally skipping setting permission and ownership of SAP installation files. It also introduces new role parameters for setting the mode, owner, and group of the software directory, the directory for SAPCAR, and the directory for SWPM, as well as the files within.

Solves issue #663.