### PR TITLE
sap_swpm: Remove pids module

### DIFF
--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -23,20 +23,19 @@
 ### Async method
 
 # Required for Ansible Module pids
-- name: Install Python devel, Python pip and gcc to system Python
-  ansible.builtin.package:
-    name:
-      - python3-devel
-      - python3-pip
-      - gcc
-    state: present
+#- name: Install Python devel, Python pip and gcc to system Python
+#  ansible.builtin.package:
+#    name:
+#      - python3-devel
+#      - python3-pip
+#      - gcc
+#    state: present
 
 # Required for Ansible Module pids
-- name: Install Python dependency psutil to system Python
-  ansible.builtin.pip:
-    name:
-      - psutil
-#    executable: pip3.6
+#- name: Install Python dependency psutil to system Python
+#  ansible.builtin.pip:
+#    name:
+#      - psutil
 
 - name: Set fact for the sapinst command line
   ansible.builtin.set_fact:
@@ -71,15 +70,12 @@
   poll: 0 # Seconds between polls, use 0 to run Ansible Tasks concurrently
 
 # Monitor sapinst process (i.e. ps aux | grep sapinst) and wait for exit
-- name: SAP SWPM - Wait for sapinst process to exit, poll every 60 seconds
-  community.general.pids:
-    name: sapinst
-#  shell: ps -ef | awk '/sapinst/&&!/awk/&&!/ansible/{print}'
+- name: SAP SWPM - Wait for sapinst process to exit, poll every 10 seconds
+  ansible.builtin.shell: ps -ef | awk '/sapinst/&&!/awk/&&!/ansible/{print}'
   register: pids_sapinst
-  until: "pids_sapinst.pids | length == 0"
-#  until: "pids_sapinst.stdout | length == 0"
+  until: "pids_sapinst.stdout | length == 0"
   retries: 1000
-  delay: 60
+  delay: 10
 
 - name: SAP SWPM - Verify if sapinst process finished successfully
   ansible.builtin.async_status:

--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -22,24 +22,9 @@
 
 ### Async method
 
-# Required for Ansible Module pids
-#- name: Install Python devel, Python pip and gcc to system Python
-#  ansible.builtin.package:
-#    name:
-#      - python3-devel
-#      - python3-pip
-#      - gcc
-#    state: present
-
-# Required for Ansible Module pids
-#- name: Install Python dependency psutil to system Python
-#  ansible.builtin.pip:
-#    name:
-#      - psutil
-
 - name: Set fact for the sapinst command line
   ansible.builtin.set_fact:
-    __sap_swpm_sapinst_command: "umask {{ sap_swpm_umask | default('022') }} ; ./sapinst {{ sap_swpm_swpm_command_inifile }}
+    __sap_swpm_sapinst_command: "umask {{ sap_swpm_umask | d('022') }} ; ./sapinst {{ sap_swpm_swpm_command_inifile }}
     {{ sap_swpm_swpm_command_product_id }}
     {{ sap_swpm_swpm_command_extra_args }}"
   tags: sap_swpm_sapinst_commandline
@@ -69,13 +54,13 @@
   async: 32400 # Seconds for maximum runtime, set to 9 hours
   poll: 0 # Seconds between polls, use 0 to run Ansible Tasks concurrently
 
-# Monitor sapinst process (i.e. ps aux | grep sapinst) and wait for exit
-- name: SAP SWPM - Wait for sapinst process to exit, poll every 10 seconds
-  ansible.builtin.shell: ps -ef | awk '/sapinst/&&!/awk/&&!/ansible/{print}'
+# Monitor sapinst process and wait for exit
+- name: SAP SWPM - Wait for sapinst process to exit, poll every 60 seconds
+  ansible.builtin.shell: ps -ef | awk '/sapinst/&&!/ awk /{print}'
   register: pids_sapinst
   until: "pids_sapinst.stdout | length == 0"
   retries: 1000
-  delay: 10
+  delay: 60
 
 - name: SAP SWPM - Verify if sapinst process finished successfully
   ansible.builtin.async_status:

--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -56,7 +56,7 @@
 
 # Monitor sapinst process and wait for exit
 - name: SAP SWPM - Wait for sapinst process to exit, poll every 60 seconds
-  ansible.builtin.shell: set -o pipefail && ps -ef | awk '/sapinst/&&!/ awk /{print}'
+  ansible.builtin.shell: set -o pipefail && ps -ef | awk '/\.\/sapinst /&&!/umask/&&!/ awk /{print}'
   register: pids_sapinst
   until: "pids_sapinst.stdout | length == 0"
   retries: 1000

--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -56,11 +56,12 @@
 
 # Monitor sapinst process and wait for exit
 - name: SAP SWPM - Wait for sapinst process to exit, poll every 60 seconds
-  ansible.builtin.shell: ps -ef | awk '/sapinst/&&!/ awk /{print}'
+  ansible.builtin.shell: set -o pipefail && ps -ef | awk '/sapinst/&&!/ awk /{print}'
   register: pids_sapinst
   until: "pids_sapinst.stdout | length == 0"
   retries: 1000
   delay: 60
+  changed_when: false
 
 - name: SAP SWPM - Verify if sapinst process finished successfully
   ansible.builtin.async_status:


### PR DESCRIPTION
We should better remove the `community.general.pids` module. Advantages:
- No dependency on `community.general` in the role sap_swpm, simplifying support for downstream versions
- No more Python related package installations at the beginning of the role
- Probably also solving https://github.com/sap-linuxlab/community.sap_install/issues/716.

Solves https://github.com/sap-linuxlab/community.sap_install/issues/719.