### PR TITLE
sap_netweaver_preconfigure-RHEL: Sync with SAP note 3119751 v.13

### DIFF
--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -7,49 +7,52 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-# Reason for noqa: We do not want to fail if there is no output from the ls command.
-- name: Identify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
-  ansible.builtin.shell:
-  args:
-    cmd: ls compat-sap-c++-1* | sort | tail -1
-    chdir: /opt/rh/SAP/lib64
-  register: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp
-  changed_when: false
+- name: Indentify all compat-sap-c++-NUM.so files with NUM >= 10
+  ansible.builtin.find:
+    paths: '/opt/rh/SAP/lib64'
+    patterns: "compat-sap-c++-1*"
+  register: __sap_netweaver_preconfigure_register_find_compat_sap_cpp
 
-# Note: The file compat-sap-c++-NUM.so file with NUM >= 10 will be available if the role sap_general_preconfigure has been run before.
-- name: Fail if there is no file compat-sap-c++-NUM.so file with NUM >= 10
+# Note: The file compat-sap-c++-NUM.so with NUM >= 10 will be available if the role sap_general_preconfigure has been run before,
+# which is a requirement.
+- name: Fail if there is no file 'compat-sap-c++-NUM.so' file with NUM >= 10
   ansible.builtin.fail:
-    msg: |
-      - There is no file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so file with NUM >= 10.
-      - Make sure that package compat-sap-c++-10 or later is installed.
-  when: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is undefined or
-        __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is none or
-        __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length == 0
+    msg: There is no file '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' file with NUM >= 10!
+  when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched == 0
+
+# Note: All following tasks depend on the previous task not having failed, so no further when condition is used below.
+- name: Set fact for file names from find result
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | d([]) + [ __sap_netweaver_preconfigure_item.path | basename ] }}"
+  loop: "{{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files }}"
+  loop_control:
+    loop_var: __sap_netweaver_preconfigure_item
+    label: __sap_netweaver_preconfigure_item
+
+- name: Set fact for the latest compat-sap-c++.NUM.so file name
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | sort | last }}"
 
 - name: Display the identified compat-sap-c++-NUM.so file name
   ansible.builtin.debug:
-    msg: "File /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }} is present."
+    msg: "File /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }} is present."
 
-- name: Ensure necessary symlinks for RHEL 8 are available
-  when: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length > 0
-  block:
+- name: Ensure there is a symlink in directory '/opt/rh/SAP/lib64' named 'libstdc++.so.6', pointing to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'
+  ansible.builtin.file:
+    src: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}"
+    dest: "/opt/rh/SAP/lib64/libstdc++.so.6"
+    state: link
 
-    - name: Ensure there is a symlink in directory '/opt/rh/SAP/lib64' named 'libstdc++.so.6', pointing to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'
-      ansible.builtin.file:
-        src: "{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}"
-        dest: "/opt/rh/SAP/lib64/libstdc++.so.6"
-        state: link
+- name: Ensure directory '{{ sap_netweaver_preconfigure_rpath }}' is present
+  ansible.builtin.file:
+    path: "{{ sap_netweaver_preconfigure_rpath }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
 
-    - name: Ensure directory '{{ sap_netweaver_preconfigure_rpath }}' is present
-      ansible.builtin.file:
-        path: "{{ sap_netweaver_preconfigure_rpath }}"
-        state: directory
-        owner: root
-        group: root
-        mode: '0755'
-
-    - name: Ensure there is a symlink in directory '{{ sap_netweaver_preconfigure_rpath }}' named 'libstdc++.so.6' pointing to '/opt/rh/SAP/lib64/libstdc++.so.6'
-      ansible.builtin.file:
-        src: /opt/rh/SAP/lib64/libstdc++.so.6
-        dest: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
-        state: link
+- name: Ensure there is a symlink in directory '{{ sap_netweaver_preconfigure_rpath }}' named 'libstdc++.so.6' pointing to '/opt/rh/SAP/lib64/libstdc++.so.6'
+  ansible.builtin.file:
+    src: /opt/rh/SAP/lib64/libstdc++.so.6
+    dest: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
+    state: link

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -7,7 +7,7 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Indentify all compat-sap-c++-NUM.so files with NUM >= 10
+- name: Identify all compat-sap-c++-NUM.so files with NUM >= 10
   ansible.builtin.find:
     paths: '/opt/rh/SAP/lib64'
     patterns: "compat-sap-c++-1*"
