### PR TITLE
sap_swpm: legacy ascs ha code

### DIFF
--- a/roles/sap_swpm/tasks/pre_install/create_os_user.yml
+++ b/roles/sap_swpm/tasks/pre_install/create_os_user.yml
@@ -3,52 +3,52 @@
 # Legacy code, appears to serve no function but does cause ASCS HA <sid>adm to not default to C Shell
 # As test without this code installed ASCS HA successfully, the call to this file has been commented out for removal at later date
 
-- name: SAP SWPM Pre Install - Remove existing {{ sap_swpm_sid | lower + 'adm' }}
-  block:
+# - name: SAP SWPM Pre Install - Remove existing {{ sap_swpm_sid | lower + 'adm' }}
+#   block:
 
-# Reason for noqa: We currently do not determine if there are processes to be killed
-    - name: SAP SWPM Pre Install - Kill all processes under {{ sap_swpm_sid | lower + 'adm' }}
-      ansible.builtin.shell: |
-        killall -u {{ sap_swpm_sid | lower }}adm
-      ignore_errors: yes
-      changed_when: true
+# # Reason for noqa: We currently do not determine if there are processes to be killed
+#     - name: SAP SWPM Pre Install - Kill all processes under {{ sap_swpm_sid | lower + 'adm' }}
+#       ansible.builtin.shell: |
+#         killall -u {{ sap_swpm_sid | lower }}adm
+#       ignore_errors: yes
+#       changed_when: true
 
-    - name: SAP SWPM Pre Install - Remove user {{ sap_swpm_sid | lower + 'adm' }}
-      ansible.builtin.user:
-        name: '{{ sap_swpm_sid | lower }}adm'
-        state: absent
-        remove: yes
-        force: yes
+#     - name: SAP SWPM Pre Install - Remove user {{ sap_swpm_sid | lower + 'adm' }}
+#       ansible.builtin.user:
+#         name: '{{ sap_swpm_sid | lower }}adm'
+#         state: absent
+#         remove: yes
+#         force: yes
 
-    - name: SAP SWPM Pre Install - Remove group {{ sap_swpm_sid | lower + 'adm' }}
-      ansible.builtin.group:
-        name: '{{ sap_swpm_sid | lower }}adm'
-        state: absent
+#     - name: SAP SWPM Pre Install - Remove group {{ sap_swpm_sid | lower + 'adm' }}
+#       ansible.builtin.group:
+#         name: '{{ sap_swpm_sid | lower }}adm'
+#         state: absent
 
-- name: SAP SWPM Pre Install - Create sapsys group
-  ansible.builtin.group:
-    name: 'sapsys'
-    gid: '{{ sap_swpm_sapsys_gid }}'
-    state: present
+# - name: SAP SWPM Pre Install - Create sapsys group
+#   ansible.builtin.group:
+#     name: 'sapsys'
+#     gid: '{{ sap_swpm_sapsys_gid }}'
+#     state: present
 
-- name: SAP SWPM Pre Install - Create {{ sap_swpm_sid | lower + 'adm' }}
-  ansible.builtin.user:
-    name: '{{ sap_swpm_sid | lower }}adm'
-    comment: "SAP User - {{ sap_swpm_sid }}"
-    uid: '{{ sap_swpm_sidadm_uid }}'
-    group: '{{ sap_swpm_sapsys_gid }}'
+# - name: SAP SWPM Pre Install - Create {{ sap_swpm_sid | lower + 'adm' }}
+#   ansible.builtin.user:
+#     name: '{{ sap_swpm_sid | lower }}adm'
+#     comment: "SAP User - {{ sap_swpm_sid }}"
+#     uid: '{{ sap_swpm_sidadm_uid }}'
+#     group: '{{ sap_swpm_sapsys_gid }}'
 
-- name: SAP SWPM Pre Install - Create a /usr/sap/{{ sap_swpm_sid }}
-  ansible.builtin.file:
-    path: /usr/sap/{{ sap_swpm_sid }}
-    state: directory
-    owner: '{{ sap_swpm_sid | lower }}adm'
-    group: sapsys
-    recurse: yes
-    mode: '0755'
+# - name: SAP SWPM Pre Install - Create a /usr/sap/{{ sap_swpm_sid }}
+#   ansible.builtin.file:
+#     path: /usr/sap/{{ sap_swpm_sid }}
+#     state: directory
+#     owner: '{{ sap_swpm_sid | lower }}adm'
+#     group: sapsys
+#     recurse: yes
+#     mode: '0755'
 
