### PR TITLE
collection: Modify for latest yamllint requirements

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,7 +7,9 @@ rules:
   brackets: {max-spaces-inside: 1, level: error}
 #  colons: {max-spaces-after: -1, level: error}
 #  commas: {max-spaces-after: -1, level: error}
-  comments: disable
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
   comments-indentation: disable
 #  document-start: disable
 #  empty-lines: {max: 3, level: error}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -19,3 +19,6 @@ rules:
 #  new-lines: {type: unix}
 #  trailing-spaces: disable
   truthy: disable
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/increase-nofile-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/increase-nofile-limits.yml
@@ -9,7 +9,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/limits.d/99-sap.conf
     create: yes
-    mode: 0644
+    mode: "0644"
     regexp: '^@sapsys\s+{{ line_item }}\s+nofile\s.*'
     line: "@sapsys\t{{ line_item }}\tnofile\t1048576"
   with_items:
@@ -26,7 +26,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/limits.d/99-sap.conf
     create: yes
-    mode: 0644
+    mode: "0644"
     regexp: '^@{{ sap_general_preconfigure_db_group_name }}\s+{{ line_item }}\s+nofile\s.*'
     line: "@{{ sap_general_preconfigure_db_group_name }}\t{{ line_item }}\tnofile\t1048576"
   with_items:

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/increase-nproc-limits.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/increase-nproc-limits.yml
@@ -9,7 +9,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/limits.d/99-sap.conf
     create: yes
-    mode: 0644
+    mode: "0644"
     regexp: '^@sapsys\s+{{ line_item }}\s+nproc\s.*'
     line: "@sapsys\t{{ line_item }}\tnproc\tunlimited"
   with_items:
@@ -26,7 +26,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/limits.d/99-sap.conf
     create: yes
-    mode: 0644
+    mode: "0644"
     regexp: '^@{{ sap_general_preconfigure_db_group_name }}\s+{{ line_item }}\s+nproc\s.*'
     line: "@{{ sap_general_preconfigure_db_group_name }}\t{{ line_item }}\tnproc\tunlimited"
   with_items:

--- a/roles/sap_hana_install/tasks/pre_install/extract_sarfile.yml
+++ b/roles/sap_hana_install/tasks/pre_install/extract_sarfile.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ __sap_hana_install_tmp_software_extract_directory }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
 

--- a/roles/sap_hana_install/tasks/pre_install/prepare_sarfiles.yml
+++ b/roles/sap_hana_install/tasks/pre_install/prepare_sarfiles.yml
@@ -52,7 +52,7 @@
         src: "{{ __sap_hana_install_fact_software_directory }}/{{ item }}"
         dest: "{{ sap_hana_install_software_extract_directory }}/sarfiles/{{ item }}"
         remote_src: true
-        mode: 0755
+        mode: "0755"
         owner: root
         group: root
       with_items: "{{ __sap_hana_install_fact_sarfiles }}"

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-cpu-governor-for-performance.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-cpu-governor-for-performance.yml
@@ -29,7 +29,7 @@
           ansible.builtin.file:
             path: /etc/rc.d/rc.local
             state: touch
-            mode: 0644
+            mode: "0644"
 
         - name: Configure CPU Governor for performance at boot time (x86_64 platform only)
           ansible.builtin.lineinfile:

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-epb.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-epb.yml
@@ -30,7 +30,7 @@
           ansible.builtin.file:
             path: /etc/init.d/boot.local
             state: touch
-            mode: 0755
+            mode: "0755"
 
         - name: Configure EPB at boot time
           ansible.builtin.lineinfile:

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-coredumps.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-coredumps.yml
@@ -8,7 +8,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/limits.d/99-sap.conf
     create: yes
-    mode: 0644
+    mode: "0644"
     regexp: '^\*\s+{{ line_item }}\s+core\s.*'
     line: "*\t{{ line_item }}\tcore\t0"
   with_items:

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-ksm.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-ksm.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: /etc/init.d/boot.local
     state: touch
