### PR TITLE
sap_hana_install: Solve issue #788.

### DIFF
--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -5,7 +5,7 @@
   ansible.builtin.set_fact:
     sap_hana_install_sid: "{{ sap_hana_sid | d(sap_hana_install_sid) | d('') }}"
     sap_hana_install_number: "{{ sap_hana_instance_number | d(sap_hana_install_instance_nr) | d(sap_hana_install_instance_number) | d(sap_hana_install_number) | d('') }}"
-    sap_hana_install_master_password: "{{ sap_hana_install_common_master_password | d(sap_hana_install_master_password) }}"
+    sap_hana_install_master_password: "{{ sap_hana_install_common_master_password | d(sap_hana_install_master_password) | d('') }}"
     sap_hana_install_system_usage: "{{ sap_hana_install_env_type | d(sap_hana_install_system_usage) }}"
     sap_hana_install_restrict_max_mem: "{{ sap_hana_install_mem_restrict | d(sap_hana_install_restrict_max_mem) }}"
   tags:


### PR DESCRIPTION
We do not want to fail the role in task `Rename some variables used by hdblcm configfile` if `sap_hana_install_common_master_password` is not set.