### PR TITLE
sap_*_preconfigure: Tests with ansible parameter -i instead of -l #671

### DIFF
--- a/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
+++ b/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
@@ -143,6 +143,7 @@ for par1 in __tests:
     command = (
         'ansible-playbook sap_general_preconfigure-default-settings.yml '
         + par1['command_line_parameter']
+        + '-u root '
         + '-i '
         + _managed_node
         + ', '

--- a/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
+++ b/roles/sap_general_preconfigure/tests/run-sap_general_preconfigure-tests.py
@@ -143,9 +143,9 @@ for par1 in __tests:
     command = (
         'ansible-playbook sap_general_preconfigure-default-settings.yml '
         + par1['command_line_parameter']
-        + '-l '
+        + '-i '
         + _managed_node
-        + ' '
+        + ', '
         + '-e "'
     )
     for par2 in par1['role_vars']:

--- a/roles/sap_hana_install/tests/install/run-sap_hana_install-install-tests.py
+++ b/roles/sap_hana_install/tests/install/run-sap_hana_install-install-tests.py
@@ -104,8 +104,10 @@ for par1 in __tests[0:3]:
     command = ('ansible-playbook prepare-install-test-'
                + par1['number']
                + '.yml '
-               + '-l '
+               + '-u root '
+               + '-i '
                + __managed_node)
+               + ','
     args = shlex.split(command)
 #    _py_rc = os.system(command)
     __logfile = __logdir + '/' + __logfile_prefix + __datestr + '-prepare-' + par1['number'] + '.log'
@@ -121,9 +123,10 @@ for par1 in __tests[0:3]:
                + par1['number']
                + '.yml '
                + par1['command_line_parameter']
-               + '-l '
+               + '-u root '
+               + '-i '
                + __managed_node
-               + ' '
+               + ', '
                + '-e "')
 # add all role vars for this test:
     for par2 in par1['role_vars']:
@@ -151,8 +154,10 @@ for par1 in __tests[0:3]:
 
 # uninstall SAP HANA:
     command = ('ansible-playbook hana-uninstall.yml '
-               + '-l '
+               + '-u root '
+               + '-i '
                + __managed_node)
+               + ','
     args = shlex.split(command)
     __logfile = __logdir + '/' + __logfile_prefix + __datestr + '-uninstall-' + par1['number'] + '.log'
     with open(__logfile, 'wb') as __filedescriptor:

--- a/roles/sap_hana_preconfigure/tests/run-sap_hana_preconfigure-tests.py
+++ b/roles/sap_hana_preconfigure/tests/run-sap_hana_preconfigure-tests.py
@@ -186,6 +186,7 @@ for par1 in __tests:
     print('\n' + 'Test ' + par1['number'] + ': ' + par1['name'])
     command = ('ansible-playbook sap_hana_preconfigure-default-settings.yml '
                + par1['command_line_parameter']
+               + '-u root '
                + '-i '
                + _managed_node
                + ', '

--- a/roles/sap_hana_preconfigure/tests/run-sap_hana_preconfigure-tests.py
+++ b/roles/sap_hana_preconfigure/tests/run-sap_hana_preconfigure-tests.py
@@ -186,9 +186,9 @@ for par1 in __tests:
     print('\n' + 'Test ' + par1['number'] + ': ' + par1['name'])
     command = ('ansible-playbook sap_hana_preconfigure-default-settings.yml '
                + par1['command_line_parameter']
-               + '-l '
+               + '-i '
                + _managed_node
-               + ' '
+               + ', '
                + '-e "')
     for par2 in par1['role_vars']:
         command += str(par2)

--- a/roles/sap_netweaver_preconfigure/tests/run-sap_netweaver_preconfigure-tests.py
+++ b/roles/sap_netweaver_preconfigure/tests/run-sap_netweaver_preconfigure-tests.py
@@ -98,9 +98,9 @@ for par1 in __tests:
     print('\n' + 'Test ' + par1['number'] + ': ' + par1['name'])
     command = ('ansible-playbook sap_netweaver_preconfigure-default-settings.yml '
                + par1['command_line_parameter']
-               + '-l '
+               + '-i '
                + _managed_node
-               + ' '
+               + ', '
                + '-e "')
     for par2 in par1['role_vars']:
         command += str(par2)

--- a/roles/sap_netweaver_preconfigure/tests/run-sap_netweaver_preconfigure-tests.py
+++ b/roles/sap_netweaver_preconfigure/tests/run-sap_netweaver_preconfigure-tests.py
@@ -98,6 +98,7 @@ for par1 in __tests:
     print('\n' + 'Test ' + par1['number'] + ': ' + par1['name'])
     command = ('ansible-playbook sap_netweaver_preconfigure-default-settings.yml '
                + par1['command_line_parameter']
+               + '-u root '
                + '-i '
                + _managed_node
                + ', '


### PR DESCRIPTION
This PR is changing ansible-playbook parameter `-l` to `-i` in tests scripts.
No more need to specify hosts in the file `/etc/ansible/hosts` each time.