### PR TITLE
sap_storage_setup: Add support for HANA Scaleout NFS filesystems

### DIFF
--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
@@ -45,18 +45,16 @@
             'dir_only': '/' + sap_storage_setup_sid,
           }
         ]) %}
-      {%- endif %}
 
-      {%- if nfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap/trans' %}
+      {%- elif nfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap/trans' %}
         {%- set add_trans = mount_list.extend([
           {
             'mount_src': nfs_item.nfs_path | regex_replace('/$', ''),
             'mountpoint': nfs_item.mountpoint | regex_replace('/$', ''),
           }
         ]) %}
-      {%- endif %}
 
-      {%- if nfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
+      {%- elif nfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
         {%- for common in sap_storage_setup_nfs_dirs_usr_sap.all %}
           {%- set add_all_usrsap = mount_list.extend([
             {
@@ -76,6 +74,14 @@
             ]) %}
           {%- endfor %}
         {%- endfor %}
+
+      {%- elif nfs_item.mountpoint.startswith('/hana/') %}
+        {%- set add_hana = mount_list.extend([
+          {
+            'mount_src': nfs_item.nfs_path | regex_replace('/$', ''),
+            'mountpoint': nfs_item.mountpoint | regex_replace('/$', ''),
+          }
+        ]) %}
 
       {%- endif %}
       {{ mount_list }}


### PR DESCRIPTION
Description:

1. Changes IF blocks to ELIF for simplification.
2. Add /hana/* block required for SAP HANA Scaleout

```yaml
      {%- elif nfs_item.mountpoint.startswith('/hana/') %}
        {%- set add_hana = mount_list.extend([
          {
            'mount_src': nfs_item.nfs_path | regex_replace('/$', ''),
            'mountpoint': nfs_item.mountpoint | regex_replace('/$', ''),
          }
        ]) %}
```