### PR TITLE
sap_hana_install: Add support for fapolicyd

### DIFF
--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -33,7 +33,7 @@ sap_hana_install_keep_copied_sarfiles: no
 sap_hana_install_use_fapolicyd: no
 
 # When using fapolicyd, the file name in /etc/fapolicyd/trust.d/ must be set:
-sap_hana_install_fapolicyd_trust_filename: '_hana'
+sap_hana_install_fapolicyd_trust_filename: 'hana'
 
 # File name of SAPCAR*EXE in the software directory. If the variable is not set and there is more than one SAPCAR executable
 # in the software directory, the latest SAPCAR executable for the CPU architecture will be selected automatically.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -29,6 +29,12 @@ sap_hana_install_copy_sarfiles: no
 # removed after extraction.
 sap_hana_install_keep_copied_sarfiles: no
 
+# For supporting fapolicyd, set the following variable to `yes`:
+sap_hana_install_use_fapolicyd: no
+
+# When using fapolicyd, the file name in /etc/fapolicyd/trust.d/ must be set:
+sap_hana_install_fapolicyd_trust_filename: '_hana'
+
 # File name of SAPCAR*EXE in the software directory. If the variable is not set and there is more than one SAPCAR executable
 # in the software directory, the latest SAPCAR executable for the CPU architecture will be selected automatically.
 #sap_hana_install_sapcar_filename: SAPCAR_1115-70006178.EXE
@@ -114,7 +120,8 @@ sap_hana_install_components: 'all'
 # Instance details
 sap_hana_install_sid:
 sap_hana_install_number:
-sap_hana_install_install_path: '/hana/shared'
+sap_hana_install_root_path: '/hana'
+sap_hana_install_install_path: '{{ sap_hana_install_root_path }}/shared'
 
 # Adjust these accordingly for your installation type
 sap_hana_install_system_usage: 'custom'

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -92,7 +92,7 @@ sap_hana_install_local_configfile_directory: '/tmp'
 sap_hana_install_check_installation: false
 
 # Only if sap_hana_install_check_installation (above) is set to 'true', you can select which command to use by setting the
-# following variable to `false` or `false`.
+# following variable to `true` or `false`.
 # true: use the command 'hdbcheck', with parameters `--remote_execution=ssh` and `--scope=system`
 # false: use the command `hdblcm --action=check_installation`
 sap_hana_install_use_hdbcheck: true

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -29,11 +29,12 @@ sap_hana_install_copy_sarfiles: false
 # removed after extraction.
 sap_hana_install_keep_copied_sarfiles: false
 
-# For supporting fapolicyd, set the following variable to `false`:
+# For installing SAP HANA with fapolicyd support, set the following variable to `true`:
 sap_hana_install_use_fapolicyd: false
 
-# When using fapolicyd, the file name in /etc/fapolicyd/trust.d/ must be set:
-sap_hana_install_fapolicyd_trust_filename: 'hana'
+# When using fapolicyd, modify the following variable to change or add the directories which contain SAP HANA executables:
+sap_hana_install_directories_with_executables:
+  - {{ sap_hana_install_root_path }}
 
 # File name of SAPCAR*EXE in the software directory. If the variable is not set and there is more than one SAPCAR executable
 # in the software directory, the latest SAPCAR executable for the CPU architecture will be selected automatically.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -20,17 +20,17 @@ sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_direc
 # set the value to true. By default, this directory will not be removed
 sap_hana_install_cleanup_extract_directory: false
 
-# Set this variable to `yes` if you want to copy the SAR files from `sap_hana_install_software_directory`
+# Set this variable to `false` if you want to copy the SAR files from `sap_hana_install_software_directory`
 # to `sap_hana_install_software_extract_directory/sarfiles` before extracting.
 # This might be useful if the SAR files are on a slow fileshare.
-sap_hana_install_copy_sarfiles: no
+sap_hana_install_copy_sarfiles: false
 
-# Set the following variable to `yes` if you want to keep the copied SAR files. By default, the SAR files will be
+# Set the following variable to `false` if you want to keep the copied SAR files. By default, the SAR files will be
 # removed after extraction.
-sap_hana_install_keep_copied_sarfiles: no
+sap_hana_install_keep_copied_sarfiles: false
 
-# For supporting fapolicyd, set the following variable to `yes`:
-sap_hana_install_use_fapolicyd: no
+# For supporting fapolicyd, set the following variable to `false`:
+sap_hana_install_use_fapolicyd: false
 
 # When using fapolicyd, the file name in /etc/fapolicyd/trust.d/ must be set:
 sap_hana_install_fapolicyd_trust_filename: 'hana'
@@ -45,9 +45,9 @@ sap_hana_install_fapolicyd_trust_filename: 'hana'
 #  - SAPHOSTAGENT54_54-80004822.SAR
 #  - IMDB_SERVER20_060_0-80002031.SAR
 
-# Set the following variable to `yes` to let the role abort if checksum verification fails for any SAPCAR or SAR file
+# Set the following variable to `false` to let the role abort if checksum verification fails for any SAPCAR or SAR file
 # called or used by the role.
-sap_hana_install_verify_checksums: no
+sap_hana_install_verify_checksums: false
 
 # Checksum algorithm for checksum verification. Default is sha256, for which a checksum is available in the SAP software
 # download pages.
@@ -56,9 +56,9 @@ sap_hana_install_checksum_algorithm: sha256
 # In case a global checksum file is present, use the following variable to specify the full path to this file:
 #sap_hana_install_global_checksum_file: "{{ sap_hana_install_software_directory }}/SHA256"
 
-# Set the following variable to `yes` to let hdbclm verify SAR file signatures. This corresponds to the hdblcm command line
+# Set the following variable to `false` to let hdbclm verify SAR file signatures. This corresponds to the hdblcm command line
 # argument `--verify_signature`.
-sap_hana_install_verify_signature: no
+sap_hana_install_verify_signature: false
 
 # hdblcm configfile related variables:
 # Directory where to store the hdblcm configfile template and the Jinja2 template:
@@ -75,36 +75,36 @@ sap_hana_install_configfile_template_prefix: "hdblcm_configfile_template"
 # Directory where to download the Jinja2 template:
 sap_hana_install_local_configfile_directory: '/tmp'
 
-# If you would like to perform an installation check after the installation, set the following variable to 'yes'.
+# If you would like to perform an installation check after the installation, set the following variable to 'false'.
 # Note: This only works if there is no static configfile available in sap_hana_install_configfile_directory.
-sap_hana_install_check_installation: no
+sap_hana_install_check_installation: false
 
-# Only if sap_hana_install_check_installation (above) is set to 'yes', you can select which command to use by setting the
-# following variable to `yes` or `no`.
-# yes: use the command 'hdbcheck', with parameters `--remote_execution=ssh` and `--scope=system`
+# Only if sap_hana_install_check_installation (above) is set to 'false', you can select which command to use by setting the
+# following variable to `false` or `false`.
+# false: use the command 'hdbcheck', with parameters `--remote_execution=ssh` and `--scope=system`
 # no: use the command `hdblcm --action=check_installation`
-sap_hana_install_use_hdbcheck: yes
+sap_hana_install_use_hdbcheck: true
 
-# If the following variable is set to yes, the HANA installation check will be skipped
-sap_hana_install_force: no
+# If the following variable is set to false, the HANA installation check will be skipped
+sap_hana_install_force: false
 
-# If the following variable is set to `no`, the role will attempt to install SAP HANA even if there is already a sidadm user.
-# Default is `yes`.
-sap_hana_install_check_sidadm_user: yes
+# If the following variable is set to `false`, the role will attempt to install SAP HANA even if there is already a sidadm user.
+# Default is `false`.
+sap_hana_install_check_sidadm_user: true
 
-# If the following variable is undefined or set to `yes`, the role will perform a fresh SAP HANA installation.
-# If set to `no`, additional hosts as specified by variable sap_hana_install_addhosts will be added to
+# If the following variable is undefined or set to `false`, the role will perform a fresh SAP HANA installation.
+# If set to `false`, additional hosts as specified by variable sap_hana_install_addhosts will be added to
 # an existing HANA system.
