### PR TITLE
sap_ha_pacemaker_cluster: ASCS ERS Simple Mount

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -322,6 +322,20 @@ Inherits the value of `ha_cluster_hacluster_password`, when defined.<br>
 Parameter for the 'SAPHana' cluster resource.<br>
 Define if a former primary should be re-registered automatically as secondary.<br>
 
+### sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name
+
+- _Type:_ `string`
+- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_primary`
+
+Customize the cluster constraint name for VIP and SAPHana primary clone colocation.<br>
+
+### sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name
+
+- _Type:_ `string`
+- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_readonly`
+
+Customize the cluster constraint name for VIP and SAPHana secondary clone colocation.<br>
+
 ### sap_ha_pacemaker_cluster_hana_duplicate_primary_timeout
 
 - _Type:_ `int`
@@ -409,6 +423,27 @@ sap_ha_pacemaker_cluster_hana_hooks:
 The instance number of the SAP HANA database which this role will configure in the cluster.<br>
 Inherits the value of `sap_hana_instance_number`, when defined.<br>
 Mandatory for SAP HANA cluster setups.<br>
+
+### sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name
+
+- _Type:_ `string`
+- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_primary`
+
+Customize the cluster constraint name for VIP and SAPHana primary clone order.<br>
+
+### sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name
+
+- _Type:_ `string`
+- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_readonly`
+
+Customize the cluster constraint name for VIP and SAPHana secondary clone order.<br>
+
+### sap_ha_pacemaker_cluster_hana_order_topology_hana_name
+
+- _Type:_ `string`
+- _Default:_ `ord_saphana_saphanatop_<SID>_HDB<Instance Number>`
+
+Customize the cluster constraint name for SAPHana and Topology order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_prefer_site_takeover
 
@@ -551,6 +586,14 @@ Mandatory for NetWeaver AAS cluster configuration.<br>
 The standard NetWeaver ASCS/ERS cluster will be set up as ENSA2.<br>
 Set this parameter to 'true' to configure it as ENSA1.<br>
 
+### sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+
+- _Type:_ `bool`
+- _Default:_ `True`
+
+Enables preferred method for ASCS ERS ENSA2 clusters - Simple Mount<br>
+Set this parameter to 'true' to configure ENSA2 Simple Mount.<br>
+
 ### sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name
 
 - _Type:_ `string`
@@ -601,6 +644,7 @@ Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ens
 
 The name of the ASCS instance, typically the profile name.<br>
 Mandatory for the NetWeaver ASCS/ERS cluster setup<br>
+Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname>.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name
 
@@ -622,6 +666,13 @@ NetWeaver ASCS instance resource stickiness attribute.<br>
 
 The full path and name of the ASCS instance profile.<br>
 Mandatory for the NetWeaver ASCS/ERS cluster setup.<br>
+
+### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
+
+- _Type:_ `string`
+- _Default:_ `rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>`
+
+Name of the ASCS SAPStartSrv resource for simple mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name
 
@@ -650,6 +701,7 @@ NetWeaver ERS instance resource option "AUTOMATIC_RECOVER".<br>
 
 The name of the ERS instance, typically the profile name.<br>
 Mandatory for the NetWeaver ASCS/ERS cluster setup.<br>
+Recommended format <SID>_ERS<ERS-instance-number>_<ERS-hostname>.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name
 
@@ -664,6 +716,13 @@ Name of the ERS instance resource.<br>
 
 The full path and name of the ERS instance profile.<br>
 Mandatory for the NetWeaver ASCS/ERS cluster.<br>
+
+### sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name
+
+- _Type:_ `string`
+- _Default:_ `rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>`
+
+Name of the ERS SAPstartSrv resource for simple mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
 
@@ -680,6 +739,20 @@ SID of the NetWeaver instances.<br>
 Mandatory for NetWeaver cluster configuration.<br>
 Uses `sap_swpm_sid` if defined.<br>
 Mandatory for NetWeaver cluster setups.<br>
+
+### sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name
+
+- _Type:_ `string`
+- _Default:_ `col_ascs_separate_<SID>`
+
+Customize the cluster constraint name for ASCS and ERS separation colocation.<br>
+
+### sap_ha_pacemaker_cluster_nwas_order_ascs_first_name
+
+- _Type:_ `string`
+- _Default:_ `ord_ascs_first_<SID>`
+
+Customize the cluster constraint name for ASCS starting before ERS order.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name
 

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -135,6 +135,20 @@ sap_ha_pacemaker_cluster_hana_filesystem_resource_name: >-
 sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name: >-
   cln_SAPHanaFil_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
 
+# SAP HANA - Constraint names
+sap_ha_pacemaker_cluster_hana_order_topology_hana_name: >-
+  ord_saphana_saphanatop_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
+
+sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name: >-
+  col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
+sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name: >-
+  col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
+
+sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name: >-
+  ord_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
+sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name: >-
+  ord_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly
+
 # Multiple VIP parameters can be defined and will be combined.
 # See tasks/include_construct_vip_resources.yml
 #
