### PR TITLE
sap_hana_preconfigure/SLES: Zypper lock handler for #791

### DIFF
--- a/roles/sap_general_preconfigure/handlers/main.yml
+++ b/roles/sap_general_preconfigure/handlers/main.yml
@@ -9,6 +9,18 @@
   when:
     - sap_general_preconfigure_reboot_ok|d(false)
 
+# Kernel update triggers zypper purge-kernels and lock after reboot.
+- name: Wait for Zypper lock to be released
+  ansible.builtin.command:
+    cmd: zypper info zypper
+  retries: 60
+  timeout: 5
+  listen: __sap_general_preconfigure_reboot_handler
+  when:
+    - ansible_os_family == 'Suse'
+    - sap_general_preconfigure_reboot_ok | d(false)
+  changed_when: false
+
 - name: Let the role fail if a reboot is required
   ansible.builtin.fail:
     msg: Reboot is required!

--- a/roles/sap_hana_preconfigure/handlers/main.yml
+++ b/roles/sap_hana_preconfigure/handlers/main.yml
@@ -83,6 +83,18 @@
   when:
     - sap_hana_preconfigure_reboot_ok | d(false)
 
+# Kernel update triggers zypper purge-kernels and lock after reboot.
+- name: Wait for Zypper lock to be released
+  ansible.builtin.command:
+    cmd: zypper info zypper
+  retries: 60
+  timeout: 5
+  listen: __sap_hana_preconfigure_reboot_handler
+  when:
+    - ansible_os_family == 'Suse'
+    - sap_hana_preconfigure_reboot_ok | d(false)
+  changed_when: false
+
 - name: Let the role fail if a reboot is required
   ansible.builtin.fail:
     msg: Reboot is required!


### PR DESCRIPTION
This PR adds Suse specific check for zypper to ensure that it is not locked by time both roles are finished.

Applies to:
```
sap_general_preconfigure
sap_hana_preconfigure
```

Execution example:
```console
RUNNING HANDLER [/mnt/c/scripts/community.sap_install/roles/sap_hana_preconfigure : Reboot the managed node] ************************************************
changed: [s01s4hana]

RUNNING HANDLER [/mnt/c/scripts/community.sap_install/roles/sap_hana_preconfigure : Wait for Zypper lock to be released] ************************************
FAILED - RETRYING: [s01s4hana]: Wait for Zypper lock to be released (60 retries left).
ok: [s01s4hana]
```

Solves: https://github.com/sap-linuxlab/community.sap_install/issues/791