### PR TITLE
sap_swpm: Fix item label in swpm.yml

### DIFF
--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -143,4 +143,4 @@
   loop: "{{ swpm_sapcontrol_file_contents.results }}"
   loop_control:
     loop_var: file_output
-    label: "{{ file_output.item }}"
+    label: "{{ file_output.line_item }}"


### PR DESCRIPTION
This is to address issue #681, which was created because an error was thrown complaining about the name in the label.

I noticed that the new name had been added 2 tasks above, and then I used the same label name on the last task and re-executed the playbook, which then finished successfully.