-sap_hana_install_new_system: yes
+sap_hana_install_new_system: true
 
 # The first tenant database is using a port range not within the range of the ports of additional tenant databases.
-# In case this is not desired, you can set the following parameter to `yes` to recreate the initial tenant database.
-sap_hana_install_recreate_tenant_database: no
+# In case this is not desired, you can set the following parameter to `false` to recreate the initial tenant database.
+sap_hana_install_recreate_tenant_database: false
 
 # For compatibility of SAP HANA with SELinux in enforcing mode, the role will recursively relabel directories and files
 # in `/hana` before the installation starts and in `/usr/sap` after the installation has finished.
-# If relabeling not desired, set the following variable to `no`.
-sap_hana_install_modify_selinux_labels: yes
+# If relabeling not desired, set the following variable to `false`.
+sap_hana_install_modify_selinux_labels: true
 
 ################
 # Parameters for hdblcm:
@@ -147,7 +147,7 @@ sap_hana_install_use_master_password: 'y'
 #sap_hana_install_xs_org_password:
 
 # Optional steps
-sap_hana_install_update_firewall: no
+sap_hana_install_update_firewall: false
 
 # List of firewall ports for SAP HANA. Note: The structure of the variable is compatible
 # with the variable `firewall` of Linux System Role `firewall`.
@@ -173,14 +173,14 @@ sap_hana_install_firewall:
       state: 'enabled' }
 
 # The following variable is no longer used. Setting /etc/hosts entries is done in role sap_general_preconfigure.
-#sap_hana_install_update_etchosts: yes
+#sap_hana_install_update_etchosts: true
 
 # Post install parameters
 sap_hana_install_hdbuserstore_key: 'HDB_SYSTEMDB'
 sap_hana_install_nw_input_location: '/tmp'
 
 # License
-sap_hana_install_apply_license: no
+sap_hana_install_apply_license: false
 #sap_hana_install_license_path:
 #sap_hana_install_license_file_name:
 

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -39,7 +39,7 @@ sap_hana_install_fapolicyd_integrity: 'sha256'
 
 # When using fapolicyd, modify the following variable to change or add the directories which contain SAP HANA executables:
 sap_hana_install_fapolicyd_trusted_directories:
-  - "{{ sap_hana_install_root_path }}/shared"
+  - "{{ sap_hana_install_root_path }}"
   - /usr/sap
 
 # File name of SAPCAR*EXE in the software directory. If the variable is not set and there is more than one SAPCAR executable

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -101,7 +101,6 @@ sap_hana_install_use_hdbcheck: true
 sap_hana_install_force: false
 
 # If the following variable is set to `false`, the role will attempt to install SAP HANA even if there is already a sidadm user.
-# Default is `false`.
 sap_hana_install_check_sidadm_user: true
 
 # If the following variable is undefined or set to `true`, the role will perform a fresh SAP HANA installation.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -131,8 +131,8 @@ sap_hana_install_components: 'all'
 # Instance details
 sap_hana_install_sid:
 sap_hana_install_number:
-sap_hana_install_root_path: '/hana'
-sap_hana_install_install_path: '{{ sap_hana_install_root_path }}/shared'
+sap_hana_install_root_path: "{{ '/' + sap_hana_install_install_path.split('/')[1] if sap_hana_install_install_path is defined else '/hana' }}"
+sap_hana_install_shared_path: "{{ sap_hana_install_install_path | d(sap_hana_install_root_path + '/shared') }}"
 
 # Adjust these accordingly for your installation type
 sap_hana_install_system_usage: 'custom'

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -32,9 +32,15 @@ sap_hana_install_keep_copied_sarfiles: false
 # For installing SAP HANA with fapolicyd support, set the following variable to `true`:
 sap_hana_install_use_fapolicyd: false
 
+# When using fapolicyd, you can set the following variable to one of `none`, `size`, `sha256`, or `ima`. Note that before setting
+# to `ima`, it is essential to prepare the system accordingly (e.g. boot with a different kernel parameter). See the
+# RHEL 9 Managing, monitoring, and updating the kernel guide for more information on this topic.
+sap_hana_install_fapolicyd_integrity: 'sha256'
+
 # When using fapolicyd, modify the following variable to change or add the directories which contain SAP HANA executables:
-sap_hana_install_directories_with_executables:
-  - {{ sap_hana_install_root_path }}
+sap_hana_install_fapolicyd_trusted_directories:
+  - "{{ sap_hana_install_root_path }}/shared"
+  - /usr/sap
 
 # File name of SAPCAR*EXE in the software directory. If the variable is not set and there is more than one SAPCAR executable
 # in the software directory, the latest SAPCAR executable for the CPU architecture will be selected automatically.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -37,10 +37,15 @@ sap_hana_install_use_fapolicyd: false
 # RHEL 9 Managing, monitoring, and updating the kernel guide for more information on this topic.
 sap_hana_install_fapolicyd_integrity: 'sha256'
 
+# When using fapolicyd, the following variable is used to define the fapolicyd rule file in which the rules for
+# protecting shell scripts are stored. The rule file will be created in the directory '/etc/fapolicyd/rules.d'.
+# Note: The mandatory file ending '.rules' will be added in the corresponding task of this role.
+sap_hana_install_fapolicyd_rule_file: '71-sap-shellscripts'
+
 # When using fapolicyd, modify the following variable to change or add the directories which contain SAP HANA executables:
 sap_hana_install_fapolicyd_trusted_directories:
   - "{{ sap_hana_install_root_path }}"
-  - /usr/sap
+  - '/usr/sap'
 
 # File name of SAPCAR*EXE in the software directory. If the variable is not set and there is more than one SAPCAR executable
 # in the software directory, the latest SAPCAR executable for the CPU architecture will be selected automatically.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -20,12 +20,12 @@ sap_hana_install_software_extract_directory: "{{ sap_hana_install_software_direc
 # set the value to true. By default, this directory will not be removed
 sap_hana_install_cleanup_extract_directory: false
 
-# Set this variable to `false` if you want to copy the SAR files from `sap_hana_install_software_directory`
+# Set this variable to `true` if you want to copy the SAR files from `sap_hana_install_software_directory`
 # to `sap_hana_install_software_extract_directory/sarfiles` before extracting.
 # This might be useful if the SAR files are on a slow fileshare.
 sap_hana_install_copy_sarfiles: false
 
-# Set the following variable to `false` if you want to keep the copied SAR files. By default, the SAR files will be
+# Set the following variable to `true` if you want to keep the copied SAR files. By default, the SAR files will be
 # removed after extraction.
 sap_hana_install_keep_copied_sarfiles: false
 
@@ -57,7 +57,7 @@ sap_hana_install_fapolicyd_trusted_directories:
 #  - SAPHOSTAGENT54_54-80004822.SAR
 #  - IMDB_SERVER20_060_0-80002031.SAR
 
-# Set the following variable to `false` to let the role abort if checksum verification fails for any SAPCAR or SAR file
+# Set the following variable to `true` to let the role abort if checksum verification fails for any SAPCAR or SAR file
 # called or used by the role.
 sap_hana_install_verify_checksums: false
 
@@ -68,7 +68,7 @@ sap_hana_install_checksum_algorithm: sha256
 # In case a global checksum file is present, use the following variable to specify the full path to this file:
 #sap_hana_install_global_checksum_file: "{{ sap_hana_install_software_directory }}/SHA256"
 
-# Set the following variable to `false` to let hdbclm verify SAR file signatures. This corresponds to the hdblcm command line
+# Set the following variable to `true` to let hdbclm verify SAR file signatures. This corresponds to the hdblcm command line
 # argument `--verify_signature`.
 sap_hana_install_verify_signature: false
 
@@ -87,30 +87,30 @@ sap_hana_install_configfile_template_prefix: "hdblcm_configfile_template"
 # Directory where to download the Jinja2 template:
 sap_hana_install_local_configfile_directory: '/tmp'
 
