### PR TITLE
sap_hana_install: update README.md

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -247,7 +247,7 @@ You can find more complex playbooks in directory `playbooks` of the collection `
 
 #### Perform Initial Checks
 
-These checks are only performed if `sap_hana_install_force` is set to `true`. Its default value is `false`
+These checks are only performed if `sap_hana_install_force` is set to `false`. Its default value is `false`
 - If variable `sap_hana_install_check_sidadm_user` is undefined or set to `yes`: Check if user sidadm exists. If yes,
   abort the role.
 


### PR DESCRIPTION
Initial checks whether a system is already running or not will only be performed if "sap_hana_install_force" is set to false. If it is set to true if will not run and potentials overwrite the installation. Just a documentation error.