@@ -171,6 +185,9 @@ sap_ha_pacemaker_cluster_hana_global_ini_path: "/usr/sap/{{
 # Default will be ENSA2. To configure HA resources for ENSA1,
 # set this parameter to 'true'.
 sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1: false
+
+# Enable ENSA2 simple mount configuration
+sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount: true
 
 # Enable/Disable sap_cluster_connector.
 # Ref.: https://access.redhat.com/solutions/3606101
@@ -239,12 +256,6 @@ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name: >-
 # Set this parameter to "true" to configure the 3 shared filesystems as part of the cluster.
 sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed: false
 
-# SAP NetWeaver resource group names as convenience parameters
-sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name: >-
-  grp_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
-sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name: >-
-  grp_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
-
 ################################################################################
 # ASCS resource defaults
 ################################################################################
@@ -262,7 +273,18 @@ sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name: >-
   rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
 sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name: >-
   rsc_SAPInstance_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
-# sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_clone_name: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}-clone"
+sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name: >-
+  rsc_SAPStartSrv_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
+
+sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name: >-
+  grp_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
+
+sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name: >-
+  col_ascs_separate_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}
+
+sap_ha_pacemaker_cluster_nwas_order_ascs_first_name: >-
+  ord_ascs_first_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}
+
 sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool: false
 sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness: 5000
 sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold: 1
@@ -281,12 +303,17 @@ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name: ''
 # Full path with instance profile name - mandatory to be user-defined
 sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string: ''
 
+# SAP NetWeaver ABAP ERS - Resource IDs (names) as convenience parameters.
 sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name: >-
-  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
+  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
 sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name: >-
-  rsc_SAPInstance_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
-# sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_clone_name: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}-clone"
+  rsc_SAPInstance_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
+sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name: >-
+  rsc_SAPStartSrv_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
 sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool: false
+
+sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name: >-
+  grp_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
 
 
 ################################################################################

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -142,7 +142,7 @@ sap_ha_pacemaker_cluster_hana_order_topology_hana_name: >-
 sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name: >-
   col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
 sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name: >-
-  col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
+  col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly
 
 sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name: >-
   ord_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -352,6 +352,11 @@ argument_specs:
         description:
           - Customize the cluster resource name of the SAP HANA Filesystem clone.
 
+      sap_ha_pacemaker_cluster_hana_order_topology_hana_name:
+        default: "ord_saphana_saphanatop_<SID>_HDB<Instance Number>"
+        description:
+          - Customize the cluster constraint name for SAPHana and Topology order.
+
       sap_ha_pacemaker_cluster_vip_hana_primary_ip_address:
         description:
           - The virtual IP of the primary HANA instance.
@@ -372,6 +377,26 @@ argument_specs:
         description:
           - Customize the name of the resource managing the Virtual IP of read-only access to the
             secondary HANA instance.
+
+      sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name:
+        default: "ord_saphana_vip_<SID>_HDB<Instance Number>_primary"
+        description:
+          - Customize the cluster constraint name for VIP and SAPHana primary clone order.
+
+      sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name:
+        default: "ord_saphana_vip_<SID>_HDB<Instance Number>_readonly"
+        description:
+          - Customize the cluster constraint name for VIP and SAPHana secondary clone order.
+
+      sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name:
+        default: "col_saphana_vip_<SID>_HDB<Instance Number>_primary"
+        description:
+          - Customize the cluster constraint name for VIP and SAPHana primary clone colocation.
+
+      sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name:
+        default: "col_saphana_vip_<SID>_HDB<Instance Number>_readonly"
+        description:
+          - Customize the cluster constraint name for VIP and SAPHana secondary clone colocation.
 
       sap_ha_pacemaker_cluster_hana_hooks:
         type: list
@@ -424,6 +449,13 @@ argument_specs:
       ##########################################################################
       # NetWeaver specific parameters
       ##########################################################################
+
+      sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount:
+        type: bool
+        default: true
+        description:
+          - Enables preferred method for ASCS ERS ENSA2 clusters - Simple Mount
+          - Set this parameter to 'true' to configure ENSA2 Simple Mount.
 
       sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1:
         type: bool
@@ -603,16 +635,6 @@ argument_specs:
           - Change this parameter to 'true' if the 3 shared filesystems `/usr/sap/trans`,
             `/usr/sap/<SID>/SYS` and '/sapmnt' shall be configured as cloned cluster resources.
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name:
-        default: grp_<SID>_ASCS<ASCS-instance-number>
-        description:
-          - Name of the NetWeaver ASCS resource group.
-
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name:
-        default: grp_<SID>_ERS<ERS-instance-number>
-        description:
-          - Name of the NetWeaver ERS resource group.
-
       ##########################################################################
       # NetWeaver ASCS specific parameters
       ##########################################################################
@@ -621,6 +643,7 @@ argument_specs:
         description:
           - The name of the ASCS instance, typically the profile name.
           - Mandatory for the NetWeaver ASCS/ERS cluster setup
+          - Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname>.
 
       sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string:
         description:
@@ -636,6 +659,26 @@ argument_specs:
         default: rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>
         description:
           - Name of the ASCS instance resource.
