### PR TITLE
sap_swpm: manage sap_swpm_db_schema_abap_password in hdbuserstore

### DIFF
--- a/roles/sap_swpm/tasks/post_install.yml
+++ b/roles/sap_swpm/tasks/post_install.yml
@@ -46,7 +46,8 @@
     /usr/sap/{{ sap_swpm_sid }}/hdbclient/hdbuserstore \
     SET DEFAULT \
     {{ sap_swpm_db_host }}:3{{ sap_swpm_db_instance_nr }}13@{{ sap_swpm_db_sid }} \
-    {{ sap_swpm_db_schema_abap }} '{{ sap_swpm_db_system_password }}'
+    {{ sap_swpm_db_schema_abap }} "{% if sap_swpm_db_schema_abap_password is defined %}{{ sap_swpm_db_schema_abap_password }}{% else %}
+    {{ sap_swpm_db_system_password }}{% endif %}"
   args:
     executable: /bin/bash
   become: true


### PR DESCRIPTION
In the case where the `sap_swpm_db_schema_abap_password` variable is set, the `DEFAULT` key is set with the wrong password `sap_swpm_db_system_password`.

With the modification, the code handles both cases correctly