### PR TITLE
sap_ha_pacemaker_cluster: Enhance corosync totem handling

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -48,18 +48,38 @@
       + __sap_ha_pacemaker_cluster_fence_agent_packages)
       | unique }}"
 
-- name: "SAP HA Prepare Pacemaker - Add default corosync totem settings"
-  when:
-    - sap_ha_pacemaker_cluster_corosync_totem is defined
-    - sap_ha_pacemaker_cluster_corosync_totem.options is defined
-    - sap_ha_pacemaker_cluster_corosync_totem.options | length > 0
+# Prepare corosync totem variable with either:
+# - User provided sap_ha_pacemaker_cluster_corosync_totem if present
+# - Combine corosync totem from OS variables and Platform variables if present
+# - Use default corosync totem from OS variables if Platform variable is not present
+- name: "SAP HA Prepare Pacemaker - Prepare corosync totem settings"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_corosync_totem:
       options: "{{ __sap_ha_pacemaker_cluster_corosync_totem.options | default([]) + __totem_settings }}"
   vars:
+    # Identify if provided sap_ha_pacemaker_cluster_corosync_totem is defined
+    __user_totem_is_present:
+      "{{ true if (sap_ha_pacemaker_cluster_corosync_totem is defined
+        and sap_ha_pacemaker_cluster_corosync_totem.options is defined
+        and sap_ha_pacemaker_cluster_corosync_totem | length > 0) else false }}"
+
+    # Identify if __sap_ha_pacemaker_cluster_corosync_totem_platform is defined
+    __platform_totem_is_present:
+      "{{ true if (__sap_ha_pacemaker_cluster_corosync_totem_platform is defined
+        and __sap_ha_pacemaker_cluster_corosync_totem_platform.options is defined
+        and __sap_ha_pacemaker_cluster_corosync_totem_platform | length > 0) else false }}"
+
     __totem_settings: |-
+      {% if __user_totem_is_present %}
+      {% set corosync_totem = sap_ha_pacemaker_cluster_corosync_totem %}
+      {% elif __platform_totem_is_present %}
+      {% set corosync_totem = __sap_ha_pacemaker_cluster_corosync_totem_default
+       | combine(__sap_ha_pacemaker_cluster_corosync_totem_platform, recursive=True) %}
+      {% else %}
+      {% set corosync_totem = __sap_ha_pacemaker_cluster_corosync_totem_default %}
+      {% endif %}
       {% set new_opts = [] %}
-      {% for option in sap_ha_pacemaker_cluster_corosync_totem.options | dict2items -%}
+      {% for option in corosync_totem.options | dict2items -%}
         {%- set add_opts = new_opts.extend([
           {
             'name': option.key,
@@ -67,3 +87,5 @@
           }]) -%}
       {%- endfor %}
       {{ new_opts }}
+
+# TODO: Add support for ha_cluster_quorum

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -31,10 +31,10 @@ sap_ha_pacemaker_cluster_stonith_default:
 #    secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
 #    region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
 
-# Platform corosync totem configuration
-sap_ha_pacemaker_cluster_corosync_totem:
+# Default corosync options - Platform specific
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
   options:
-    token: 29000
+    token: 30000
 
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: aws_vpc_move_ip

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -42,8 +42,8 @@ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: "620{{ sap_ha_pacemaker
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
-# Platform corosync totem configuration
-sap_ha_pacemaker_cluster_corosync_totem:
+# Default corosync options - Platform specific
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
   options:
     token: 20000
     token_retransmits_before_loss_const: 10

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -31,6 +31,11 @@ sap_ha_pacemaker_cluster_stonith_default:
     subscriptionId: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
     resourceGroup: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
 
+# Default corosync options - Platform specific
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
+  options:
+    token: 30000
+
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: azure_lb
 

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -22,6 +22,10 @@ __sap_ha_pacemaker_cluster_command:
   resource_defaults_update: "pcs resource defaults update"
   resource_restart: "pcs resource restart"
 
+# Default corosync options - OS specific
+__sap_ha_pacemaker_cluster_corosync_totem_default:
+  options: []
+
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
 sap_ha_pacemaker_cluster_fence_agent_minimal_packages:

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -16,6 +16,15 @@ __sap_ha_pacemaker_cluster_command:
   resource_defaults_update: "crm configure rsc_defaults"
   resource_restart: "crm resource restart"
 
+# Default corosync options - OS specific
+__sap_ha_pacemaker_cluster_corosync_totem_default:
+  options:
+    token: 5000
+    token_retransmits_before_loss_const: 10
+    join: 60
+    consensus: 6000
+    max_messages: 20
+
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
 sap_ha_pacemaker_cluster_fence_agent_minimal_packages:


### PR DESCRIPTION
Changes:
- Add `__sap_ha_pacemaker_cluster_corosync_totem_default` in OS variable files with baseline corosync totem settings
- Add `__sap_ha_pacemaker_cluster_corosync_totem_platform` in Platform variable files with recommended corosync totem settings
- Rework logic inside of construct_vars_common.yml to become dynamic - Platform totem is combined with OS totem, where Platform can overwrite OS values as required.
```yaml
# Prepare corosync totem variable with either:
# - User provided sap_ha_pacemaker_cluster_corosync_totem if present
# - Combine corosync totem from OS variables and Platform variables if present
# - Use default corosync totem from OS variables if Platform variable is not present
```

Tested on:

- SLES15 SP5 - SAP ASCS/ERS and HANA clusters

**Note 1:** 
This change is now applicable to SUSE after changes in ha_cluster https://github.com/linux-system-roles/ha_cluster/pull/212

**Note 2:**
Platform specific totem values are taken from comprehensive configuration in crmsh https://github.com/ClusterLabs/crmsh/blob/master/etc/profiles.yml