### PR TITLE
sap_swpm: Remove the pids module

### DIFF
--- a/roles/sap_swpm/tasks/swpm.yml
+++ b/roles/sap_swpm/tasks/swpm.yml
@@ -22,25 +22,9 @@
 
 ### Async method
 
-# Required for Ansible Module pids
-- name: Install Python devel, Python pip and gcc to system Python
-  ansible.builtin.package:
-    name:
-      - python3-devel
-      - python3-pip
-      - gcc
-    state: present
-
-# Required for Ansible Module pids
-- name: Install Python dependency psutil to system Python
-  ansible.builtin.pip:
-    name:
-      - psutil
-#    executable: pip3.6
-
 - name: Set fact for the sapinst command line
   ansible.builtin.set_fact:
-    __sap_swpm_sapinst_command: "umask {{ sap_swpm_umask | default('022') }} ; ./sapinst {{ sap_swpm_swpm_command_inifile }}
+    __sap_swpm_sapinst_command: "umask {{ sap_swpm_umask | d('022') }} ; ./sapinst {{ sap_swpm_swpm_command_inifile }}
     {{ sap_swpm_swpm_command_product_id }}
     {{ sap_swpm_swpm_command_extra_args }}"
   tags: sap_swpm_sapinst_commandline
@@ -70,16 +54,14 @@
   async: 86400 # Seconds for maximum runtime, set to 24 hours
   poll: 0 # Seconds between polls, use 0 to run Ansible Tasks concurrently
 
-# Monitor sapinst process (i.e. ps aux | grep sapinst) and wait for exit
+# Monitor sapinst process and wait for exit
 - name: SAP SWPM - Wait for sapinst process to exit, poll every 60 seconds
-  community.general.pids:
-    name: sapinst
-#  shell: ps -ef | awk '/sapinst/&&!/awk/&&!/ansible/{print}'
-  register: pids_sapinst
-  until: "pids_sapinst.pids | length == 0"
-#  until: "pids_sapinst.stdout | length == 0"
+  ansible.builtin.shell: set -o pipefail && ps -ef | awk '/\.\/sapinst /&&!/umask/&&!/ awk /{print}'
+  register: __sap_swpm_register_pids_sapinst
+  until: "__sap_swpm_register_pids_sapinst.stdout | length == 0"
   retries: 1440
   delay: 60
+  changed_when: false
 
 - name: SAP SWPM - Verify if sapinst process finished successfully
   ansible.builtin.async_status:


### PR DESCRIPTION
This PR is a essentially a reopening of https://github.com/sap-linuxlab/community.sap_install/pull/720 after version 1.4.1 has been published.
Solves issue #719.

Advantages:
- No dependency on community.general in the role sap_swpm, simplifying support for downstream versions
- No more Python related package installations at the beginning of the role