@@ -23,7 +23,7 @@
 # Note: All following tasks depend on the previous task not having failed, so no further when condition is used below.
 - name: Set fact for file names from find result
   ansible.builtin.set_fact:
-    __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | d([]) + [ __sap_netweaver_preconfigure_item.path | basename ] }}"
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | d([]) + [__sap_netweaver_preconfigure_item.path | basename] }}"
   loop: "{{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files }}"
   loop_control:
     loop_var: __sap_netweaver_preconfigure_item

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -8,7 +8,7 @@
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
 # Reason for noqa: We do not want to fail if there is no output from the ls command.
-- name: Indentify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
+- name: Identify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
   ansible.builtin.shell:
   args:
     cmd: ls compat-sap-c++-1* | sort | tail -1

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -5,6 +5,8 @@
     msg: "SAP note {{ (__sap_netweaver_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3119751$') | first).number }}
           (version {{ (__sap_netweaver_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3119751$') | first).version }}): Linux Requirements for SAP Kernel 754 and for SAP Kernel 788 and higher"
 
+# Note: This file is only included for RHEL 8, so no further when condition is required here.
+
 # Reason for noqa: We do not want to fail if there is no output from the ls command.
 - name: Indentify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
   ansible.builtin.shell:
@@ -12,7 +14,6 @@
     cmd: ls compat-sap-c++-1* | sort | tail -1
     chdir: /opt/rh/SAP/lib64
   register: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp
-  when: ansible_distribution_major_version == '8'
   changed_when: false
 
 # Note: The file compat-sap-c++-NUM.so file with NUM >= 10 will be available if the role sap_general_preconfigure has been run before.
@@ -21,20 +22,16 @@
     msg: |
       - There is no file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so file with NUM >= 10.
       - Make sure that package compat-sap-c++-10 or later is installed.
-  when:
-    - ansible_distribution_major_version == '8'
-    - (__sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is undefined or
-       __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is none or
-       __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length == 0)
+  when: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is undefined or
+        __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is none or
+        __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length == 0
 
 - name: Display the identified compat-sap-c++-NUM.so file name
   ansible.builtin.debug:
     msg: "File /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }} is present."
 
 - name: Ensure necessary symlinks for RHEL 8 are available
-  when:
-    - ansible_distribution_major_version == '8'
-    - __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length > 0
+  when: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length > 0
   block:
 
     - name: Ensure there is a symlink in directory '/opt/rh/SAP/lib64' named 'libstdc++.so.6', pointing to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -7,7 +7,7 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Identify all compat-sap-c++-NUM.so files with NUM >= 10
+- name: Identify all 'compat-sap-c++-NUM.so' files with NUM >= 10
   ansible.builtin.find:
     paths: '/opt/rh/SAP/lib64'
     patterns: "compat-sap-c++-1*"
@@ -27,13 +27,13 @@
   loop: "{{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files }}"
   loop_control:
     loop_var: __sap_netweaver_preconfigure_item
-    label: __sap_netweaver_preconfigure_item
+    label: "{{ __sap_netweaver_preconfigure_item.path }}"
 
-- name: Set fact for the latest compat-sap-c++.NUM.so file name
+- name: Set fact for the latest 'compat-sap-c++.NUM.so' file name
   ansible.builtin.set_fact:
     __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | sort | last }}"
 
-- name: Display the identified compat-sap-c++-NUM.so file name
+- name: Display the identified 'compat-sap-c++-NUM.so' file name
   ansible.builtin.debug:
     msg: "File /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }} is present."
 

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -7,35 +7,32 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Identify all 'compat-sap-c++-NUM.so' files with NUM >= 10
+- name: Identify all 'compat-sap-c++-NUM.so' symlinks with NUM >= 10
   ansible.builtin.find:
     paths: '/opt/rh/SAP/lib64'
-    patterns: "compat-sap-c++-1*"
+    patterns: "compat-sap-c\\+\\+-1[0-9].so"
+    file_type: link
+    use_regex: true
   register: __sap_netweaver_preconfigure_register_find_compat_sap_cpp
 
-# Note: The file compat-sap-c++-NUM.so with NUM >= 10 will be available if the role sap_general_preconfigure has been run before,
+# Note: The symlink compat-sap-c++-NUM.so with NUM >= 10 will be available if the role sap_general_preconfigure has been run before,
 # which is a requirement.
-- name: Fail if there is no file 'compat-sap-c++-NUM.so' file with NUM >= 10
+- name: Fail if there is no 'compat-sap-c++-NUM.so' symlink with NUM >= 10
   ansible.builtin.fail:
-    msg: There is no file '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' file with NUM >= 10!
+    msg: There is no symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10!
   when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched == 0
 
 # Note: All following tasks depend on the previous task not having failed, so no further when condition is used below.
-- name: Set fact for file names from find result
+- name: Set fact for the latest 'compat-sap-c++.NUM.so' symlink
   ansible.builtin.set_fact:
-    __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | d([]) + [__sap_netweaver_preconfigure_item.path | basename] }}"
-  loop: "{{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files }}"
-  loop_control:
-    loop_var: __sap_netweaver_preconfigure_item
-    label: "{{ __sap_netweaver_preconfigure_item.path }}"
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: >-
+     {{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files
+       | map(attribute = 'path')
+       | sort | last | basename }}
 