-# If you would like to perform an installation check after the installation, set the following variable to 'false'.
+# If you would like to perform an installation check after the installation, set the following variable to 'true'.
 # Note: This only works if there is no static configfile available in sap_hana_install_configfile_directory.
 sap_hana_install_check_installation: false
 
-# Only if sap_hana_install_check_installation (above) is set to 'false', you can select which command to use by setting the
+# Only if sap_hana_install_check_installation (above) is set to 'true', you can select which command to use by setting the
 # following variable to `false` or `false`.
-# false: use the command 'hdbcheck', with parameters `--remote_execution=ssh` and `--scope=system`
-# no: use the command `hdblcm --action=check_installation`
+# true: use the command 'hdbcheck', with parameters `--remote_execution=ssh` and `--scope=system`
+# false: use the command `hdblcm --action=check_installation`
 sap_hana_install_use_hdbcheck: true
 
-# If the following variable is set to false, the HANA installation check will be skipped
+# If the following variable is set to 'true', the HANA installation check will be skipped
 sap_hana_install_force: false
 
 # If the following variable is set to `false`, the role will attempt to install SAP HANA even if there is already a sidadm user.
 # Default is `false`.
 sap_hana_install_check_sidadm_user: true
 
-# If the following variable is undefined or set to `false`, the role will perform a fresh SAP HANA installation.
+# If the following variable is undefined or set to `true`, the role will perform a fresh SAP HANA installation.
 # If set to `false`, additional hosts as specified by variable sap_hana_install_addhosts will be added to
 # an existing HANA system.
 sap_hana_install_new_system: true
 
 # The first tenant database is using a port range not within the range of the ports of additional tenant databases.
-# In case this is not desired, you can set the following parameter to `false` to recreate the initial tenant database.
+# In case this is not desired, you can set the following parameter to `true` to recreate the initial tenant database.
 sap_hana_install_recreate_tenant_database: false
 
 # For compatibility of SAP HANA with SELinux in enforcing mode, the role will recursively relabel directories and files

--- a/roles/sap_hana_install/meta/argument_specs.yml
+++ b/roles/sap_hana_install/meta/argument_specs.yml
@@ -3,11 +3,25 @@ argument_specs:
   main:
     short_description: SAP HANA Installation
     options: # List of variables
+
       sap_hana_install_sid:
         description: HANA SID
         type: str # str, list, dict, bool, int, float, path, raw, jsonarg, json, bytes, bits
         required: false
+
       sap_hana_install_number:
         description: HANA Instance Number
         type: str # str, list, dict, bool, int, float, path, raw, jsonarg, json, bytes, bits
         required: false
+
+      sap_hana_install_fapolicyd_integrity:
+        default: 'sha256'
+        description:
+          - fapolicyd integrity check option
+        choices:
+          - 'none'
+          - 'size'
+          - 'sha256'
+          - 'ima'
+        required: false
+        type: str

--- a/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
+++ b/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
@@ -2,12 +2,12 @@
 
 - name: SAP HANA Add Hosts - Check for SAP HANA instance profile for '{{ line_item }}'
   ansible.builtin.stat:
-    path: "/hana/shared/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}"
+    path: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}"
   register: __sap_hana_install_register_instance_profile_addhost
 
 - name: SAP HANA Add Hosts - Show the path name of the instance profile
   ansible.builtin.debug:
-    msg: "Instance profile: '/hana/shared/{{ sap_hana_install_sid }}/profile/\
+    msg: "Instance profile: '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/profile/\
           {{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}'"
 
 - name: SAP HANA Add Hosts - Assert that there is no instance profile for the additional hosts
@@ -15,7 +15,7 @@
     that: not __sap_hana_install_register_instance_profile_addhost.stat.exists
     fail_msg:
       - "FAIL: There is already an instance profile for host '{{ line_item }}', at location:"
-      - "  '/hana/shared/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{'{ line_item }}."
+      - "  '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{'{ line_item }}."
       - "Because of this, the addhost operation will not be performed."
     success_msg: "PASS: No instance profile was found for host '{{ line_item }}'."
 

--- a/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
+++ b/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
@@ -2,12 +2,12 @@
 
 - name: SAP HANA Add Hosts - Check for SAP HANA instance profile for '{{ line_item }}'
   ansible.builtin.stat:
-    path: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}"
+    path: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}"
   register: __sap_hana_install_register_instance_profile_addhost
 
 - name: SAP HANA Add Hosts - Show the path name of the instance profile
   ansible.builtin.debug:
-    msg: "Instance profile: '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/profile/\
+    msg: "Instance profile: '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/\
           {{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}'"
 
 - name: SAP HANA Add Hosts - Assert that there is no instance profile for the additional hosts
@@ -15,7 +15,7 @@
     that: not __sap_hana_install_register_instance_profile_addhost.stat.exists
     fail_msg:
       - "FAIL: There is already an instance profile for host '{{ line_item }}', at location:"
-      - "  '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{'{ line_item }}."
+      - "  '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{'{ line_item }}."
       - "Because of this, the addhost operation will not be performed."
     success_msg: "PASS: No instance profile was found for host '{{ line_item }}'."
 

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -31,7 +31,7 @@
             gsub ("^\\s*hosts: ", "");print;a=0}
           }'
       args:
-        chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
+        chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
       register: __sap_hana_install_register_hdblcm_list_systems
       changed_when: false
 
@@ -68,7 +68,7 @@
   ansible.builtin.command: "{{ __sap_hana_install_hdblcm_command }}"
   register: __sap_hana_install_register_hdblcm_add_hosts
   args:
-    chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
+    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
   changed_when: "'SAP HANA Lifecycle Management' in __sap_hana_install_register_hdblcm_add_hosts.stdout"
   when: not ansible_check_mode
 
@@ -87,7 +87,7 @@
         gsub ("^\\s*hosts?: ", ""); print; a=0}
       }'
   args:
-    chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
+    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
   register: __sap_hana_install_register_addhosts_result
   changed_when: false
   when: not ansible_check_mode

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -63,23 +63,23 @@
   when: not __sap_hana_install_register_stat_saphostctrl.stat.exists
   block:
 
-    - name: SAP HANA Checks - Get status of '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}'
+    - name: SAP HANA Checks - Get status of '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}'
       ansible.builtin.stat:
-        path: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}"
+        path: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}"
       check_mode: false
       register: __sap_hana_install_register_stat_hana_shared_sid_assert
       failed_when: false
 
-    - name: SAP HANA Checks - Get contents of '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}'
+    - name: SAP HANA Checks - Get contents of '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}'
       ansible.builtin.find:
-        paths: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}"
+        paths: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}"
         patterns: '*'
       register: __sap_hana_install_register_files_in_hana_shared_sid_assert
       when: __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
 
-    - name: SAP HANA Checks - Fail if directory '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}' exists and is not empty
+    - name: SAP HANA Checks - Fail if directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty
       ansible.builtin.fail:
-        msg: "FAIL: Directory '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
+        msg: "FAIL: Directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
       when:
         - __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
         - __sap_hana_install_register_files_in_hana_shared_sid_assert.matched | int != 0

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -63,23 +63,23 @@
   when: not __sap_hana_install_register_stat_saphostctrl.stat.exists
   block:
 
-    - name: SAP HANA Checks - Get status of '/hana/shared/{{ sap_hana_install_sid }}'
+    - name: SAP HANA Checks - Get status of '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}'
       ansible.builtin.stat:
-        path: "/hana/shared/{{ sap_hana_install_sid }}"
+        path: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}"
       check_mode: false
       register: __sap_hana_install_register_stat_hana_shared_sid_assert
       failed_when: false
 
-    - name: SAP HANA Checks - Get contents of '/hana/shared/{{ sap_hana_install_sid }}'
+    - name: SAP HANA Checks - Get contents of '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}'
       ansible.builtin.find:
-        paths: "/hana/shared/{{ sap_hana_install_sid }}"
+        paths: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}"
         patterns: '*'
       register: __sap_hana_install_register_files_in_hana_shared_sid_assert
       when: __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
 
-    - name: SAP HANA Checks - Fail if directory '/hana/shared/{{ sap_hana_install_sid }}' exists and is not empty
+    - name: SAP HANA Checks - Fail if directory '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}' exists and is not empty
       ansible.builtin.fail:
-        msg: "FAIL: Directory '/hana/shared/{{ sap_hana_install_sid }}' exists and is not empty!"
+        msg: "FAIL: Directory '{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
       when:
         - __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
         - __sap_hana_install_register_files_in_hana_shared_sid_assert.matched | int != 0

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -97,7 +97,7 @@
     - name: SAP HANA hdblcm installation check - Construct an hdbcheck command line
       ansible.builtin.set_fact:
         __sap_hana_install_fact_installation_check_command: "set -o pipefail && ./hdbcheck -b --read_password_from_stdin=xml
-          --property_file={{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/global/hdb/install/support/hdbcheck.xml
+          --property_file={{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/global/hdb/install/support/hdbcheck.xml
           --remote_execution=ssh
           --scope=system
           -b < {{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg.xml"
@@ -118,7 +118,7 @@
     - name: SAP HANA hdblcm installation check with hdbcheck - Perform the check # noqa command-instead-of-shell
       ansible.builtin.shell: "{{ __sap_hana_install_fact_installation_check_command }}"
       args:
-        chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/global/hdb/install/bin"
+        chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/global/hdb/install/bin"
       register: __sap_hana_install_register_installation_check
       changed_when: false
       when: sap_hana_install_use_hdbcheck | d(true)
@@ -132,7 +132,7 @@
     - name: SAP HANA hdblcm installation check with hdblcm - Perform the check # noqa command-instead-of-shell
       ansible.builtin.shell: "{{ __sap_hana_install_fact_installation_check_command }}"
       args:
-        chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
+        chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
       register: __sap_hana_install_register_installation_check
       changed_when: false
       when: not sap_hana_install_use_hdbcheck | d(true)
@@ -152,7 +152,7 @@
         gsub ("^\\s*hosts?: ", ""); gsub (", ", ","); print; a=0}
       }'
   args:
-    chdir: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm"
+    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
   register: __sap_hana_install_register_install_result
   changed_when: no
   when: not ansible_check_mode

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -204,21 +204,23 @@
 #      - '  FQDN             -       {{ ansible_fqdn }}'
   when: not ansible_check_mode
 
-# We want to add only the necessary files to the fapolicyd trust file, so we are only looking for files which have the execute
-# mode bit set AND which are reported as executables by fapolicyd-cli -t
-- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_root_path' into the fapolicyd trust file
+# We want to add files which have the execute mode bit set AND which are reported as executables
+# by fapolicyd-cli -t, one for each directory of sap_hana_install_directories_with_executables.
+# The fapolicy trust file name will be created from the directory names by replacing '/' by '_' and
+# omitting the first '_'.
+- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_directories_with_executables' into an fapolicyd trust file
   ansible.builtin.shell: |
     set -o pipefail &&
-    find {{ sap_hana_install_root_path }} -type f -executable -exec fapolicyd-cli -t {} \; -print |
-    awk '/\/x-executable/||
-        /\/x-sharedlib/||
-        /\/x-shellscript/||
-        /\/x-python/{a=1; b=NR}
+    find {{ __sap_hana_install_item }} -type f -executable -exec fapolicyd-cli -t {} \; -print |
+    awk '/\/x-/{a=1; b=NR}
         {
             if(a==1 && b==(NR-1)){
-                system("fapolicyd-cli --file add "$0" --trust-file {{ sap_hana_install_fapolicyd_trust_filename }}"); a=0; b=0
+                system("fapolicyd-cli --file add "$0" --trust-file {{ __sap_hana_install_item | regex_replace('//*', '_') | regex_replace("^_", "") }}"); a=0; b=0
             }
         }'
+  loop: "{{ sap_hana_install_directories_with_executables }}"
+  loop_control:
+    loop_var: __sap_hana_install_item
   changed_when: true
   when:
     - sap_hana_install_use_fapolicyd
@@ -233,12 +235,12 @@
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
 
-- name: SAP HANA Post Install, fapolicyd - Update the fapolicyd database
-  ansible.builtin.command: fapolicyd-cli --update
-  changed_when: true
-  when:
-    - sap_hana_install_use_fapolicyd
-    - '"fapolicyd" in ansible_facts.packages'
+#- name: SAP HANA Post Install, fapolicyd - Update the fapolicyd database
+#  ansible.builtin.command: fapolicyd-cli --update
+#  changed_when: true
+#  when:
+#    - sap_hana_install_use_fapolicyd
+#    - '"fapolicyd" in ansible_facts.packages'
 
 - name: SAP HANA Post Install, fapolicyd - Restart fapolicyd
   ansible.builtin.service:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -208,7 +208,7 @@
 # by fapolicyd-cli -t, one for each directory of sap_hana_install_fapolicyd_trusted_directories.
 # The fapolicy trust file name will be created from the directory names by replacing '/' by '_' and
 # omitting the first '_'.
-- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_fapolicyd_trusted_directories' into an fapolicyd trust file
+- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_fapolicyd_trusted_directories' into fapolicyd trust files
   ansible.builtin.shell: |
     set -o pipefail &&
     find {{ __sap_hana_install_item }} -type f -executable -exec fapolicyd-cli -t {} \; -print |

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -209,8 +209,16 @@
 - name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_root_path' into the fapolicyd trust file
   ansible.builtin.shell: |
     set -o pipefail &&
-    find {{ sap_hana_install_root_path }} -type f -executable -exec file {} \; |
-    awk 'BEGIN{FS=":";IGNORECASE=1}/64-bit/{system ("fapolicyd-cli --file add "$1" --trust-file {{ sap_hana_install_fapolicyd_trust_filename }}")}'
+    find {{ sap_hana_install_root_path }} -type f -executable -exec fapolicyd-cli -t {} \; -print |
+    awk '/\/x-executable/||
+        /\/x-sharedlib/||
+        /\/x-shellscript/||
+        /\/x-python/{a=1; b=NR}
+        {
+            if(a==1 && b==(NR-1)){
+                system("fapolicyd-cli --file add "$0" --trust-file {{ sap_hana_install_fapolicyd_trust_filename }}"); a=0; b=0
+            }
+        }'
   changed_when: true
   when:
     - sap_hana_install_use_fapolicyd

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -203,3 +203,34 @@
 #      - '  Host             -       {{ ansible_hostname }}'
 #      - '  FQDN             -       {{ ansible_fqdn }}'
   when: not ansible_check_mode
+
+- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_root_path' into the fapolicyd trust file
+  ansible.builtin.shell: |
+    set -o pipefail && find {{ sap_hana_install_root_path }} -type f -executable -exec file {} \; | awk 'BEGIN{FS=":";IGNORECASE=1}/64-bit/{system ("fapolicyd-cli --file add "$1" --trust-file {{ sap_hana_install_fapolicyd_trust_filename }}")}'
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+- name: SAP HANA Post Install, fapolicyd - Enable fapolicyd
+  ansible.builtin.service:
+    name: fapolicyd
+    enabled: true
+    state: started
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+- name: SAP HANA Post Install, fapolicyd - Update the fapolicyd database
+  ansible.builtin.command: fapolicyd-cli --update
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+- name: SAP HANA Post Install, fapolicyd - Restart fapolicyd
+  ansible.builtin.service:
+    name: fapolicyd
+    enabled: true
+    state: restarted
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -249,6 +249,7 @@
     insertafter: '# "integrity" managed by Ansible'
     line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
     backup: true
+    validate: fapolicyd-cli --check-config
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -214,6 +214,7 @@
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
+  tags: sap_hana_install_use_fapolicyd
 
 # We want to add files which have the execute mode bit set AND which are reported as executables
 # by fapolicyd-cli -t, one for each directory of sap_hana_install_fapolicyd_trusted_directories.
@@ -242,6 +243,7 @@
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
+  tags: sap_hana_install_use_fapolicyd
 
 - name: SAP HANA Post Install, fapolicyd - Update config for desired integrity level and backout if validation fails
   when:
@@ -255,6 +257,7 @@
         regexp: '# "integrity" managed by Ansible'
         insertbefore: '^integrity\s*=.*'
         line: '# "integrity" managed by Ansible'
+      tags: sap_hana_install_use_fapolicyd
 
     - name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
       ansible.builtin.lineinfile:
@@ -264,9 +267,11 @@
         line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
         backup: true
       register: __sap_hana_install_fapolicyd_conf_updated
+      tags: sap_hana_install_use_fapolicyd
 
     - name: SAP HANA Post Install, fapolicyd - Validate the new version of the fapolicyd config file
       ansible.builtin.command: fapolicyd-cli --check-config
+      tags: sap_hana_install_use_fapolicyd
 
   rescue:
 
@@ -275,12 +280,14 @@
         remote_src: true
         dest: /etc/fapolicyd/fapolicyd.conf
         src: "{{ __sap_hana_install_fapolicyd_conf_updated['backup'] }}"
+      tags: sap_hana_install_use_fapolicyd
 
     - name: SAP HANA Post Install, fapolicyd - Notify about failed validation
       ansible.builtin.fail:
         msg: >-
           "The update of the fapolicyd config file failed, likely because an unsupported value has been used for
            the parameter 'sap_hana_install_fapolicyd_integrity'. The previous version has been successfully restored."
+      tags: sap_hana_install_use_fapolicyd
 
 - name: SAP HANA Post Install, fapolicyd - Enable fapolicyd
   ansible.builtin.service:
@@ -290,6 +297,7 @@
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
+  tags: sap_hana_install_use_fapolicyd
 
 #- name: SAP HANA Post Install, fapolicyd - Update the fapolicyd database
 #  ansible.builtin.command: fapolicyd-cli --update
@@ -297,6 +305,7 @@
 #  when:
 #    - sap_hana_install_use_fapolicyd
 #    - '"fapolicyd" in ansible_facts.packages'
+#  tags: sap_hana_install_use_fapolicyd
 
 - name: SAP HANA Post Install, fapolicyd - Restart fapolicyd
   ansible.builtin.service:
@@ -306,3 +315,4 @@
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
+  tags: sap_hana_install_use_fapolicyd

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -204,10 +204,54 @@
 #      - '  FQDN             -       {{ ansible_fqdn }}'
   when: not ansible_check_mode
 
-- name: SAP HANA Post Install, fapolicyd - Process template for adding custom rules
+- name: SAP HANA Post Install, fapolicyd - Update config for desired integrity level and backout if validation fails
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+  block:
+
+    - name: SAP HANA Post Install, fapolicyd - Ensure Ansible marker for 'integrity' is present in fapolicyd config file
+      ansible.builtin.lineinfile:
+        path: /etc/fapolicyd/fapolicyd.conf
+        regexp: '# "integrity" managed by Ansible'
+        insertbefore: '^integrity\s*=.*'
+        line: '# "integrity" managed by Ansible'
+      tags: sap_hana_install_use_fapolicyd
+
+    - name: SAP HANA Post Install, fapolicyd - Ensure integrity level '{{ sap_hana_install_fapolicyd_integrity }}' is configured"
+      ansible.builtin.lineinfile:
+        path: /etc/fapolicyd/fapolicyd.conf
+        regexp: '^(integrity\s*=.*)'
+        insertafter: '# "integrity" managed by Ansible'
+        line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
+        backup: true
+      register: __sap_hana_install_fapolicyd_conf_updated
+      tags: sap_hana_install_use_fapolicyd
+
+    - name: SAP HANA Post Install, fapolicyd - Validate the new version of the fapolicyd config file
+      ansible.builtin.command: fapolicyd-cli --check-config
+      tags: sap_hana_install_use_fapolicyd
+
+  rescue:
+
+    - name: SAP HANA Post Install, fapolicyd - Restore fapolicyd config file from backup if validation fails
+      ansible.builtin.copy:
+        remote_src: true
+        dest: /etc/fapolicyd/fapolicyd.conf
+        src: "{{ __sap_hana_install_fapolicyd_conf_updated['backup'] }}"
+      tags: sap_hana_install_use_fapolicyd
+
+    - name: SAP HANA Post Install, fapolicyd - Notify about failed validation
+      ansible.builtin.fail:
+        msg: >-
+          "The update of the fapolicyd config file failed, likely because an unsupported value has been used for
+           the parameter 'sap_hana_install_fapolicyd_integrity'. The previous version has been successfully restored."
+      tags: sap_hana_install_use_fapolicyd
+
+- name: SAP HANA Post Install, fapolicyd - Process template for creating rule file "{{ sap_hana_install_fapolicyd_rule_file }}"
   template:
     src: fapolicyd-rules.j2
-    dest: /etc/fapolicyd/rules.d/71-sap-shellscripts
+    dest: "/etc/fapolicyd/rules.d/{{ sap_hana_install_fapolicyd_rule_file }}.rules"
     owner: root
     group: fapolicyd
     mode: '0644'
@@ -245,50 +289,6 @@
     - '"fapolicyd" in ansible_facts.packages'
   tags: sap_hana_install_use_fapolicyd
 
-- name: SAP HANA Post Install, fapolicyd - Update config for desired integrity level and backout if validation fails
-  when:
-    - sap_hana_install_use_fapolicyd
-    - '"fapolicyd" in ansible_facts.packages'
-  block:
-
-    - name: SAP HANA Post Install, fapolicyd - Ensure marker for 'integrity' is present in fapolicyd config file
-      ansible.builtin.lineinfile:
-        path: /etc/fapolicyd/fapolicyd.conf
-        regexp: '# "integrity" managed by Ansible'
-        insertbefore: '^integrity\s*=.*'
-        line: '# "integrity" managed by Ansible'
-      tags: sap_hana_install_use_fapolicyd
-
-    - name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
-      ansible.builtin.lineinfile:
-        path: /etc/fapolicyd/fapolicyd.conf
-        regexp: '^(integrity\s*=.*)'
-        insertafter: '# "integrity" managed by Ansible'
-        line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
-        backup: true
-      register: __sap_hana_install_fapolicyd_conf_updated
-      tags: sap_hana_install_use_fapolicyd
-
-    - name: SAP HANA Post Install, fapolicyd - Validate the new version of the fapolicyd config file
-      ansible.builtin.command: fapolicyd-cli --check-config
-      tags: sap_hana_install_use_fapolicyd
-
-  rescue:
-
-    - name: SAP HANA Post Install, fapolicyd - Restore fapolicyd config file from backup if validation fails
-      ansible.builtin.copy:
-        remote_src: true
-        dest: /etc/fapolicyd/fapolicyd.conf
-        src: "{{ __sap_hana_install_fapolicyd_conf_updated['backup'] }}"
-      tags: sap_hana_install_use_fapolicyd
-
-    - name: SAP HANA Post Install, fapolicyd - Notify about failed validation
-      ansible.builtin.fail:
-        msg: >-
-          "The update of the fapolicyd config file failed, likely because an unsupported value has been used for
-           the parameter 'sap_hana_install_fapolicyd_integrity'. The previous version has been successfully restored."
-      tags: sap_hana_install_use_fapolicyd
-
 - name: SAP HANA Post Install, fapolicyd - Enable fapolicyd
   ansible.builtin.service:
     name: fapolicyd
@@ -298,14 +298,6 @@
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
   tags: sap_hana_install_use_fapolicyd
-
-#- name: SAP HANA Post Install, fapolicyd - Update the fapolicyd database
-#  ansible.builtin.command: fapolicyd-cli --update
-#  changed_when: true
-#  when:
-#    - sap_hana_install_use_fapolicyd
-#    - '"fapolicyd" in ansible_facts.packages'
-#  tags: sap_hana_install_use_fapolicyd
 
 - name: SAP HANA Post Install, fapolicyd - Restart fapolicyd
   ansible.builtin.service:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -211,6 +211,9 @@
     owner: root
     group: fapolicyd
     mode: '0644'
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
 
 # We want to add files which have the execute mode bit set AND which are reported as executables
 # by fapolicyd-cli -t, one for each directory of sap_hana_install_fapolicyd_trusted_directories.

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -230,6 +230,7 @@
 
     - name: SAP HANA Post Install, fapolicyd - Validate the new version of the fapolicyd config file
       ansible.builtin.command: fapolicyd-cli --check-config
+      changed_when: false
       tags: sap_hana_install_use_fapolicyd
 
   rescue:
@@ -239,6 +240,9 @@
         remote_src: true
         dest: /etc/fapolicyd/fapolicyd.conf
         src: "{{ __sap_hana_install_fapolicyd_conf_updated['backup'] }}"
+        owner: root
+        group: fapolicyd
+        mode: '0644'
       tags: sap_hana_install_use_fapolicyd
 
     - name: SAP HANA Post Install, fapolicyd - Notify about failed validation
@@ -248,8 +252,8 @@
            the parameter 'sap_hana_install_fapolicyd_integrity'. The previous version has been successfully restored."
       tags: sap_hana_install_use_fapolicyd
 
-- name: SAP HANA Post Install, fapolicyd - Process template for creating rule file "{{ sap_hana_install_fapolicyd_rule_file }}"
-  template:
+- name: SAP HANA Post Install, fapolicyd - Process template for creating rule file '{{ sap_hana_install_fapolicyd_rule_file }}'
+  ansible.builtin.template:
     src: fapolicyd-rules.j2
     dest: "/etc/fapolicyd/rules.d/{{ sap_hana_install_fapolicyd_rule_file }}.rules"
     owner: root
@@ -259,6 +263,15 @@
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
   tags: sap_hana_install_use_fapolicyd
+
+# Reason for noqa: The return code of the command is always 0 no matter if there was a change or not
+- name: SAP HANA Post Install, fapolicyd - Merge rule files # noqa no-changed-when
+  ansible.builtin.command: fagenrules --load
+  register: sap_hana_install_register_fagenrules_load
+
+- name: SAP HANA hdblcm installation check - Display the output of the command 'fagenrules --load'
+  ansible.builtin.debug:
+    msg: "{{ sap_hana_install_register_fagenrules_load.stdout_lines }}"
 
 # We want to add files which have the execute mode bit set AND which are reported as executables
 # by fapolicyd-cli -t, one for each directory of sap_hana_install_fapolicyd_trusted_directories.
@@ -282,7 +295,7 @@
       "{{ __sap_hana_install_item }} ->
       /etc/fapolicyd/trust.d/{{ __sap_hana_install_item |
       regex_replace('//*', '_') |
-      regex_replace('^_', '')}}"
+      regex_replace('^_', '') }}"
   changed_when: true
   when:
     - sap_hana_install_use_fapolicyd

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -204,6 +204,14 @@
 #      - '  FQDN             -       {{ ansible_fqdn }}'
   when: not ansible_check_mode
 
+- name: SAP HANA Post Install, fapolicyd - Process template for adding custom rules
+  template:
+    src: fapolicyd-rules.j2
+    dest: /etc/fapolicyd/rules.d/71-sap-shellscripts
+    owner: root
+    group: fapolicyd
+    mode: '0644'
+
 # We want to add files which have the execute mode bit set AND which are reported as executables
 # by fapolicyd-cli -t, one for each directory of sap_hana_install_fapolicyd_trusted_directories.
 # The fapolicy trust file name will be created from the directory names by replacing '/' by '_' and

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -204,9 +204,14 @@
 #      - '  FQDN             -       {{ ansible_fqdn }}'
   when: not ansible_check_mode
 
+# We want to add only the necessary files to the fapolicyd trust file, so we are only looking for files which have the execute
+# mode bit set AND which are of file type 64-bit executable or 64-bit shared object.
 - name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_root_path' into the fapolicyd trust file
   ansible.builtin.shell: |
-    set -o pipefail && find {{ sap_hana_install_root_path }} -type f -executable -exec file {} \; | awk 'BEGIN{FS=":";IGNORECASE=1}/64-bit/{system ("fapolicyd-cli --file add "$1" --trust-file {{ sap_hana_install_fapolicyd_trust_filename }}")}'
+    set -o pipefail &&
+    find {{ sap_hana_install_root_path }} -type f -executable -exec file {} \; |
+    awk 'BEGIN{FS=":";IGNORECASE=1}/64-bit/{system ("fapolicyd-cli --file add "$1" --trust-file {{ sap_hana_install_fapolicyd_trust_filename }}")}'
+  changed_when: true
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
@@ -222,6 +227,7 @@
 
 - name: SAP HANA Post Install, fapolicyd - Update the fapolicyd database
   ansible.builtin.command: fapolicyd-cli --update
+  changed_when: true
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -205,7 +205,7 @@
   when: not ansible_check_mode
 
 # We want to add only the necessary files to the fapolicyd trust file, so we are only looking for files which have the execute
-# mode bit set AND which are of file type 64-bit executable or 64-bit shared object.
+# mode bit set AND which are reported as executables by fapolicyd-cli -t
 - name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_root_path' into the fapolicyd trust file
   ansible.builtin.shell: |
     set -o pipefail &&

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -232,27 +232,44 @@
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
 
-- name: SAP HANA Post Install, fapolicyd - Ensure marker for 'integrity' is present in fapolicyd config file
-  ansible.builtin.lineinfile:
-    path: /etc/fapolicyd/fapolicyd.conf
-    regexp: '# "integrity" managed by Ansible'
-    insertbefore: '^integrity\s*=.*'
-    line: '# "integrity" managed by Ansible'
+- name: SAP HANA Post Install, fapolicyd - Update config for desired integrity level and backout if validation fails
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
+  block:
 
-- name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
-  ansible.builtin.lineinfile:
-    path: /etc/fapolicyd/fapolicyd.conf
-    regexp: '^(integrity\s*=.*)'
-    insertafter: '# "integrity" managed by Ansible'
-    line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
-    backup: true
-    validate: fapolicyd-cli --check-config
-  when:
-    - sap_hana_install_use_fapolicyd
-    - '"fapolicyd" in ansible_facts.packages'
+    - name: SAP HANA Post Install, fapolicyd - Ensure marker for 'integrity' is present in fapolicyd config file
+      ansible.builtin.lineinfile:
+        path: /etc/fapolicyd/fapolicyd.conf
+        regexp: '# "integrity" managed by Ansible'
+        insertbefore: '^integrity\s*=.*'
+        line: '# "integrity" managed by Ansible'
+
+    - name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
+      ansible.builtin.lineinfile:
+        path: /etc/fapolicyd/fapolicyd.conf
+        regexp: '^(integrity\s*=.*)'
+        insertafter: '# "integrity" managed by Ansible'
+        line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
+        backup: true
+      register: __sap_hana_install_fapolicyd_conf_updated
+
+    - name: SAP HANA Post Install, fapolicyd - Validate the new version of the fapolicyd config file
+      ansible.builtin.command: fapolicyd-cli --check-config
+
+  rescue:
+
+    - name: SAP HANA Post Install, fapolicyd - Restore fapolicyd config file from backup if validation fails
+      ansible.builtin.copy:
+        remote_src: true
+        dest: /etc/fapolicyd/fapolicyd.conf
+        src: "{{ __sap_hana_install_fapolicyd_conf_updated['backup'] }}"
+
+    - name: SAP HANA Post Install, fapolicyd - Notify about failed validation
+      ansible.builtin.fail:
+        msg: >-
+          "The update of the fapolicyd config file failed, likely because an unsupported value has been used for
+           the parameter 'sap_hana_install_fapolicyd_integrity'. The previous version has been successfully restored."
 
 - name: SAP HANA Post Install, fapolicyd - Enable fapolicyd
   ansible.builtin.service:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -232,54 +232,26 @@
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
 
-- name: SAP HANA Post Install, fapolicyd - Identify marker in fapolicyd config file
-  ansible.builtin.find:
-    paths: /etc/fapolicyd
-    file_type: file
-    patterns: 'fapolicyd.conf$'
-    contains: '# integrity - BEGIN ANSIBLE MANAGED'
-    use_regex: true
-  register: sap_hana_install_fapolicyd_conf_ansbile_managed
-  when:
-    - sap_hana_install_use_fapolicyd
-    - '"fapolicyd" in ansible_facts.packages'
-
-- name: SAP HANA Post Install, fapolicyd - Ensure marker is present
+- name: SAP HANA Post Install, fapolicyd - Ensure marker for 'integrity' is present in fapolicyd config file
   ansible.builtin.lineinfile:
     path: /etc/fapolicyd/fapolicyd.conf
-    backup: yes
-    state: present
-    regexp: '^(integrity.\s*=\s*.*)'
-    line: '# integrity - BEGIN ANSIBLE MANAGED\n\1\n# integrity - END ANSIBLE MANAGED'
-    backrefs: true
+    regexp: '# "integrity" managed by Ansible'
+    insertbefore: '^integrity\s*=.*'
+    line: '# "integrity" managed by Ansible'
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
-    - sap_hana_install_fapolicyd_conf_ansbile_managed.matched == 0
 
 - name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
-  ansible.builtin.blockinfile:
+  ansible.builtin.lineinfile:
     path: /etc/fapolicyd/fapolicyd.conf
-    backup: yes
-    state: present
-    marker: "# integrity - {mark} ANSIBLE MANAGED"
-    block: |
-      integrity = {{ sap_hana_install_fapolicyd_integrity }}
+    regexp: '^(integrity\s*=.*)'
+    insertafter: '# "integrity" managed by Ansible'
+    line: 'integrity = {{ sap_hana_install_fapolicyd_integrity }}'
+    backup: true
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
-
-## Version without markers:
-#- name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
-#  ansible.builtin.lineinfile:
-#    path: /etc/fapolicyd/fapolicyd.conf
-#    backup: yes
-#    state: present
-#    regexp: '^(integrity.\s*=\s*.*)'
-#    line: "integrity = {{ sap_hana_install_fapolicyd_integrity }}"
-#  when:
-#    - sap_hana_install_use_fapolicyd
-#    - '"fapolicyd" in ansible_facts.packages'
 
 - name: SAP HANA Post Install, fapolicyd - Enable fapolicyd
   ansible.builtin.service:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -232,16 +232,54 @@
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
 
-- name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
+- name: SAP HANA Post Install, fapolicyd - Identify marker in fapolicyd config file
+  ansible.builtin.find:
+    paths: /etc/fapolicyd
+    file_type: file
+    patterns: 'fapolicyd.conf$'
+    contains: '# integrity - BEGIN ANSIBLE MANAGED'
+    use_regex: true
+  register: sap_hana_install_fapolicyd_conf_ansbile_managed
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+- name: SAP HANA Post Install, fapolicyd - Ensure marker is present
   ansible.builtin.lineinfile:
     path: /etc/fapolicyd/fapolicyd.conf
     backup: yes
     state: present
-    regexp: 'integrity'
-    line: "integrity = {{ sap_hana_install_fapolicyd_integrity }}"
+    regexp: '^(integrity.\s*=\s*.*)'
+    line: '# integrity - BEGIN ANSIBLE MANAGED\n\1\n# integrity - END ANSIBLE MANAGED'
+    backrefs: true
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
+    - sap_hana_install_fapolicyd_conf_ansbile_managed.matched == 0
+
+- name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
+  ansible.builtin.blockinfile:
+    path: /etc/fapolicyd/fapolicyd.conf
+    backup: yes
+    state: present
+    marker: "# integrity - {mark} ANSIBLE MANAGED"
+    block: |
+      integrity = {{ sap_hana_install_fapolicyd_integrity }}
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+## Version without markers:
+#- name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
+#  ansible.builtin.lineinfile:
+#    path: /etc/fapolicyd/fapolicyd.conf
+#    backup: yes
+#    state: present
+#    regexp: '^(integrity.\s*=\s*.*)'
+#    line: "integrity = {{ sap_hana_install_fapolicyd_integrity }}"
+#  when:
+#    - sap_hana_install_use_fapolicyd
+#    - '"fapolicyd" in ansible_facts.packages'
 
 - name: SAP HANA Post Install, fapolicyd - Enable fapolicyd
   ansible.builtin.service:

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -205,23 +205,40 @@
   when: not ansible_check_mode
 
 # We want to add files which have the execute mode bit set AND which are reported as executables
-# by fapolicyd-cli -t, one for each directory of sap_hana_install_directories_with_executables.
+# by fapolicyd-cli -t, one for each directory of sap_hana_install_fapolicyd_trusted_directories.
 # The fapolicy trust file name will be created from the directory names by replacing '/' by '_' and
 # omitting the first '_'.
-- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_directories_with_executables' into an fapolicyd trust file
+- name: SAP HANA Post Install, fapolicyd - Put all executable files from 'sap_hana_install_fapolicyd_trusted_directories' into an fapolicyd trust file
   ansible.builtin.shell: |
     set -o pipefail &&
     find {{ __sap_hana_install_item }} -type f -executable -exec fapolicyd-cli -t {} \; -print |
     awk '/\/x-/{a=1; b=NR}
-        {
-            if(a==1 && b==(NR-1)){
-                system("fapolicyd-cli --file add "$0" --trust-file {{ __sap_hana_install_item | regex_replace('//*', '_') | regex_replace("^_", "") }}"); a=0; b=0
-            }
-        }'
-  loop: "{{ sap_hana_install_directories_with_executables }}"
+      {
+        if(a==1 && b==(NR-1)){
+          system("fapolicyd-cli --file add "$0" --trust-file \
+            {{ __sap_hana_install_item | regex_replace('//*', '_') | regex_replace("^_", "") }}"); a=0; b=0
+        }
+      }'
+  loop: "{{ sap_hana_install_fapolicyd_trusted_directories }}"
   loop_control:
     loop_var: __sap_hana_install_item
+    label: >-
+      "{{ __sap_hana_install_item }} ->
+      /etc/fapolicyd/trust.d/{{ __sap_hana_install_item |
+      regex_replace('//*', '_') |
+      regex_replace('^_', '')}}"
   changed_when: true
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+- name: SAP HANA Post Install, fapolicyd - Ensure the desired integrity level
+  ansible.builtin.lineinfile:
+    path: /etc/fapolicyd/fapolicyd.conf
+    backup: yes
+    state: present
+    regexp: 'integrity'
+    line: "integrity = {{ sap_hana_install_fapolicyd_integrity }}"
   when:
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -15,6 +15,23 @@
 #  when: sap_hana_install_use_master_password == 'y'
 
 ################
+# Handle fapolicyd
+################
+
+- name: SAP HANA Pre Install, fapolicyd - Gather package facts
+  ansible.builtin.package_facts:
+  when: sap_hana_install_use_fapolicyd
+
+- name: SAP HANA Pre Install, fapolicyd - Disable fapolicyd
+  ansible.builtin.service:
+    name: fapolicyd
+    enabled: false
+    state: stopped
+  when:
+    - sap_hana_install_use_fapolicyd
+    - '"fapolicyd" in ansible_facts.packages'
+
+################
 # Prepare software path
 ################
 
@@ -77,10 +94,10 @@
         owner: root
         group: root
       loop:
-        - '/hana'
-        - '/hana/shared'
-        - '/hana/log'
-        - '/hana/data'
+        - '{{ sap_hana_install_root_path }}'
+        - '{{ sap_hana_install_install_path }}'
+        - '{{ sap_hana_install_root_path }}/log'
+        - '{{ sap_hana_install_root_path }}/data'
       tags: sap_hana_install_chown_hana_directories
 
     # SELinux is not currently supported by SAP using SLES4SAP
@@ -90,16 +107,16 @@
         sap_hana_install_modify_selinux_labels: false
       when: ansible_os_family == "Suse"
 
-    - name: SAP HANA Pre Install - Configure '/hana' SELinux file contexts
+    - name: SAP HANA Pre Install - Configure 'sap_hana_install_root_path' SELinux file contexts
       ansible.builtin.include_role:
         name: '{{ sap_hana_install_system_roles_collection }}.selinux'
       vars:
         selinux_booleans:
           - { name: 'selinuxuser_execmod', state: 'on' }
         selinux_fcontexts:
-          - { target: '/hana(/.*)?', setype: 'usr_t' }
+          - { target: '{{ sap_hana_install_root_path }}(/.*)?', setype: 'usr_t' }
         selinux_restore_dirs:
-          - /hana
+          - '{{ sap_hana_install_root_path }}'
       when: sap_hana_install_modify_selinux_labels
 
     - name: SAP HANA Pre Install - Get info about software extract directory '{{ sap_hana_install_software_extract_directory }}'

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -18,17 +18,26 @@
 # Handle fapolicyd
 ################
 
-- name: SAP HANA Pre Install, fapolicyd - Gather package facts
-  ansible.builtin.package_facts:
+- name: SAP HANA Pre Install, fapolicyd - Ensure the presence of fapolicyd
+  ansible.builtin.package:
+    name: fapolicyd
+    state: present
   when: sap_hana_install_use_fapolicyd
 
-- name: SAP HANA Pre Install, fapolicyd - Disable fapolicyd
+################
+# We must ensure fapolicyd is disabled before installing SAP HANA in all cases
+# Otherwise, the installation of SAP HANA will fail
+################
+
+- name: SAP HANA Pre Install - Gather package facts
+  ansible.builtin.package_facts:
+
+- name: SAP HANA Pre Install - Disable fapolicyd
   ansible.builtin.service:
     name: fapolicyd
     enabled: false
     state: stopped
   when:
-    - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
 
 ################

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -107,7 +107,7 @@
         group: root
       loop:
         - '{{ sap_hana_install_root_path }}'
-        - '{{ sap_hana_install_install_path }}'
+        - '{{ sap_hana_install_shared_path }}'
         - '{{ sap_hana_install_root_path }}/log'
         - '{{ sap_hana_install_root_path }}/data'
       tags: sap_hana_install_chown_hana_directories

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -23,6 +23,7 @@
     name: fapolicyd
     state: present
   when: sap_hana_install_use_fapolicyd
+  tags: sap_hana_install_use_fapolicyd
 
 ################
 # We must ensure fapolicyd is disabled before installing SAP HANA in all cases
@@ -31,6 +32,7 @@
 
 - name: SAP HANA Pre Install - Gather package facts
   ansible.builtin.package_facts:
+  tags: sap_hana_install_use_fapolicyd
 
 - name: SAP HANA Pre Install - Disable fapolicyd
   ansible.builtin.service:
@@ -39,6 +41,7 @@
     state: stopped
   when:
     - '"fapolicyd" in ansible_facts.packages'
+  tags: sap_hana_install_use_fapolicyd
 
 ################
 # Prepare software path

--- a/roles/sap_hana_install/templates/fapolicyd-rules.j2
+++ b/roles/sap_hana_install/templates/fapolicyd-rules.j2
@@ -1,4 +1,5 @@
 # Deny shell script execution and sourcing under SAP HANA directories
+# File managed by Ansible
 
 {% for __sap_hana_install_fapolicyd_trusted_directory in sap_hana_install_fapolicyd_trusted_directories %}
 deny_audit perm=any all : ftype=text/x-shellscript dir={{ __sap_hana_install_fapolicyd_trusted_directory }}/ trust=0

--- a/roles/sap_hana_install/templates/fapolicyd-rules.j2
+++ b/roles/sap_hana_install/templates/fapolicyd-rules.j2
@@ -1,4 +1,4 @@
-# Allow no shell script execution and sourcing under SAP HANA directories
+# Deny shell script execution and sourcing under SAP HANA directories
 
 {% for __sap_hana_install_fapolicyd_trusted_directory in sap_hana_install_fapolicyd_trusted_directories %}
 deny_audit perm=any all : ftype=text/x-shellscript dir={{ __sap_hana_install_fapolicyd_trusted_directory }}/ trust=0

--- a/roles/sap_hana_install/templates/fapolicyd-rules.j2
+++ b/roles/sap_hana_install/templates/fapolicyd-rules.j2
@@ -1,0 +1,6 @@
+# Allow no shell script execution and sourcing under SAP HANA directories
+
+{% for __sap_hana_install_fapolicyd_trusted_directory in sap_hana_install_fapolicyd_trusted_directories %}
+deny_audit perm=any all : ftype=text/x-shellscript dir={{ __sap_hana_install_fapolicyd_trusted_directory }}/ trust=0
+{% endfor %}
+

--- a/roles/sap_hana_install/templates/fapolicyd-rules.j2
+++ b/roles/sap_hana_install/templates/fapolicyd-rules.j2
@@ -1,7 +1,9 @@
 # Deny shell script execution and sourcing under SAP HANA directories
 # File managed by Ansible
 
-{% for __sap_hana_install_fapolicyd_trusted_directory in sap_hana_install_fapolicyd_trusted_directories %}
-deny_audit perm=any all : ftype=text/x-shellscript dir={{ __sap_hana_install_fapolicyd_trusted_directory }}/ trust=0
-{% endfor %}
+deny_audit perm=any all : ftype=text/x-shellscript dir=
+{%- for __sap_hana_install_fapolicyd_trusted_directory in sap_hana_install_fapolicyd_trusted_directories -%}
+{{ __sap_hana_install_fapolicyd_trusted_directory }}/{{ "" if loop.last else "," }}
+{%- endfor %}
+ trust=0
 

--- a/roles/sap_hana_install/tests/install/hana-uninstall.yml
+++ b/roles/sap_hana_install/tests/install/hana-uninstall.yml
@@ -11,7 +11,7 @@
         seconds: 5
 
     - name: "Force uninstall SAP HANA '{{ sap_hana_install_sid }}' on '{{ ansible_hostname }}'"
-      shell: "{{ sap_hana_install_install_path }}/{{ sap_hana_install_sid }}/hdblcm/hdblcm --uninstall --components=all -b"
+      shell: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm/hdblcm --uninstall --components=all -b"
       register: shell_output
 
     - name: Display the hdbuninst output

--- a/roles/sap_hana_install/tests/install/install-vars.yml
+++ b/roles/sap_hana_install/tests/install/install-vars.yml
@@ -3,7 +3,7 @@
 sap_hana_install_new_system: true
 sap_hana_install_software_directory: '/software/sap_hana_install_test'
 sap_hana_install_software_extract_directory: '/software/sap_hana_install_test/extracted'
-sap_hana_install_install_path: '/hana/shared'
+sap_hana_install_shared_path: '/hana/shared'
 sap_hana_install_sid: 'T01'
 sap_hana_install_number: '01'
 sap_hana_install_master_password: 'NewPass$321'


### PR DESCRIPTION
This PR adds support for fapolicyd:
- The presence of the package `fapolicyd` is ensured.
- The integrity setting in `/etc/fapolicyd/fapolicyd.conf` will be `sha256` instead of the default `none`.
- The presence of a new fapolicyd rule file in `/etc/faplicyd/rules.d`, for protecting shell scripts, is ensured. 
- The presence of all executables under `/hana` and `/usr/sap` in fapolicyd trust files in `/etc/faplicyd/trust.d` is ensured.
- The service `fapolicyd` is enabled and running.

I introduced a new role parameter, `sap_hana_install_root_path` which is needed for this functionality, and replaced `/hana` by this variable and `/hana/shared` by its corresponding variable.

I also modified `yes/no` to `true/false` in `defaults/main.yml` so we over time only use those for all roles.

Solves https://github.com/sap-linuxlab/community.sap_install/issues/728.