+
+      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name:
+        default: rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>
+        description:
+          - Name of the ASCS SAPStartSrv resource for simple mount.
+
+      sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name:
+        default: grp_<SID>_ASCS<ASCS-instance-number>
+        description:
+          - Name of the NetWeaver ASCS resource group.
+
+      sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name:
+        default: "col_ascs_separate_<SID>"
+        description:
+          - Customize the cluster constraint name for ASCS and ERS separation colocation.
+
+      sap_ha_pacemaker_cluster_nwas_order_ascs_first_name:
+        default: "ord_ascs_first_<SID>"
+        description:
+          - Customize the cluster constraint name for ASCS starting before ERS order.
 
       sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool:
         type: bool
@@ -677,6 +720,7 @@ argument_specs:
         description:
           - The name of the ERS instance, typically the profile name.
           - Mandatory for the NetWeaver ASCS/ERS cluster setup.
+          - Recommended format <SID>_ERS<ERS-instance-number>_<ERS-hostname>.
 
       sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string:
         description:
@@ -699,6 +743,15 @@ argument_specs:
         description:
           - Name of the ERS instance resource.
 
+      sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name:
+        default: rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>
+        description:
+          - Name of the ERS SAPstartSrv resource for simple mount.
+
+      sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name:
+        default: grp_<SID>_ERS<ERS-instance-number>
+        description:
+          - Name of the NetWeaver ERS resource group.
 
       ##########################################################################
       # PAS specific parameters

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -37,14 +37,15 @@
       changed_when: false
       run_once: true  # noqa: run_once[task]
 
-    - name: "SAP HA Install Pacemaker - SAPStartSrv crm resource cleanup"
-      ansible.builtin.command:
-        cmd: crm resource cleanup {{ item }}
-      loop:
-        - "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name }}"
-        - "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name }}"
-      when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
-      changed_when: true
+    # # Workaround situation when ASCS and ERS mounts are not present on both nodes.
+    # - name: "SAP HA Install Pacemaker - SAPStartSrv crm resource cleanup"
+    #   ansible.builtin.command:
+    #     cmd: crm resource cleanup {{ item }}
+    #   loop:
+    #     - "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name }}"
+    #     - "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name }}"
+    #   when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+    #   changed_when: true
 
     - name: "SAP HA Install Pacemaker - Fetch CIB configuration"
       ansible.builtin.command:
@@ -62,7 +63,7 @@
         mode: '0600'
       check_mode: false
 
-    # Removes monitor, start, stop operations from SAPStartSrv
+    # SAPStartSrv - Remove monitor, start, stop operations from SAPStartSrv
     # These operations are not supported and not recommended.
     # TODO: Limit deletion in future, when more supported is added in Resource Agent
     - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
@@ -71,8 +72,8 @@
       when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
       changed_when: true
 
-    # Remove default operations: promote, demote, start, stop
-    - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
+    # SAPInstance - Remove default operations: promote, demote, start, stop
+    - name: "SAP HA Install Pacemaker - Remove operations for SAPInstance"
       ansible.builtin.command:
         cmd: cibadmin -d --force --xpath "//primitive[@type='SAPInstance']//op[{{ item }}]"
       loop:

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -25,7 +25,7 @@
       check_mode: false
       changed_when: true
 
