### PR TITLE
sap_general_preconfigure: Use FQCN for import_role

### DIFF
--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -16,7 +16,7 @@
 
 - name: Import role sap_maintain_etc_hosts
   ansible.builtin.import_role:
-    name: sap_maintain_etc_hosts
+    name: 'community.sap_install.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_general_preconfigure_ip }}"

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
@@ -16,7 +16,7 @@
 
 - name: Import role sap_maintain_etc_hosts
   ansible.builtin.import_role:
-    name: sap_maintain_etc_hosts
+    name: 'community.sap_install.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_general_preconfigure_ip }}"

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
@@ -16,7 +16,7 @@
 
 - name: Import role sap_maintain_etc_hosts
   ansible.builtin.import_role:
-    name: sap_maintain_etc_hosts
+    name: 'community.sap_install.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_general_preconfigure_ip }}"


### PR DESCRIPTION
We need to use the FQCN when importing the role sap_maintain_etc_hosts.

Solves issue #826.