-- name: Set fact for the latest 'compat-sap-c++.NUM.so' file name
-  ansible.builtin.set_fact:
-    __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | sort | last }}"
-
-- name: Display the identified 'compat-sap-c++-NUM.so' file name
+- name: Display the identified 'compat-sap-c++-NUM.so' symlink
   ansible.builtin.debug:
-    msg: "File /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }} is present."
+    msg: "Symlink /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }} is present."
 
 - name: Ensure there is a symlink in directory '/opt/rh/SAP/lib64' named 'libstdc++.so.6', pointing to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'
   ansible.builtin.file:

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -32,7 +32,7 @@
 
 - name: Display the identified 'compat-sap-c++-NUM.so' symlink
   ansible.builtin.debug:
-    msg: "Symlink /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }} is present."
+    msg: "Symlink '/opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}' is present."
 
 - name: Ensure there is a symlink in directory '/opt/rh/SAP/lib64' named 'libstdc++.so.6', pointing to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'
   ansible.builtin.file:

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/3119751.yml
@@ -5,23 +5,54 @@
     msg: "SAP note {{ (__sap_netweaver_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3119751$') | first).number }}
           (version {{ (__sap_netweaver_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3119751$') | first).version }}): Linux Requirements for SAP Kernel 754 and for SAP Kernel 788 and higher"
 
-- name: Get info about the compat-sap-c++-10.so file
-  ansible.builtin.stat:
-    path: /opt/rh/SAP/lib64/compat-sap-c++-10.so
-  register: __sap_netweaver_preconfigure_register_stat_compat_sap_cpp
+# Reason for noqa: We do not want to fail if there is no output from the ls command.
+- name: Indentify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
+  ansible.builtin.shell:
+  args:
+    cmd: ls compat-sap-c++-1* | sort | tail -1
+    chdir: /opt/rh/SAP/lib64
+  register: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp
+  when: ansible_distribution_major_version == '8'
+  changed_when: false
 
-- name: Create directory '{{ sap_netweaver_preconfigure_rpath }}'
-  ansible.builtin.file:
-    path: "{{ sap_netweaver_preconfigure_rpath }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  when: __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
+# Note: The file compat-sap-c++-NUM.so file with NUM >= 10 will be available if the role sap_general_preconfigure has been run before.
+- name: Fail if there is no file compat-sap-c++-NUM.so file with NUM >= 10
+  ansible.builtin.fail:
+    msg: |
+      - There is no file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so file with NUM >= 10.
+      - Make sure that package compat-sap-c++-10 or later is installed.
+  when:
+    - ansible_distribution_major_version == '8'
+    - (__sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is undefined or
+       __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout is none or
+       __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length == 0)
 
-- name: Create a link to '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6'
-  ansible.builtin.file:
-    src: /opt/rh/SAP/lib64/compat-sap-c++-10.so
-    dest: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
-    state: link
-  when: __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
+- name: Display the identified compat-sap-c++-NUM.so file name
+  ansible.builtin.debug:
+    msg: "File /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }} is present."
+
+- name: Ensure necessary symlinks for RHEL 8 are available
+  when:
+    - ansible_distribution_major_version == '8'
+    - __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length > 0
+  block:
+
+    - name: Ensure there is a symlink in directory '/opt/rh/SAP/lib64' named 'libstdc++.so.6', pointing to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'
+      ansible.builtin.file:
+        src: "{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}"
+        dest: "/opt/rh/SAP/lib64/libstdc++.so.6"
+        state: link
+
+    - name: Ensure directory '{{ sap_netweaver_preconfigure_rpath }}' is present
+      ansible.builtin.file:
+        path: "{{ sap_netweaver_preconfigure_rpath }}"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Ensure there is a symlink in directory '{{ sap_netweaver_preconfigure_rpath }}' named 'libstdc++.so.6' pointing to '/opt/rh/SAP/lib64/libstdc++.so.6'
+      ansible.builtin.file:
+        src: /opt/rh/SAP/lib64/libstdc++.so.6
+        dest: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
+        state: link

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
@@ -7,29 +7,42 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Identify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
-  ansible.builtin.shell:
-  args:
-    cmd: ls compat-sap-c++-1* | sort | tail -1
-    chdir: /opt/rh/SAP/lib64
-  register: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp
-  changed_when: false
+- name: Identify all 'compat-sap-c++-NUM.so' files with NUM >= 10
+  ansible.builtin.find:
+    paths: '/opt/rh/SAP/lib64'
+    patterns: "compat-sap-c++-1*"
+  register: __sap_netweaver_preconfigure_register_find_compat_sap_cpp
 
-# Note: The file compat-sap-c++-NUM.so file with NUM >= 10 will be available if the role sap_general_preconfigure has been run before.
-- name: Assert that there is at least one file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so with NUM >= 10
+- name: Set fact for file names from find result
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | d([]) + [__sap_netweaver_preconfigure_item.path | basename] }}"
+  loop: "{{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files }}"
+  loop_control:
+    loop_var: __sap_netweaver_preconfigure_item
+    label: "{{ __sap_netweaver_preconfigure_item.path }}"
+  when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
+
+- name: Set fact for the latest 'compat-sap-c++.NUM.so' file name
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | sort | last }}"
+  when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
+
+# Note: The file compat-sap-c++-NUM.so with NUM >= 10 will be available if the role sap_general_preconfigure has been run before,
+# which is a requirement.
+- name: Assert that there is at least one file '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length > 0
-    fail_msg: "FAIL: There is no file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so file with NUM >= 10!"
-    success_msg: "PASS: Found file /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}."
+    that: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
+    fail_msg: "FAIL: There is no file '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' file with NUM >= 10!"
+    success_msg: "PASS: Identified file '/opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 
 # Verify /opt/rh/SAP/lib64/libstdc++.so.6