-    - name: "SAP HA Install Pacemaker - Verify that maintenace-mode is true"
+    - name: "SAP HA Install Pacemaker - Verify that maintenance-mode is true"
       ansible.builtin.command:
         cmd: crm status
       register: __sap_ha_pacemaker_cluster_crm_status_maint

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -1,0 +1,92 @@
+---
+# Recent crmsh changes have added default behavior, where all default metadata
+# op parameters are added and it cannot be controlled. Not adding them during
+# creation, will forcefully add them regardless.
+
+# Following steps are similar to crmsh code in ha_cluster role, but they are
+# too SAP specific, so they are added here instead of there.
+
+- name: Block to ensure that changes are executed only once
+  run_once: true  # noqa: run_once[task]
+  block:
+
+    - name: "SAP HA Install Pacemaker - Create file for CIB backup"
+      ansible.builtin.tempfile:
+        state: file
+        suffix: _sap_ha_pacemaker_cluster_cib_xml_backup
+      register: __sap_ha_pacemaker_cluster_cib_xml_backup
+
+    - name: "SAP HA Install Pacemaker - Put cluster in maintenance mode"
+      ansible.builtin.expect:
+        command: crm configure property maintenance-mode=true
+        responses:
+          ".*is-managed.*": "n"
+          ".*already.*": "n"
+      check_mode: false
+      changed_when: true
+
+    - name: "SAP HA Install Pacemaker - Verify that maintenace-mode is true"
+      ansible.builtin.command:
+        cmd: crm status
+      register: __sap_ha_pacemaker_cluster_crm_status_maint
+      retries: 10
+      delay: 5
+      until:
+        '"Resource management is DISABLED" in __sap_ha_pacemaker_cluster_crm_status_maint.stdout'
+      check_mode: false
+      changed_when: false
+      run_once: true  # noqa: run_once[task]
+
+    - name: "SAP HA Install Pacemaker - SAPStartSrv crm resource cleanup"
+      ansible.builtin.command:
+        cmd: crm resource cleanup {{ item }}
+      loop:
+        - "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name }}"
+        - "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name }}"
+      when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+      changed_when: true
+
+    - name: "SAP HA Install Pacemaker - Fetch CIB configuration"
+      ansible.builtin.command:
+        cmd: cibadmin --query
+      register: __sap_ha_pacemaker_cluster_cib_query
+      check_mode: false
+      changed_when: false
+
+    - name: "SAP HA Install Pacemaker - Save CIB configuration"
+      ansible.builtin.copy:
+        content: "{{ __sap_ha_pacemaker_cluster_cib_query.stdout }}"
+        dest: "{{ __sap_ha_pacemaker_cluster_cib_xml_backup.path }}"
+        owner: root
+        group: root
+        mode: '0600'
+      check_mode: false
+
+    # Removes monitor, start, stop operations from SAPStartSrv
+    # These operations are not supported and not recommended.
+    # TODO: Limit deletion in future, when more supported is added in Resource Agent
+    - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
+      ansible.builtin.command:
+        cmd: cibadmin -d --force --xpath "//primitive[@type='SAPStartSrv']//operations"
+      when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+      changed_when: true
+
+    # Remove default operations: promote, demote, start, stop
+    - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
+      ansible.builtin.command:
+        cmd: cibadmin -d --force --xpath "//primitive[@type='SAPInstance']//op[{{ item }}]"
+      loop:
+        - "@name='promote' and @interval='0s'"
+        - "@name='demote' and @interval='0s'"
+        - "@name='start' and @interval='0s'"
+        - "@name='stop' and @interval='0s'"
+      changed_when: true
+
+    - name: "SAP HA Install Pacemaker - Disable maintenance mode"
+      ansible.builtin.expect:
+        command: crm configure property maintenance-mode=false
+        responses:
+          ".*is-managed.*": "n"
+          ".*already.*": "n"
+      check_mode: false
+      changed_when: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -129,14 +129,13 @@
         loop_var: nwas_profile_item
         label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
 
-    # Sleep added to aleviate WaitforStarted finishing before resources are available.
+    # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ascs
       ansible.builtin.shell: |
-        sleep 30
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 15
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
 
@@ -145,7 +144,7 @@
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 15
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
 
@@ -170,13 +169,6 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function RestartService
       changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait after service restart"
-      when:
-        - __sap_ha_pacemaker_cluster_register_restart_ascs.changed
-          or __sap_ha_pacemaker_cluster_register_restart_ers.changed
-      ansible.builtin.command: sleep 10
-      changed_when: false
-
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ASCS"
       when:
@@ -185,6 +177,7 @@
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_config
       ansible.builtin.shell: |
+        sleep 10
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
 
@@ -197,6 +190,14 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines }}
 
 
     # Block to restart cluster resources if RestartService is not enough.
@@ -211,7 +212,6 @@
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
           ansible.builtin.shell: |
             {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ __rsc_ascs }} {{ __rsc_ers }}
-            sleep 30
           run_once: true
           vars:
             __rsc_ascs: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
@@ -227,7 +227,7 @@
           become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
           register: __sap_ha_pacemaker_cluster_register_where_ascs_restart
           ansible.builtin.shell: |
-            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 15
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
 
@@ -236,7 +236,7 @@
           become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
           register: __sap_ha_pacemaker_cluster_register_where_ers_restart
           ansible.builtin.shell: |
-            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 15
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
 
@@ -248,6 +248,7 @@
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha
       ansible.builtin.shell: |
+        sleep 30
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
@@ -265,19 +266,34 @@
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_where_ers.stdout"
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HA check results for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-      ansible.builtin.debug:
-        msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha.stdout }}
+      become: true
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HA check results for ERS"
+    # Only ASCS is required as both outputs are same.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ers_ha.stdout }}
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines }}
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha.stdout_lines }}
 
 
     # TODO: verification checks that the instances are running and HA Interface is enabled

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -212,7 +212,6 @@
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
           ansible.builtin.shell: |
             {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ __rsc_ascs }} {{ __rsc_ers }}
-          run_once: true
           vars:
             __rsc_ascs: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
               if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
@@ -266,6 +265,7 @@
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_where_ers.stdout"
 
+
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
@@ -275,12 +275,26 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
-      failed_when:
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
-           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout
+      # failed_when:
+      #   - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout
 
-    # Only ASCS is required as both outputs are same.
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+      become: true
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+      # failed_when:
+      #   - __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout
+
+
+    # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines is defined
@@ -288,6 +302,16 @@
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines }}
 
+    # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout_lines }}
+
+    # HACheckConfig shows same statues on both nodes, therefore only ASCS is shown
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -170,23 +170,23 @@
       changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_config
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
       ansible.builtin.shell: |
         sleep 10
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ERS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ers_ha_config
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
@@ -194,20 +194,42 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HACheckConfig
+      changed_when: false
+      failed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
 
 
     # Block to restart cluster resources if RestartService is not enough.
     # This is required for SUSE, where SAP needs full restart to load HAlib.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
       when:
-        - "(__sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
-           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout)
-          or (__sap_ha_pacemaker_cluster_register_ers_ha_config.stdout is defined
-           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout)"
+        - "(__sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout)
+          or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout)
+          or (__sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout is defined
+           and 'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout)"
       block:
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
           ansible.builtin.shell: |
@@ -219,6 +241,8 @@
             __rsc_ers: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name
               if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
               else sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}"
+          when:
+            - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
           changed_when: true
 
         - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
@@ -240,85 +264,85 @@
           failed_when: false
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Run HA check for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
       ansible.builtin.shell: |
         sleep 30
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
-        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha.stdout"
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout"
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Run HA check for ERS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ers_ha
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
-        - "'ERROR' in __sap_ha_pacemaker_cluster_register_where_ers.stdout"
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_config
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       # failed_when:
-      #   - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
-      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout
+      #   - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ERS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ers_ha_config
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       # failed_when:
-      #   - __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout is defined
-      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout
+      #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout
 
 
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
 
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
 
     # HACheckConfig shows same statues on both nodes, therefore only ASCS is shown
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
 
 
     # TODO: verification checks that the instances are running and HA Interface is enabled

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -275,6 +275,7 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      failed_when:
         - __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
            and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -108,7 +108,8 @@
     - sap_ha_pacemaker_cluster_enable_cluster_connector
   block:
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm user to 'haclient' group"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm
+       user to 'haclient' group"  # noqa name[template]
       ansible.builtin.user:
         name: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
         groups: haclient
@@ -128,11 +129,13 @@
         loop_var: nwas_profile_item
         label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
 
+    # Sleep added to aleviate WaitforStarted finishing before resources are available.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
       become: true
       become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ascs
       ansible.builtin.shell: |
+        sleep 30
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 15
       changed_when: false
       failed_when: false
@@ -145,6 +148,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 15
       changed_when: false
       failed_when: false
+
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
       when:
@@ -166,12 +170,76 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function RestartService
       changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Pause after service restart"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait after service restart"
       when:
         - __sap_ha_pacemaker_cluster_register_restart_ascs.changed
           or __sap_ha_pacemaker_cluster_register_restart_ers.changed
-      ansible.builtin.pause:
-        seconds: 10
+      ansible.builtin.command: sleep 10
+      changed_when: false
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HA config for ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+      become: true
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+
+
+    # Block to restart cluster resources if RestartService is not enough.
+    # This is required for SUSE, where SAP needs full restart to load HAlib.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
+      when:
+        - "(__sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_config.stdout)
+          or (__sap_ha_pacemaker_cluster_register_ers_ha_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_config.stdout)"
+      block:
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
+          ansible.builtin.shell: |
+            {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ __rsc_ascs }} {{ __rsc_ers }}
+            sleep 30
+          run_once: true
+          vars:
+            __rsc_ascs: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
+              if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+              else sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}"
+            __rsc_ers: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name
+              if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+              else sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}"
+          changed_when: true
+
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
+          become: true
+          become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+          register: __sap_ha_pacemaker_cluster_register_where_ascs_restart
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 15
+          changed_when: false
+          failed_when: false
+
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
+          become: true
+          become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+          register: __sap_ha_pacemaker_cluster_register_where_ers_restart
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 15
+          changed_when: false
+          failed_when: false
+
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Run HA check for ASCS"
       when:
@@ -182,6 +250,8 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HACheckConfig
       changed_when: false
+      failed_when:
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha.stdout"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Run HA check for ERS"
       when:
@@ -192,6 +262,8 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HACheckConfig
       changed_when: false
+      failed_when:
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_where_ers.stdout"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HA check results for ASCS"
       when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup.yml
@@ -168,6 +168,7 @@
       "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_hana_topology] }}"
   vars:
     __constraint_order_hana_topology:
+      id: "{{ sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
       resource_first:
         id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
         action: start

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup_angi.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup_angi.yml
@@ -194,6 +194,7 @@
       "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_hana_topology] }}"
   vars:
     __constraint_order_hana_topology:
+      id: "{{ sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
       resource_first:
         id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
         action: start

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
@@ -36,7 +36,8 @@
         value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
         value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool | string }}"
-
+      - name: IS_ERS
+        value: true
 
 - name: "SAP HA Prepare Pacemaker - Define ASCS/ERS instance attributes (ENSA1)"
   when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
@@ -60,7 +61,8 @@
         value: true
 
 
-### ASCS/ERS instance filesystems
+### Resources
+# ASCS/ERS instance filesystems
 - name: "SAP HA Prepare Pacemaker - Add filesystem resources for ASCS/ERS to resource definition"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_filesystem] }}"
@@ -238,20 +240,11 @@
   when:
     - __resource_sapinstance_ers.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
-
-#################################################
-# Group resources that belong together
-# ###############################################
-
-# ASCS group consists of resources for
+### Groups
+# ASCS group consists of resources in this order:
 # - ASCS filesystem
 # - ASCS instance
 # - ASCS VIP
