### PR TITLE
sap_install_media_detect: Detection of duplicate SAR files for EXE, EXEDB, igs, igshelper and webdisp should count only file with type=sapcar

### DIFF
--- a/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/create_file_list_phase_2.yml
@@ -120,7 +120,7 @@
       ansible.builtin.assert:
         that:
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_kernel') | length > 0
-          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPEXE_') | length == 1
+          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPEXE_') | selectattr('archive_type', 'equalto', 'sapcar') | length == 1
         fail_msg: "No, or more than one, DB independent SAP Kernel file found"
       when:
         - sap_install_media_detect_kernel
@@ -129,7 +129,7 @@
       ansible.builtin.assert:
         that:
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_') | length > 0
-          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPEXEDB_') | length == 1
+          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPEXEDB_') | selectattr('archive_type', 'equalto', 'sapcar') | length == 1
         fail_msg: "No, or more than one, DB dependent SAP Kernel file found"
       when:
         - sap_install_media_detect_kernel
@@ -191,7 +191,7 @@
       ansible.builtin.assert:
         that:
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_igs') | length > 0
-          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'igsexe') | length > 0
+          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'igsexe') | selectattr('archive_type', 'equalto', 'sapcar') | length > 0
         fail_msg: "No igsexe file found"
       when:
         - sap_install_media_detect_igs
@@ -200,7 +200,7 @@
       ansible.builtin.assert:
         that:
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_igs') | length > 0
-          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'igshelper') | length > 0
+          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'igshelper') | selectattr('archive_type', 'equalto', 'sapcar') | length > 0
         fail_msg: "No igshelper file found"
       when:
         - sap_install_media_detect_igs
@@ -209,7 +209,7 @@
       ansible.builtin.assert:
         that:
           - __sap_install_media_detect_fact_files_sapfile_results | selectattr('sap_file_type', 'equalto', 'sap_webdisp') | length > 0
-          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPWEBDISP_') | length == 1
+          - __sap_install_media_detect_fact_files_sapfile_results | selectattr('file', 'search', 'SAPWEBDISP_') | selectattr('archive_type', 'equalto', 'sapcar') | length == 1
         fail_msg: "No, or more than one, SAPWEBDISP file found"
       when:
         - sap_install_media_detect_webdisp


### PR DESCRIPTION
This is a fix for issue #703 