### PR TITLE
sap_maintain_etc_hosts: no longer use ansible.utils.ip

### DIFF
--- a/roles/sap_maintain_etc_hosts/defaults/main.yml
+++ b/roles/sap_maintain_etc_hosts/defaults/main.yml
@@ -45,3 +45,7 @@
 # the role creates a default value from ansible_facts
 
 sap_maintain_etc_hosts_list: "{{ sap_hana_cluster_nodes | default(sap_ha_pacemaker_cluster_cluster_nodes) | default(omit) }}"
+
+# regex patterns for IP address validation:
+sap_maintain_etc_hosts_regexp_ipv4: '^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$'
+sap_maintain_etc_hosts_regexp_ipv6: '^(?:[a-fA-F0-9]{0,4}:){7}[a-fA-F0-9]{0,4}$'

--- a/roles/sap_maintain_etc_hosts/meta/argument_specs.yml
+++ b/roles/sap_maintain_etc_hosts/meta/argument_specs.yml
@@ -82,3 +82,15 @@ argument_specs:
               state: absent
             - node_name: host2
               state: absent
+
+      sap_maintain_etc_hosts_regexp_ipv4:
+        default: '^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$'
+        description:
+          - regex pattern for IPv4 address validation
+        type: str
+
+      sap_maintain_etc_hosts_regexp_ipv6:
+        default: '^(?:[a-fA-F0-9]{0,4}:){7}[a-fA-F0-9]{0,4}$'
+        description:
+          - regex pattern for IPv6 address validation
+        type: str

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_absent.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_absent.yml
@@ -1,7 +1,8 @@
 ---
 - name: Verify that variable node_ip is in the correct format
   ansible.builtin.assert:
-    that: thishost.node_ip is ansible.utils.ip
+    that: thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) or
+          thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6)
     msg: "Variable 'node_ip' is not an IP address. Please use the correct format"
   when: thisnode.node_ip is defined
 

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -6,7 +6,8 @@
 
 - name: Verify that variable node_ip is in the correct format
   ansible.builtin.assert:
-    that: thishost.node_ip is ansible.utils.ip
+    that: thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) or
+          thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6)
     msg: "Variable 'node_ip' is not an IP address. Please use the correct format"
 
 - name: Verify that variable node_name is set


### PR DESCRIPTION
Checking the ip address against a regex pattern should be sufficient to ensure that valid IP addresses are passed to the role.

Solves issue #667.

Should not cause merge conflicts with #668 but probably worth checking.