-- name: Get info about file /opt/rh/SAP/lib64/libstdc++.so.6
+- name: Get info about file '/opt/rh/SAP/lib64/libstdc++.so.6'
   ansible.builtin.stat:
     path: /opt/rh/SAP/lib64/libstdc++.so.6
   register: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert
 
-- name: Assert that file /opt/rh/SAP/lib64/libstdc++.so.6 exists
+- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' exists
   ansible.builtin.assert:
     that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
     fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' does not exist!"
@@ -44,11 +57,11 @@
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
   when: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
 
-- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'
+- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.lnk_target == __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout
-    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' is not a symlink to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}!'"
-    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'."
+    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.lnk_target == __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest
+    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' is not a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}!'"
+    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
   when: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
 

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
@@ -5,46 +5,77 @@
     msg: "SAP note {{ (__sap_netweaver_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3119751$') | first).number }}
           (version {{ (__sap_netweaver_preconfigure_sapnotes_versions | selectattr('number', 'match', '^3119751$') | first).version }}): Linux Requirements for SAP Kernel 754 and for SAP Kernel 788 and higher"
 
-- name: Get info about the compat-sap-c++-10.so file
-  ansible.builtin.stat:
-    path: /opt/rh/SAP/lib64/compat-sap-c++-10.so
-  register: __sap_netweaver_preconfigure_register_stat_compat_sap_cpp
+# Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Report if checking for a link from libstdc++.so.6 to compat-sap-c++-10.so is skipped
-  ansible.builtin.debug:
-    msg: "INFO: Not checking for link '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' - file '/opt/rh/SAP/lib64/compat-sap-c++-10.so' does not exist on this system."
-  when: not __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
+- name: Indentify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
+  ansible.builtin.shell:
+  args:
+    cmd: ls compat-sap-c++-1* | sort | tail -1
+    chdir: /opt/rh/SAP/lib64
+  register: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp
+  changed_when: false
+
+# Note: The file compat-sap-c++-NUM.so file with NUM >= 10 will be available if the role sap_general_preconfigure has been run before.
+- name: Assert that there is at least one file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so with NUM >= 10
+  ansible.builtin.assert:
+    that: __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout | length > 0
+    fail_msg: "FAIL: There is no file /opt/rh/SAP/lib64/compat-sap-c++-NUM.so file with NUM >= 10!"
+    success_msg: "PASS: Found file /opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}."
+  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
+
+# Verify /opt/rh/SAP/lib64/libstdc++.so.6
+- name: Get info about file /opt/rh/SAP/lib64/libstdc++.so.6
+  ansible.builtin.stat:
+    path: /opt/rh/SAP/lib64/libstdc++.so.6
+  register: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert
+
+- name: Assert that file /opt/rh/SAP/lib64/libstdc++.so.6 exists
+  ansible.builtin.assert:
+    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
+    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' does not exist!"
+    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' exists."
+  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
+
+- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink
+  ansible.builtin.assert:
+    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.islnk
+    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' is not a symlink!"
+    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink."
+  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
+  when: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
+
+- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'
+  ansible.builtin.assert:
+    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.lnk_target == __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout
+    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' is not a symlink to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}!'"
+    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_register_ls_compat_sap_cpp.stdout }}'."
+  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
+  when: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
 
 - name: Get info about file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6'
   ansible.builtin.stat:
     path: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
