### PR TITLE
sap_swpm: Set DDIC password in SWPM if sap_swpm_ddic_000_password is defined

### DIFF
--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -256,7 +256,7 @@ HDB_Userstore.useABAPSSFS = false
 # NW_HDB_DBClient.clientPathStrategy = LOCAL
 {% endif %}
 
-{% if 'credentials_syscopy' in sap_swpm_inifile_list %}
+{% if sap_swpm_ddic_000_password is defined %}
 ######
 # credentials_syscopy
 ######

--- a/roles/sap_swpm/templates/configfile.j2
+++ b/roles/sap_swpm/templates/configfile.j2
@@ -257,9 +257,6 @@ HDB_Userstore.useABAPSSFS = false
 {% endif %}
 
 {% if sap_swpm_ddic_000_password is defined %}
-######
-# credentials_syscopy
-######
 # Are the passwords for the DDIC users different from the default value?
 NW_DDIC_Password.needDDICPasswords = true
 NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}


### PR DESCRIPTION
rather just when doing system copy as this parameter is relevant for both new installs and copies.