### PR TITLE
sap_install_media_detect: aws igw slow impact gpg key

### DIFF
--- a/roles/sap_install_media_detect/tasks/cleanup/disable-epel-repo.yml
+++ b/roles/sap_install_media_detect/tasks/cleanup/disable-epel-repo.yml
@@ -12,6 +12,7 @@
   ansible.builtin.rpm_key:
     state: absent
     key: "{{ sap_install_media_detect_epel_gpg_key_url }}"
+  retries: 10
   when:
     - sap_install_media_detect_use_rpm_key_module_for_removing_the_key
     - __sap_install_media_detect_register_rpm_q_gpg_pubkeys.stdout | length != 0

--- a/roles/sap_install_media_detect/tasks/prepare/enable_rar_handling.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/enable_rar_handling.yml
@@ -26,6 +26,7 @@
           ansible.builtin.rpm_key:
             state: present
             key: "{{ sap_install_media_detect_epel_gpg_key_url }}"
+          retries: 10
 #          ansible.builtin.command: "rpm --import {{ eap_install_media_detect_epel_gpg_key_url }}"
 #          changed_when: true
 
@@ -38,6 +39,7 @@
 #            name: "{{ sap_install_media_detect_epel_url }}"
             name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
             state: present
+          retries: 10
 
 # Reason for noqa: We would need an extra call to /usr/bin/crb status to determine the current status
         - name: SAP Install Media Detect - Prepare - EPEL - Enable the CRB repo # noqa no-changed-when


### PR DESCRIPTION
sap_install_media_detect: aws igw slow impact gpg key

Consistent failures in 3 tasks where the AWS IGW performance is too slow and timeout occurs, causing Ansible to have a fatal error. Fixed with retries while waiting for the SNAT to work.