-  register: __sap_netweaver_preconfigure_register_stat_libstdc_assert
-  when: __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
+  register: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert
 
 - name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' exists
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_libstdc_assert.stat.exists
+    that: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists
     fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' does not exist!"
     success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' exists."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when: __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
 
-- name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a link
+- name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_libstdc_assert.stat.islnk
-    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is not a link!"
-    success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a link."
+    that: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.islnk
+    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is not a symlink!"
+    success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when:
-    - __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
-    - __sap_netweaver_preconfigure_register_stat_libstdc_assert.stat.exists
+  when: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists
 
-- name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a link to '/opt/rh/SAP/lib64/compat-sap-c++-10.so'
+- name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_libstdc_assert.stat.lnk_target == '/opt/rh/SAP/lib64/compat-sap-c++-10.so'
-    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is not a link to '/opt/rh/SAP/lib64/compat-sap-c++-10.so!'"
-    success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a link to '/opt/rh/SAP/lib64/compat-sap-c++-10.so.'"
+    that: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.lnk_target == '/opt/rh/SAP/lib64/libstdc++.so.6'
+    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is not a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'!"
+    success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when:
-    - __sap_netweaver_preconfigure_register_stat_compat_sap_cpp.stat.exists
-    - __sap_netweaver_preconfigure_register_stat_libstdc_assert.stat.exists
+  when: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
@@ -7,7 +7,7 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Indentify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
+- name: Identify the latest compat-sap-c++-NUM.so file with NUM >= 10 # noqa risky-shell-pipe
   ansible.builtin.shell:
   args:
     cmd: ls compat-sap-c++-1* | sort | tail -1

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
@@ -21,7 +21,7 @@
   ansible.builtin.assert:
     that: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
     fail_msg: "FAIL: There is no symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10!"
