### PR TITLE
sap_ha_pacemaker_cluster: Add python3-pip and NFS fix for Azure

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -6,6 +6,19 @@
 # Following steps are similar to crmsh code in ha_cluster role, but they are
 # too SAP specific, so they are added here instead of there.
 
+# Python3-pip and pexpect are required for ansible.builtin.expect
+# Python installation was removed from sap_swpm role in PR#720
+- name: "SAP HA Install Pacemaker - Install required python3-pip"
+  ansible.builtin.package:
+    name:
+      - python3-pip
+    state: present
+
+- name: "SAP HA Install Pacemaker - Install required pip pexpect"
+  ansible.builtin.pip:
+    name:
+      - pexpect
+
 - name: Block to ensure that changes are executed only once
   run_once: true  # noqa: run_once[task]
   block:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -125,7 +125,6 @@
         state: present
 
     # Using 'lineinfile' with a nested loop to avoid duplicate entries for existing configuration.
-    # Initial run_once ensures that cross editing on NFS will not fail
     - name: "SAP HA Pacemaker - (SAP HA Interface) Add connector to start profiles"
       ansible.builtin.lineinfile:
         backup: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -9,6 +9,10 @@
     backup: true
     regexp: 'Restart_Program_01'
     replace: 'Start_Program_01'
+  # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
+  throttle: 1
+  retries: 30
+  delay: 10
 
 - name: "SAP HA Pacemaker - (ERS profile) Prevent automatic restart"
   ansible.builtin.replace:
@@ -16,6 +20,10 @@
     backup: true
     regexp: 'Restart_Program_00'
     replace: 'Start_Program_00'
+  # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
+  throttle: 1
+  retries: 30
+  delay: 10
 
 # Comment out lines in /usr/sap/sapservices, which
 # - contain the target instance profile names
@@ -117,6 +125,7 @@
         state: present
 
     # Using 'lineinfile' with a nested loop to avoid duplicate entries for existing configuration.
+    # Initial run_once ensures that cross editing on NFS will not fail
     - name: "SAP HA Pacemaker - (SAP HA Interface) Add connector to start profiles"
       ansible.builtin.lineinfile:
         backup: true
@@ -128,6 +137,10 @@
       loop_control:
         loop_var: nwas_profile_item
         label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
+    # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
+      throttle: 1
+      retries: 30
+      delay: 10
 
     # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
@@ -148,7 +161,8 @@
       changed_when: false
       failed_when: false
 
-
+    # NOTE: RestartService can cause fencing lockup and hang forever,
+    # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0


### PR DESCRIPTION
Scope:
1. Moved python3-pip code from sap_swpm to sap_ha_pacemaker_cluster to enable change in https://github.com/sap-linuxlab/community.sap_install/pull/720 for @berndfinger 

2. Added throttling and retry loop for tasks touching files on cross-mounted NFS filesystem under ASCS ERS, which was not working correctly on MS Azure NFS filesystems. It will now do change on first host by using `throttle: 1` then it will retry-loop attempt to do change on second node. @ja9fuchs 
> Testing has shown that it takes 20-40 seconds for NFS to be accessible again.