-# - name: SAP SWPM Pre Install - Purge parameters so it will not populate inifile.params to prevent SWPM from crashing
-#   ansible.builtin.set_facts:
-#     sap_swpm_sapadm_uid: ""
-#     sap_swpm_sapsys_gid: ""
-#     sap_swpm_sidadm_uid: ""
+# # - name: SAP SWPM Pre Install - Purge parameters so it will not populate inifile.params to prevent SWPM from crashing
+# #   ansible.builtin.set_facts:
+# #     sap_swpm_sapadm_uid: ""
+# #     sap_swpm_sapsys_gid: ""
+# #     sap_swpm_sidadm_uid: ""

--- a/roles/sap_swpm/tasks/pre_install/create_os_user.yml
+++ b/roles/sap_swpm/tasks/pre_install/create_os_user.yml
@@ -1,5 +1,8 @@
 ---
 
+# Legacy code, appears to serve no function but does cause ASCS HA <sid>adm to not default to C Shell
+# As test without this code installed ASCS HA successfully, the call to this file has been commented out for removal at later date
+
 - name: SAP SWPM Pre Install - Remove existing {{ sap_swpm_sid | lower + 'adm' }}
   block:
 

--- a/roles/sap_swpm/tasks/pre_install/install_type/ha_install.yml
+++ b/roles/sap_swpm/tasks/pre_install/install_type/ha_install.yml
@@ -8,8 +8,10 @@
   ansible.builtin.set_fact:
     sap_swpm_swpm_command_virtual_hostname: "SAPINST_USE_HOSTNAME={{ sap_swpm_virtual_hostname }} IS_HOST_LOCAL_USING_STRING_COMPARE=true"
 
-# Create sidadm and sapsys when HA setup
-- name: SAP SWPM Pre Install - HA Installation - Create User when ASCS (initial HA setup)
-  ansible.builtin.include_tasks: ../create_os_user.yml
-  when:
-    - "'_ASCS' in sap_swpm_product_catalog_id"
+# Legacy code, appears to serve no function but does cause ASCS HA <sid>adm to not default to C Shell
+# As test without this code installed ASCS HA successfully, commenting out for removal at later date
+# # Create sidadm and sapsys when HA setup
+# - name: SAP SWPM Pre Install - HA Installation - Create User when ASCS (initial HA setup)
+#   ansible.builtin.include_tasks: ../create_os_user.yml
+#   when:
+#     - "'_ASCS' in sap_swpm_product_catalog_id"

--- a/roles/sap_swpm/tasks/pre_install/install_type/ha_maint_plan_stack_install.yml
+++ b/roles/sap_swpm/tasks/pre_install/install_type/ha_maint_plan_stack_install.yml
@@ -8,11 +8,13 @@
   ansible.builtin.set_fact:
     sap_swpm_swpm_command_virtual_hostname: "SAPINST_USE_HOSTNAME={{ sap_swpm_virtual_hostname }} IS_HOST_LOCAL_USING_STRING_COMPARE=true"
 
-# Create sidadm and sapsys when HA setup
-- name: SAP SWPM Pre Install - HA Installation - Create User when ASCS (initial HA setup)
-  ansible.builtin.include_tasks: ../create_os_user.yml
-  when:
-    - "'_ASCS' in sap_swpm_product_catalog_id"
+# Legacy code, appears to serve no function but does cause ASCS HA <sid>adm to not default to C Shell
+# As test without this code installed ASCS HA successfully, commenting out for removal at later date
+# # Create sidadm and sapsys when HA setup
+# - name: SAP SWPM Pre Install - HA Installation - Create User when ASCS (initial HA setup)
+#   ansible.builtin.include_tasks: ../create_os_user.yml
+#   when:
+#     - "'_ASCS' in sap_swpm_product_catalog_id"
 
 
 # Install using SAP Maintenance Planner Stack XML


### PR DESCRIPTION
Legacy code for ASCS HA, traced to original IBM LSS code which does not contain any reasoning for this code to exist

The code appears to serve no function but does cause ASCS HA <sid>adm to not default to C Shell, which is problematic for runtime stability

Tested an execution of ASCS HA without this code, and it installed ASCS HA successfully (with correct use of C Shell default for <sid>adm)

Therefore, commented out the call that imports Ansible Tasks from file `create_os_user.yml` and in future suggest this code is removed entirely