-    success_msg: "FAIL: There is at least one symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10!"
+    success_msg: "PASS: There is at least one symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10!"
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 
 - name: Set fact for the latest 'compat-sap-c++.NUM.so' symlink
@@ -32,61 +32,36 @@
        | sort | last | basename }}
   when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
 
-# Verify /opt/rh/SAP/lib64/libstdc++.so.6
+# Verify /opt/rh/SAP/lib64/libstdc++.so.6:
 - name: Get info about file '/opt/rh/SAP/lib64/libstdc++.so.6'
   ansible.builtin.stat:
     path: /opt/rh/SAP/lib64/libstdc++.so.6
   register: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert
   failed_when: false
 
-- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' exists
-  ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
-    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' does not exist!"
-    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' exists."
-  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-
-- name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink
-  ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.islnk
-    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' is not a symlink!"
-    success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink."
-  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
-
 - name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.lnk_target == __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest
-    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' is not a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}!'"
+    that:
+      - __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
+      - __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.islnk
+      - __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.lnk_target == __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest
+    fail_msg: "FAIL: File '/opt/rh/SAP/lib64/libstdc++.so.6' does not exist or is not a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}!'"
     success_msg: "PASS: File '/opt/rh/SAP/lib64/libstdc++.so.6' is a symlink to '{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert.stat.exists
 
+# Verify libstdc++.so.6 in RPATH /usr/sap/lib:
 - name: Get info about file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6'
   ansible.builtin.stat:
     path: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
   register: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert
   failed_when: false
 
-- name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' exists
-  ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists
-    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' does not exist!"
-    success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' exists."
-  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-
-- name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink
-  ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.islnk
-    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is not a symlink!"
-    success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink."
-  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists
-
 - name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.lnk_target == '/opt/rh/SAP/lib64/libstdc++.so.6'
-    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is not a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'!"
+    that:
+      - __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists
+      - __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.islnk
+      - __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.lnk_target == '/opt/rh/SAP/lib64/libstdc++.so.6'
+    fail_msg: "FAIL: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' does not exist or is not a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'!"
     success_msg: "PASS: File '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' is a symlink to '/opt/rh/SAP/lib64/libstdc++.so.6'."
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
-  when: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert.stat.exists

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/assert-3119751.yml
@@ -7,40 +7,37 @@
 
 # Note: This file is only included for RHEL 8, so no further when condition is required here.
 
-- name: Identify all 'compat-sap-c++-NUM.so' files with NUM >= 10
+- name: Identify all 'compat-sap-c++-NUM.so' symlinks with NUM >= 10
   ansible.builtin.find:
     paths: '/opt/rh/SAP/lib64'
-    patterns: "compat-sap-c++-1*"
+    patterns: "compat-sap-c\\+\\+-1[0-9].so"
+    file_type: link
+    use_regex: true
   register: __sap_netweaver_preconfigure_register_find_compat_sap_cpp
 