-# The order of the resources in the group define the order in which they are
-# started - resources are stopped in reverse order.
-#
-# Only resources that were defined as resources to be configured will be
-# added to the group.
 
 - name: "SAP HA Prepare Pacemaker - Add resource group for ASCS resources"
   ansible.builtin.set_fact:
@@ -280,15 +273,10 @@
     - __ascs_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
 
 
-# ERS group consists of resources for
+# ERS group consists of resources in this order:
 # - ERS filesystem
 # - ERS instance
 # - ERS VIP
-# The order of the resources in the group define the order in which they are
-# started - resources are stopped in reverse order.
-#
-# Only resources that were defined as resources to be configured will be
-# added to the group.
 
 - name: "SAP HA Prepare Pacemaker - Add resource group for ERS resources"
   ansible.builtin.set_fact:
@@ -319,24 +307,15 @@
     - __sap_ha_pacemaker_cluster_resource_groups is defined
     - __sap_ha_pacemaker_cluster_resource_groups | length > 0
 
-#################################################
-# Constraints
-#################################################
 
-# Constraint parameters are pre-defined from potentially inherited ha_cluster LSR definitions.
-# Constraint definitions are combined into these parameters.
-# See tasks/ascertain_ha_cluster_in_inventory.yml:
-#
-# __sap_ha_pacemaker_cluster_constraints_colocation: "{{ ha_cluster_constraints_colocation }}"
-# __sap_ha_pacemaker_cluster_constraints_location: "{{ ha_cluster_constraints_location }}"
-# __sap_ha_pacemaker_cluster_constraints_order: "{{ ha_cluster_constraints_order }}"
-
+### Constraints
 # ERS and ASCS resource groups should try to avoid running on the same node
 - name: "SAP HA Prepare Pacemaker - Add colocation constraint: ERS avoids to run on the ASCS node"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
     __constraint_colo_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
       resource_leader:
         id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
         role: started
@@ -354,6 +333,7 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
   vars:
     __constraint_order_ascs_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
       resource_first:
         id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
         role: started

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
@@ -1,0 +1,215 @@
+---
+# Variables containing variables must be constructed with values
+# to be fed into the included ha_cluster role
+
+# TODO: add conditionals to verify that the same resource agent is not already
+#       defined in user input variables. Conflicting user input should take precedence.
+#
+# ASCS ERS simple mount cluster is ENSA2.
+
+### Resources
+# ASCS SAPStartSrv resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPStartSrv for Central Service (ABAP ASCS)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
+  vars:
+    __resource_sapstartsrv:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name }}"
+      agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
+      instance_attrs:
+        - attrs:
+            - name: InstanceName
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name }}"
+  when:
+    - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
+
+# ERS SAPStartSrv resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPStartSrv for Central Service (ABAP ERS)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
+  vars:
+    __resource_sapstartsrv:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name }}"
+      agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
+      instance_attrs:
+        - attrs:
+            - name: InstanceName
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name }}"
+  when:
+    - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
+
+
+# ASCS instance resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Central Service (ABAP ASCS)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
+  vars:
+    __resource_sapinstance:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}"
+      agent: "ocf:heartbeat:SAPInstance"
+      instance_attrs:
+        - attrs:
+            - name: InstanceName
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name }}"
+            - name: START_PROFILE
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string }}"
+            - name: AUTOMATIC_RECOVER
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | string }}"
+            - name: MINIMAL_PROBE
+              value: true
+      meta_attrs:
+        - attrs:
+            - name: resource-stickiness
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness }}"
+      operations:
+        # TODO: Add values for start and stop when they are published.
+        - action: monitor
+          attrs:
+            - name: interval
+              value: 11
+            - name: on-fail
+              value: restart
+            - name: timeout
+              value: 60
+  when:
+    - __resource_sapinstance.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
+
+
+# ERS instance resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Enqueue Replication Service (ABAP ERS)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
+  vars:
+    __resource_sapinstance_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}"
+      agent: "ocf:heartbeat:SAPInstance"
+      instance_attrs:
+        - attrs:
+            - name: InstanceName
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name }}"
+            - name: START_PROFILE
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string }}"
+            - name: AUTOMATIC_RECOVER
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool | string }}"
+            - name: IS_ERS
+              value: true
+            - name: MINIMAL_PROBE
+              value: true
+      operations:
+        # TODO: Add values for start and stop when they are published.
+        - action: monitor
+          attrs:
+            - name: interval
+              value: 11
+            - name: on-fail
+              value: restart
+            - name: timeout
+              value: 60
+  when:
+    - __resource_sapinstance_ers.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
+
+
+### Groups
+# ASCS group consists of resources in this order:
+# - ASCS VIP
+# - ASCS SAPStartSrv
+# - ASCS SAPInstance
+- name: "SAP HA Prepare Pacemaker - Add resource group for ASCS resources"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ascs_group] }}"
+  vars:
+    __ascs_group:
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+      resource_ids: |
+        {% set resource_ids_list = [] %}
+        {%- for resource in
+          sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name,
+          sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name,
+          sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name %}
+          {%- if resource | length > 0
+            and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
+            {%- set ids = resource_ids_list.append(resource) %}
+          {%- endif %}
+        {%- endfor %}
+        {{ resource_ids_list }}
+      meta_attrs:
+        - attrs:
+            - name: resource-stickiness
+              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness }}"
+  when:
+    - __ascs_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
+
+
+# ERS group consists of resources in this order:
+# - ERS VIP
+# - ERS SAPStartSrv
+# - ERS SAPInstance
+- name: "SAP HA Prepare Pacemaker - Add resource group for ERS resources"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
+  vars:
+    __ers_group:
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+      resource_ids: |
+        {% set resource_ids_list = [] %}
+        {%- for resource in
+          sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name,
+          sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name,
+          sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name %}
+          {%- if resource | length > 0
+            and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
+            {%- set ids = resource_ids_list.append(resource) %}
+          {%- endif %}
+        {%- endfor %}
+        {{ resource_ids_list }}
+  when:
+    - __ers_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
+
+- name: "SAP HA Prepare Pacemaker - Display VIP resource group definition if any were built"
+  ansible.builtin.debug:
+    var: __sap_ha_pacemaker_cluster_resource_groups
+  when:
+    - __sap_ha_pacemaker_cluster_resource_groups is defined
+    - __sap_ha_pacemaker_cluster_resource_groups | length > 0
+
+
+### Constraints
+# ERS and ASCS resource groups should try to avoid running on the same node
+- name: "SAP HA Prepare Pacemaker - Add colocation constraint: ERS avoids to run on the ASCS node"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
+  vars:
+    __constraint_colo_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
+      resource_leader:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+        role: started
+      resource_follower:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+      options:
+        - name: score
+          value: -5000
+  when:
+    - __constraint_colo_ers.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
+
+# Optional: ASCS should be started before ERS
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start ASCS group, then ERS group"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
+  vars:
+    __constraint_order_ascs_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
+      resource_first:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+        role: started
+      resource_then:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+      options:
+        - name: symmetrical
+          value: "false"
+        - name: kind
+          value: Optional
+  when:
+    - __constraint_order_ascs_ers.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
@@ -6,6 +6,7 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_vip] }}"
   vars:
     __constraint_order_vip:
+      id: "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name }}"
       resource_first:
         id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: promote
@@ -44,6 +45,7 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_vip] }}"
   vars:
     __constraint_order_vip:
+      id: "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name }}"
       resource_first:
         id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: start
@@ -83,6 +85,7 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_vip] }}"
   vars:
     __constraint_colo_vip:
+      id: "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name }}"
       resource_leader:
         # SAPHana is replaced by SAP HANA Controller for SAPHanaSR-angi
         id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name if __sap_ha_pacemaker_cluster_saphanasr_angi_available
@@ -142,6 +145,7 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_vip] }}"
   vars:
     __constraint_colo_vip:
+      id: "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name }}"
       resource_leader:
         # SAPHana is replaced by SAP HANA Controller for SAPHanaSR-angi
         id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name if __sap_ha_pacemaker_cluster_saphanasr_angi_available

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -83,6 +83,20 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_abap_ascs' in nwas_build_item"
+    - not sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+
+- name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ABAP ASCS/ERS
+    Simple Mount # noqa name[template]
+  ansible.builtin.include_tasks:
+    file: construct_vars_nwas_abap_ascs_ers_simple_mount.yml
+  loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
+  loop_control:
+    loop_var: nwas_build_item
+  when:
+    - "'nwas_abap_ascs' in nwas_build_item"
+    - sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+    # TODO: Remove rule when SAPStartSrv resource agents are available on Red Hat
+    - ansible_os_family == 'Suse'
 
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ABAP PAS/AAS"
   ansible.builtin.include_tasks:

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -266,6 +266,15 @@
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
 
+    # Post steps for ACS ERS crmsh cluster to remove unsupported operations
+    - name: "SAP HA Install Pacemaker - Include ASCS ERS Post Steps"
+      ansible.builtin.include_tasks:
+        file: "{{ ansible_facts['os_family'] }}/post_steps_nwas_abap_ascs_ers.yml"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+        - ansible_os_family == 'Suse'
+      run_once: true
+
 ### END OF BLOCK: prerequisite changes and cluster setup
 
 # Save all the constructed cluster parameters into a vars file.

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -257,7 +257,16 @@
         - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
       run_once: true
 
-    - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS post installation"
+    # Post steps for ACS ERS crmsh cluster to remove unsupported operations
+    - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS post steps OS specific"
+      ansible.builtin.include_tasks:
+        file: "{{ ansible_facts['os_family'] }}/post_steps_nwas_abap_ascs_ers.yml"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+        - ansible_os_family == 'Suse'
+      run_once: true
+
+    - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS post steps"
       ansible.builtin.include_tasks:
         file: configure_nwas_ascs_ers_postinstallation.yml
         apply:
@@ -266,14 +275,6 @@
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
 
