### PR TITLE
sap_*preconfigure: edge case handling for sles pkgs

### DIFF
--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -8,6 +8,7 @@
         name: sapconf
         state: stopped
         enabled: false
+      when: "'sapconf' in ansible_facts.packages"
 
     - name: Make sure that sapconf and tuned are stopped and disabled
       ansible.builtin.command: "saptune service takeover"

--- a/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
@@ -7,6 +7,12 @@
     name: "*"
   when: sap_hana_preconfigure_update | bool
 
+# SAP Note 2892338
+- name: Ensure package insserv-compat exists
+  ansible.builtin.package:
+    state: present
+    name: insserv-compat
+
 # -----------
 - name: Get contents of /etc/products.d/baseproduct
   ansible.builtin.stat:

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -8,6 +8,7 @@
         name: sapconf
         state: stopped
         enabled: false
+      when: "'sapconf' in ansible_facts.packages"
 
     - name: Make sure that sapconf and tuned are stopped and disabled
       ansible.builtin.command: "saptune service takeover"


### PR DESCRIPTION
For SLES, `sapconf` should be stopped but will error if the package does not exist and further errors for `hdblcm` if the base OS Image does not include `insserv-compat`.