-- name: Set fact for file names from find result
-  ansible.builtin.set_fact:
-    __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | d([]) + [__sap_netweaver_preconfigure_item.path | basename] }}"
-  loop: "{{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files }}"
-  loop_control:
-    loop_var: __sap_netweaver_preconfigure_item
-    label: "{{ __sap_netweaver_preconfigure_item.path }}"
-  when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
-
-- name: Set fact for the latest 'compat-sap-c++.NUM.so' file name
-  ansible.builtin.set_fact:
-    __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: "{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_filenames | sort | last }}"
-  when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
-
-# Note: The file compat-sap-c++-NUM.so with NUM >= 10 will be available if the role sap_general_preconfigure has been run before,
+# Note: The symlink compat-sap-c++-NUM.so with NUM >= 10 will be available if the role sap_general_preconfigure has been run before,
 # which is a requirement.
-- name: Assert that there is at least one file '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10
+- name: Assert that there is at least one symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10
   ansible.builtin.assert:
     that: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
-    fail_msg: "FAIL: There is no file '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' file with NUM >= 10!"
-    success_msg: "PASS: Identified file '/opt/rh/SAP/lib64/{{ __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest }}'."
+    fail_msg: "FAIL: There is no symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10!"
+    success_msg: "FAIL: There is at least one symlink '/opt/rh/SAP/lib64/compat-sap-c++-NUM.so' with NUM >= 10!"
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
+
+- name: Set fact for the latest 'compat-sap-c++.NUM.so' symlink
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_fact_compat_sap_cpp_latest: >-
+     {{ __sap_netweaver_preconfigure_register_find_compat_sap_cpp.files
+       | map(attribute = 'path')
+       | sort | last | basename }}
+  when: __sap_netweaver_preconfigure_register_find_compat_sap_cpp.matched > 0
 
 # Verify /opt/rh/SAP/lib64/libstdc++.so.6
 - name: Get info about file '/opt/rh/SAP/lib64/libstdc++.so.6'
   ansible.builtin.stat:
     path: /opt/rh/SAP/lib64/libstdc++.so.6
   register: __sap_netweaver_preconfigure_register_stat_opt_rh_libstdc_assert
+  failed_when: false
 
 - name: Assert that file '/opt/rh/SAP/lib64/libstdc++.so.6' exists
   ansible.builtin.assert:
@@ -69,6 +66,7 @@
   ansible.builtin.stat:
     path: "{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6"
   register: __sap_netweaver_preconfigure_register_stat_usr_sap_libstdc_assert
+  failed_when: false
 
 - name: Assert that file '{{ sap_netweaver_preconfigure_rpath }}/libstdc++.so.6' exists
   ansible.builtin.assert:

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_8.yml
@@ -8,7 +8,7 @@ __sap_netweaver_preconfigure_sapnotes:
 
 __sap_netweaver_preconfigure_sapnotes_versions:
   - { number: '2526952', version: '5' }
-  - { number: '3119751', version: '4' }
+  - { number: '3119751', version: '13' }
 
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap


### PR DESCRIPTION
We need to sync the role `sap_netweaver_preconfigure` with the latest status of SAP note 3119751:

For RHEL 8, the following needs to be done to be prepared for all SAP kernels which are supported on RHEL 8 so that the SAP kernel can find the GCC10 symbols:

- In directory `/opt/rh/SAP/lib64` (the directory where the shared libraries of the `compat-sap-c++-<version>` package(s) are placed), a symlink named `libstdc++.so.6` needs to be present, pointing to file `compat-sap-c++-<version>.so` in the same directory, with `<version>` being `10` or higher.
- For certain older versions of the SAP kernel, there needs to be an additional symlink in directory `/usr/sap/lib`, named  `libstdc++.so.6` and pointing to file `/opt/rh/SAP/lib64/libstdc++.so.6`. This is because `RPATH` for older kernels did not yet include `/opt/rh/SAP/lib64`.

For simplicity, maintainability and supportability, we always create both links for RHEL 8.