-    # Post steps for ACS ERS crmsh cluster to remove unsupported operations
-    - name: "SAP HA Install Pacemaker - Include ASCS ERS Post Steps"
-      ansible.builtin.include_tasks:
-        file: "{{ ansible_facts['os_family'] }}/post_steps_nwas_abap_ascs_ers.yml"
-      when:
-        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
-        - ansible_os_family == 'Suse'
-      run_once: true
 
 ### END OF BLOCK: prerequisite changes and cluster setup
 

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -65,6 +65,8 @@ __sap_ha_pacemaker_cluster_resource_agents:
 # TODO: Uncomment when SAPHanaSR-angi is available on Red Hat
 #  saphanacontroller: "ocf:heartbeat:SAPHanaController"
 #  saphanafilesystem: "ocf:heartbeat:SAPHanaFilesystem"
+# TODO: Uncomment when SAPStartSrv is available on Red Hat
+#  sapstartsrv: "ocf:heartbeat:SAPStartSrv"
 
 # TODO: Uncomment when SAPHanaSR-angi is available on Red Hat
 __sap_ha_pacemaker_cluster_saphanasr_angi_available: false
@@ -89,3 +91,7 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 # TODO: Remove when additional hooks are specified above.
 __sap_ha_pacemaker_cluster_hana_hook_tkover: false
 __sap_ha_pacemaker_cluster_hana_hook_chksrv: false
+
+# Enable ASCS/ERS Simple Mount as default
+# TODO: Enable when SAPStartSrv resource agents are available on Red Hat
+sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount: false

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -19,6 +19,7 @@ __sap_ha_pacemaker_cluster_command:
   resource_start: "pcs resource enable"
   resource_defaults_show: "pcs resource defaults config"
   resource_defaults_update: "pcs resource defaults update"
+  resource_restart: "pcs resource restart"
 
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -13,6 +13,7 @@ __sap_ha_pacemaker_cluster_command:
   resource_start: "crm resource start"
   resource_defaults_show: "crm configure show type:rsc_defaults"
   resource_defaults_update: "crm configure rsc_defaults"
+  resource_restart: "crm resource restart"
 
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -51,8 +51,7 @@ __sap_ha_pacemaker_cluster_resource_agents:
   saphana: "ocf:suse:SAPHana"
   saphanacontroller: "ocf:suse:SAPHanaController"
   saphanafilesystem: "ocf:suse:SAPHanaFilesystem"
-  # "ocf:heartbeat:Filesystem"
-  # "ocf:heartbeat:SAPInstance"
+  sapstartsrv: "ocf:suse:SAPStartSrv"
 
 # Boolean variable reflecting availability of SAPHanaSR-angi availability.
 __sap_ha_pacemaker_cluster_saphanasr_angi_available: false
@@ -113,3 +112,6 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 # Overwrite resource clone name for SAP HANA
 sap_ha_pacemaker_cluster_hana_resource_clone_name:
   "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
+
+# Enable ASCS/ERS Simple Mount as default
+sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount: true


### PR DESCRIPTION
@ja9fuchs Lets review it together next week when you are available.
  
This PR adds new feature: Simple Mount scenario for ASCS ERS cluster.

Changes:

1. Simple Mount added as separate task, enabled by as default ASCS cluster for SUSE, disabled for Red Hat and marked as TODO when SAPStartSrv agent is available.  Controlled by variable `sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount`
2. Added more variables for cluster resources and updated naming to align with previous changes: variables for order, colocation and groups.
3. Added IS_ERS parameter, which is valid for all 3 scenarios.
4. New entry for SAPStartSrv in resource agent dictionary `__sap_ha_pacemaker_cluster_resource_agents`


Requirement: Simple mount uses shared NFS for both ASCS and ERS data across both nodes, sap_storage_setup role has to be executed for both NFS entries on both servers by changing input in AP4S dictionary:
```yaml
      sap_storage_setup_host_type:
        - nwas_abap_ascs
        - nwas_abap_ers
```
sap_storage_setup vars in AP4S need to be adjusted as well to use actual variables from var files, instead of lookup based on hostname:
```yaml
        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_system_nwas_abap_ascs_instance_nr }}"
        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ sap_system_nwas_abap_ers_instance_nr }}"
```


Example of cluster with Simple Mount
```
Node List:
  * Online: [ ae1ascs ae1ers ]

Full List of Resources:
  * rsc_fence_aws       (stonith:external/ec2):  Started ae1ascs
  * Resource Group: grp_AE1_ASCS00:
    * rsc_vip_AE1_ASCS00        (ocf::heartbeat:aws-vpc-move-ip):        Started ae1ascs
    * rsc_SAPStartSrv_AE1_ASCS00        (ocf::suse:SAPStartSrv):         Started ae1ascs
    * rsc_SAPInstance_AE1_ASCS00        (ocf::heartbeat:SAPInstance):    Started ae1ascs
  * Resource Group: grp_AE1_ERS10:
    * rsc_vip_AE1_ERS10 (ocf::heartbeat:aws-vpc-move-ip):        Started ae1ers
    * rsc_SAPStartSrv_AE1_ERS10 (ocf::suse:SAPStartSrv):         Started ae1ers
    * rsc_SAPInstance_AE1_ERS10 (ocf::heartbeat:SAPInstance):    Started ae1ers
```
