### PR TITLE
sap_ha_pacemaker_cluster: Add override to use Classic SAPHanaSR agents

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -842,6 +842,13 @@ sap_ha_pacemaker_cluster_resource_defaults:
   resource-stickiness: 1000
 ```
 
+### sap_ha_pacemaker_cluster_saphanasr_angi_detection
+
+- _Type:_ `string`
+- _Default:_ `True`
+
+Disabling this variable enables to use Classic SAPHanaSR agents even on server, with SAPHanaSR-angi is available.<br>
+
 ### sap_ha_pacemaker_cluster_stonith_custom
 
 - _Type:_ `list`

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -179,6 +179,9 @@ sap_ha_pacemaker_cluster_hana_hook_chksrv: false
 sap_ha_pacemaker_cluster_hana_global_ini_path: "/usr/sap/{{
  sap_ha_pacemaker_cluster_hana_sid | upper }}/SYS/global/hdb/custom/config/global.ini"
 
+# Disable auto-detection of SAPHanaSR-angi package and use Classic
+sap_ha_pacemaker_cluster_saphanasr_angi_detection: true
+
 ################################################################################
 # NetWeaver generic definitions
 ################################################################################

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -447,6 +447,12 @@ argument_specs:
         description:
           - Path with location of global.ini for srHook update
 
+      sap_ha_pacemaker_cluster_saphanasr_angi_detection:
+        default: true
+        description:
+          - Disabling this variable enables to use Classic SAPHanaSR agents even on server,
+            with SAPHanaSR-angi is available.
+
       ##########################################################################
       # NetWeaver specific parameters
       ##########################################################################

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
@@ -6,40 +6,44 @@
 # This is destructive step if executed on running cluster
 # without proper migration from SAPHanaSR to SAPHanaSR-angi!
 
-# Requirement for package_facts Ansible Module
-- name: For SLES ensure OS Package for Python Lib of rpm bindings is enabled for System Python
-  ansible.builtin.package:
-    name: python3-rpm
-    state: present
-  when: ansible_os_family == "Suse"
+- name: "SAP HA Prepare Pacemaker - Block for detection of SAPHanaSR-angi"
+  when: sap_ha_pacemaker_cluster_saphanasr_angi_detection
+  block:
+    # Requirement for package_facts Ansible Module
+    # SLES: Ensure OS Package for Python Lib of rpm bindings is enabled for System Python
+    - name: "SAP HA Prepare Pacemaker - Ensure python3-rpm package is present"
+      ansible.builtin.package:
+        name: python3-rpm
+        state: present
+      when: ansible_os_family == "Suse"
 
-- name: "SAP HA Prepare Pacemaker - Gather installed packages facts"
-  ansible.builtin.package_facts:
-    manager: auto
+    - name: "SAP HA Prepare Pacemaker - Gather installed packages facts"
+      ansible.builtin.package_facts:
+        manager: auto
 
-- name: "SAP HA Prepare Pacemaker - Search for SAPHanaSR-angi"
-  ansible.builtin.command:
-    cmd: zypper se SAPHanaSR-angi
-  changed_when: false
-  register: __sap_ha_pacemaker_cluster_zypper_angi_check
-  failed_when: false
+    - name: "SAP HA Prepare Pacemaker - Search for SAPHanaSR-angi"
+      ansible.builtin.command:
+        cmd: zypper se SAPHanaSR-angi
+      changed_when: false
+      register: __sap_ha_pacemaker_cluster_zypper_angi_check
+      failed_when: false
 
-# package can be replaced with "rpm -e --nodeps {{ item }}"
-- name: "SAP HA Prepare Pacemaker - Remove SAPHanaSR and SAPHanaSR-doc"
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: absent
-  loop:
-    - SAPHanaSR
-    - SAPHanaSR-doc
-  when:
-    - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
-    - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
-    - "'SAPHanaSR' in ansible_facts.packages"
+    # package can be replaced with "rpm -e --nodeps {{ item }}"
+    - name: "SAP HA Prepare Pacemaker - Remove SAPHanaSR and SAPHanaSR-doc"
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - SAPHanaSR
+        - SAPHanaSR-doc
+      when:
+        - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
+        - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
+        - "'SAPHanaSR' in ansible_facts.packages"
 
-- name: "SAP HA Prepare Pacemaker - Set fact angi_available"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
-  when:
-    - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
-    - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
+    - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
+      when:
+        - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
+        - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0


### PR DESCRIPTION
Description:

- Adds variable `sap_ha_pacemaker_cluster_saphanasr_angi_detection` that enables option to disable SAPHanaSR-angi detection to install Classic agents even on servers where Angi is available.