-    mode: 0755
+    mode: "0755"
   when: not __sap_hana_preconfigure_register_stat_boot_local_ksm.stat.exists
 
 - name: Disable KSM at boot time

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2055470.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2055470.yml
@@ -58,7 +58,7 @@
       ansible.builtin.lineinfile:
         path: /etc/sysctl.d/ibm_largesend.conf
         create: yes
-        mode: 0644
+        mode: "0644"
         regexp: ^{{ line_item.name }}.*
         line: "{{ line_item.name }}={{ line_item.value }}"
         state: present

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2382421.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2382421.yml
@@ -15,7 +15,7 @@
       ansible.builtin.lineinfile:
         path: "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
         create: yes
-        mode: 0644
+        mode: "0644"
         regexp: ^{{ line_item.name }}.*
         line: "{{ line_item.name }}={{ line_item.value }}"
         state: present
@@ -53,7 +53,7 @@
           ansible.builtin.lineinfile:
             path: "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
             create: yes
-            mode: 0644
+            mode: "0644"
             regexp: ^net.core.wmem_max.*
             line: "net.core.wmem_max={{ __sap_hana_preconfigure_register_sysctl_ipv4_tcp_wmem.stdout.split()[-1] }}"
             state: present
@@ -62,7 +62,7 @@
           ansible.builtin.lineinfile:
             path: "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
             create: yes
-            mode: 0644
+            mode: "0644"
             regexp: ^net.core.rmem_max.*
             line: "net.core.rmem_max={{ __sap_hana_preconfigure_register_sysctl_ipv4_tcp_rmem.stdout.split()[-1] }}"
             state: present

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
@@ -66,7 +66,7 @@
 - name: "Energy Performance Bias (EPB, applies to Intel-based systems only)"
   ansible.builtin.lineinfile:
     path: /etc/init.d/boot.local
-    mode: 0744
+    mode: "0744"
     line: 'cpupower set -b 0'
     state: present
     create: yes
@@ -74,7 +74,7 @@
 - name: Kernel samepage merging (KSM)
   ansible.builtin.lineinfile:
     dest: /etc/init.d/boot.local
-    mode: 0744
+    mode: "0744"
     line: echo 0 > /sys/kernel/mm/ksm/run
     state: present
     create: yes

--- a/roles/sap_hana_preconfigure/tasks/sapnote/3024346.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/3024346.yml
@@ -17,7 +17,7 @@
       ansible.builtin.lineinfile:
         path: "{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}"
         create: yes
-        mode: 0644
+        mode: "0644"
         regexp: ^{{ line_item.name }}.*
         line: "{{ line_item.name }}={{ line_item.value }}"
         state: present
@@ -38,7 +38,7 @@
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/sunrpc.conf
         create: yes
-        mode: 0644
+        mode: "0644"
         regexp: '^options sunrpc tcp_max_slot_table_entries'
         line: options sunrpc tcp_max_slot_table_entries=128
       when: sap_hana_preconfigure_use_netapp_settings_nfsv3

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
@@ -37,7 +37,7 @@
     - name: SAP Storage Setup - (swap file) Adjust file permissions
       ansible.builtin.file:
         path: "{{ swap_file.swap_path }}"
-        mode: 0600
+        mode: "0600"
 
     - name: SAP Storage Setup - (swap file) Create and activate swap
       ansible.builtin.shell: |


### PR DESCRIPTION
ansible-lint 24.7.0 produced:

```
WARNING  Found incompatible custom yamllint configuration (.yamllint.yml), please either remove the file or edit it to comply with:
  - comments.min-spaces-from-content must be 1
  - octal-values.forbid-implicit-octal must be true
  - octal-values.forbid-explicit-octal must be true.
```

This PR ensures that the collection is yamllint clean again.

Relates to issue #810.