### PR TITLE
sap_ha_pacemaker_cluster: Stonith SBD enablement, stonith and repos dictionaries

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -881,9 +881,11 @@ sap_ha_pacemaker_cluster_sbd_devices:
 sap_ha_pacemaker_cluster_sbd_enabled: true
 sap_ha_pacemaker_cluster_stonith_custom:
 - agent: stonith:external/sbd
-  name: rsc_stonith_sbd
-  options:
-    pcmk_delay_max: 15
+  id: stonith_sbd
+  instance_attrs:
+  - attrs:
+    - name: pcmk_delay_max
+      value: 15
 ```
 
 ### sap_ha_pacemaker_cluster_sbd_options
@@ -891,7 +893,7 @@ sap_ha_pacemaker_cluster_stonith_custom:
 - _Type:_ `list`
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
-Provide list SBD specific options that are added into SBD configuration file.<br>
+Provide list of SBD specific options that are added into SBD configuration file.<br>
 
 Example:
 
@@ -904,6 +906,7 @@ sap_ha_pacemaker_cluster_sbd_options:
 ### sap_ha_pacemaker_cluster_sbd_watchdog
 
 - _Type:_ `str`
+- _Default:_ `/dev/watchdog`
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide watchdog name to override default /dev/watchdog<br>
@@ -915,32 +918,65 @@ Provide watchdog name to override default /dev/watchdog<br>
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of watchdog kernel modules to be loaded (creates /dev/watchdog* devices).<br>
 
+Example:
+
+```yaml
+sap_ha_pacemaker_cluster_sbd_watchdog_modules:
+- softdog
+```
+
 ### sap_ha_pacemaker_cluster_stonith_custom
 
 - _Type:_ `list`
 
 Custom list of STONITH resource(s) to be configured in the cluster.<br>
 This definition override any defaults the role would apply otherwise.<br>
+Definition follows structure of ha_cluster_resource_primitives in linux-system-roles/ha_cluster<br>
 
 - **agent**<br>
     Resource agent name, must contain the prefix "stonith:" to avoid mismatches or failures.
+- **id**<br>
+    Parameter `id` is required.<br>Name that will be used as the resource ID (name).
+- **instance_attrs**<br>
+    Defines resource agent params as list of name/value pairs.<br>Requires the mandatory options for the particular stonith resource agent to be defined, otherwise the setup will fail.<br>Example: stonith:fence_sbd agent requires devices option with list of SBD disks.<br>Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`.
+- **meta_attrs**<br>
+    Defines meta attributes as list of name/value pairs.
 - **name**<br>
-    Name that will be used as the resource ID (name).
+    WARNING! This option will be removed in future release.
+- **operations**<br>
+    Defines list of resource agent operations.
 - **options**<br>
-    The resource options listed in dictionary format, one option per line.<br>Requires the mandatory options for the particular stonith resource agent to be defined, otherwise the setup will fail.<br>Example: stonith:fence_sbd agent requires devices option with list of SBD disks.<br>Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`.
+    WARNING! This option will be removed in future release.
 
 Example:
 
 ```yaml
 sap_ha_pacemaker_cluster_stonith_custom:
 - agent: stonith:fence_rhevm
+  instance_attrs:
+  - attrs:
+    - name: ip
+      value: rhevm-server
+    - name: username
+      value: login-user
+    - name: password
+      value: login-user-password
+    - name: pcmk_host_list
+      value: node1,node2
+    - name: power_wait
+      value: 3
+  meta_attrs:
+  - attrs:
+    - name: target-role
+      value: Started
   name: my-fence-resource
-  options:
-    ip: rhevm-server
-    password: login-user-password
-    pcmk_host_list: node1,node2
-    power_wait: 3
-    username: login-user
+  operations:
+  - action: start
+    attrs:
+    - name: interval
+      value: 0
+    - name: timeout
+      value: 180
 ```
 
 ### sap_ha_pacemaker_cluster_storage_definition

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -146,14 +146,18 @@ Additional minimum requirements depend on the type of cluster setup and on the t
 - _Type:_ `string`
 
 AWS access key to allow control of instances (for example for fencing operations).<br>
-Mandatory for the cluster nodes setup on AWS EC2 instances.<br>
+Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
+1. IAM Role or Instance profile is not attached to EC2 instance.<br>
+2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`<br>
 
 ### sap_ha_pacemaker_cluster_aws_credentials_setup
 
 - _Type:_ `string`
 
 Set this parameter to 'true' to store AWS credentials into /root/.aws/credentials.<br>
-Required: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`<br>
+Requires: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`<br>
+Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
+1. IAM Role or Instance profile is not attached to EC2 instance.<br>
 
 ### sap_ha_pacemaker_cluster_aws_region
 
@@ -167,7 +171,9 @@ Mandatory for cluster nodes setup on AWS EC2 instances.<br>
 - _Type:_ `string`
 
 AWS secret key, paired with the access key for instance control.<br>
-Mandatory for the cluster setup on AWS EC2 instances.<br>
+Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
+1. IAM Role or Instance profile is not attached to EC2 instance.<br>
+2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`<br>
 
 ### sap_ha_pacemaker_cluster_aws_vip_update_rt
 
@@ -953,6 +959,7 @@ Example:
 ```yaml
 sap_ha_pacemaker_cluster_stonith_custom:
 - agent: stonith:fence_rhevm
+  id: my-fence-resource
   instance_attrs:
   - attrs:
     - name: ip
@@ -969,7 +976,6 @@ sap_ha_pacemaker_cluster_stonith_custom:
   - attrs:
     - name: target-role
       value: Started
-  name: my-fence-resource
   operations:
   - action: start
     attrs:

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -365,7 +365,7 @@ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name: >-
 # sap_ha_pacemaker_cluster_aws_access_key_id
 # sap_ha_pacemaker_cluster_aws_secret_access_key
 # sap_ha_pacemaker_cluster_aws_region
-# sap_ha_pacemaker_cluster_aws_credentials_setup
+# sap_ha_pacemaker_cluster_aws_credentials_setup: false
 
 ## Google Cloud platform, Compute Engine Virtual Machines
 # sap_ha_pacemaker_cluster_gcp_project

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -365,6 +365,7 @@ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name: >-
 # sap_ha_pacemaker_cluster_aws_access_key_id
 # sap_ha_pacemaker_cluster_aws_secret_access_key
 # sap_ha_pacemaker_cluster_aws_region
+# sap_ha_pacemaker_cluster_aws_credentials_setup
 
 ## Google Cloud platform, Compute Engine Virtual Machines
 # sap_ha_pacemaker_cluster_gcp_project

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -102,12 +102,6 @@ argument_specs:
               node_ip: 192.168.5.1
             - hana_site: DC02
 
-      sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
-        type: list
-        default: ['fence-agents-all']
-        description:
-          - The minimal set of fence agent packages that will be installed.
-
       sap_ha_pacemaker_cluster_resource_defaults:
         type: dict
         default:
@@ -181,6 +175,8 @@ argument_specs:
               - The resource options listed in dictionary format, one option per line.
               - Requires the mandatory options for the particular stonith resource agent to be
                 defined, otherwise the setup will fail.
+              - "Example: stonith:fence_sbd agent requires devices option with list of SBD disks."
+              - "Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`."
             required: true
 
         example:
@@ -193,6 +189,56 @@ argument_specs:
                 password: login-user-password
                 pcmk_host_list: node1,node2
                 power_wait: 3
+
+      sap_ha_pacemaker_cluster_sbd_enabled:
+        type: bool
+        description:
+          - Set this parameter to 'true' to enable workflow to add Stonith SBD resource.
+          - Stonith SBD resource has to be provided as part of `sap_ha_pacemaker_cluster_stonith_custom`.
+          - "Default SBD agents are: stonith:external/sbd for SLES and stonith:fence_sbd for RHEL"
+
+        example:
+          sap_ha_pacemaker_cluster_sbd_enabled: true
+          sap_ha_pacemaker_cluster_stonith_custom:
+            - name: rsc_stonith_sbd
+              agent: stonith:external/sbd
+              options:
+                pcmk_delay_max: 15
+          sap_ha_pacemaker_cluster_sbd_devices:
+            - /dev/disk/by-id/scsi-3600
+
+      sap_ha_pacemaker_cluster_sbd_devices:
+        type: list
+        description:
+          - Required if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
+          - Provide list of block devices for Stonith SBD agent
+
+        example:
+          sap_ha_pacemaker_cluster_sbd_devices:
+            - /dev/disk/by-id/scsi-3600
+
+      sap_ha_pacemaker_cluster_sbd_options:
+        type: list
+        description:
+          - Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
+          - Provide list SBD specific options that are added into SBD configuration file.
+
+        example:
+          sap_ha_pacemaker_cluster_sbd_options:
+            - name: startmode
+              value: clean
+
+      sap_ha_pacemaker_cluster_sbd_watchdog:
+        type: str
+        description:
+          - Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
+          - Provide watchdog name to override default /dev/watchdog
+
+      sap_ha_pacemaker_cluster_sbd_watchdog_modules:
+        type: list
+        description:
+          - Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
+          - Provide list of watchdog kernel modules to be loaded (creates /dev/watchdog* devices).
 
       sap_ha_pacemaker_cluster_cluster_properties:
         type: dict
@@ -251,7 +297,9 @@ argument_specs:
         type: list
         description:
           - Additional fence agent packages to be installed.
-          - This is automatically combined with `sap_ha_pacemaker_cluster_fence_agent_minimal_packages`.
+          - "This is automatically combined with default packages in:"
+          - "`__sap_ha_pacemaker_cluster_fence_agent_packages_minimal`"
+          - "`__sap_ha_pacemaker_cluster_fence_agent_packages_platform`"
 
       sap_ha_pacemaker_cluster_hacluster_user_password:
         description:
@@ -321,7 +369,7 @@ argument_specs:
         default: "msl_SAPHana_<SID>_HDB<Instance Number>"
         description:
           - Customize the cluster resource name of the SAP HANA DB resource master slave clone.
-          - Master Slave clone is specific to SAPHana resource on SUSE.
+          - Master Slave clone is specific to Classic SAPHana resource on SUSE (non-angi).
 
       sap_ha_pacemaker_cluster_hanacontroller_resource_name:
         default: "rsc_SAPHanaCon_<SID>_HDB<Instance Number>"
@@ -798,6 +846,10 @@ argument_specs:
           - AWS secret key, paired with the access key for instance control.
           - Mandatory for the cluster setup on AWS EC2 instances.
 
+      sap_ha_pacemaker_cluster_aws_credentials_setup:
+        description:
+          - Set this parameter to 'true' to store AWS credentials into /root/.aws/credentials.
+          - "Required: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`"
 
       ##########################################################################
       # Platforms: GCP specific parameters

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -164,34 +164,49 @@ argument_specs:
         elements: dict
         options:
           id:
+            type: str
             description:
+              - Parameter `id` is required.
               - Name that will be used as the resource ID (name).
-            required: true
+            # TODO: Enable to remove Tech debt after name and options are removed!
+            # required: true
           agent:
+            type: str
             description:
               - Resource agent name, must contain the prefix "stonith:" to avoid mismatches or failures.
             required: true
-          instance_attrs.attrs:
+          instance_attrs:
+            type: list
             description:
               - Defines resource agent params as list of name/value pairs.
               - Requires the mandatory options for the particular stonith resource agent to be
                 defined, otherwise the setup will fail.
               - "Example: stonith:fence_sbd agent requires devices option with list of SBD disks."
               - "Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`."
-            required: true
           operations:
+            type: list
             description:
               - Defines list of resource agent operations.
             action:
               description:
                 - Name of resource agent operation.
-              required: true
             attrs:
               description:
                 - Defines operation parameters as list of name/value pairs.
-          meta_attrs.attrs:
+          meta_attrs:
+            type: list
             description:
               - Defines meta attributes as list of name/value pairs.
+          # TODO: Tech Debt: Remove name and options in next release
+          name:
+            type: str
+            description:
+              - WARNING! This option will be removed in future release.
+          # TODO: Tech Debt: Remove name and options in next release
+          options:
+            type: dict
+            description:
+              - WARNING! This option will be removed in future release.
 
         example:
           sap_ha_pacemaker_cluster_stonith_custom:

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -210,7 +210,7 @@ argument_specs:
 
         example:
           sap_ha_pacemaker_cluster_stonith_custom:
-            - name: "my-fence-resource"
+            - id: "my-fence-resource"
               agent: "stonith:fence_rhevm"
               instance_attrs:
                 - attrs:
@@ -892,17 +892,23 @@ argument_specs:
       sap_ha_pacemaker_cluster_aws_access_key_id:
         description:
           - AWS access key to allow control of instances (for example for fencing operations).
-          - Mandatory for the cluster nodes setup on AWS EC2 instances.
+          - "Mandatory for the cluster nodes setup on AWS EC2 instances, when:"
+          - "1. IAM Role or Instance profile is not attached to EC2 instance."
+          - "2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`"
 
       sap_ha_pacemaker_cluster_aws_secret_access_key:
         description:
           - AWS secret key, paired with the access key for instance control.
-          - Mandatory for the cluster setup on AWS EC2 instances.
+          - "Mandatory for the cluster nodes setup on AWS EC2 instances, when:"
+          - "1. IAM Role or Instance profile is not attached to EC2 instance."
+          - "2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`"
 
       sap_ha_pacemaker_cluster_aws_credentials_setup:
         description:
           - Set this parameter to 'true' to store AWS credentials into /root/.aws/credentials.
-          - "Required: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`"
+          - "Requires: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`"
+          - "Mandatory for the cluster nodes setup on AWS EC2 instances, when:"
+          - "1. IAM Role or Instance profile is not attached to EC2 instance."
 
       ##########################################################################
       # Platforms: GCP specific parameters

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -160,9 +160,10 @@ argument_specs:
         description:
           - Custom list of STONITH resource(s) to be configured in the cluster.
           - This definition override any defaults the role would apply otherwise.
+          - Definition follows structure of ha_cluster_resource_primitives in linux-system-roles/ha_cluster
         elements: dict
         options:
-          name:
+          id:
             description:
               - Name that will be used as the resource ID (name).
             required: true
@@ -170,25 +171,55 @@ argument_specs:
             description:
               - Resource agent name, must contain the prefix "stonith:" to avoid mismatches or failures.
             required: true
-          options:
+          instance_attrs.attrs:
             description:
-              - The resource options listed in dictionary format, one option per line.
+              - Defines resource agent params as list of name/value pairs.
               - Requires the mandatory options for the particular stonith resource agent to be
                 defined, otherwise the setup will fail.
               - "Example: stonith:fence_sbd agent requires devices option with list of SBD disks."
               - "Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`."
             required: true
+          operations:
+            description:
+              - Defines list of resource agent operations.
+            action:
+              description:
+                - Name of resource agent operation.
+              required: true
+            attrs:
+              description:
+                - Defines operation parameters as list of name/value pairs.
+          meta_attrs.attrs:
+            description:
+              - Defines meta attributes as list of name/value pairs.
 
         example:
           sap_ha_pacemaker_cluster_stonith_custom:
             - name: "my-fence-resource"
               agent: "stonith:fence_rhevm"
-              options:
-                ip: rhevm-server
-                username: login-user
-                password: login-user-password
-                pcmk_host_list: node1,node2
-                power_wait: 3
+              instance_attrs:
+                - attrs:
+                    - name: ip
+                      value: rhevm-server
+                    - name: username
+                      value: login-user
+                    - name: password
+                      value: login-user-password
+                    - name: pcmk_host_list
+                      value: node1,node2
+                    - name: power_wait
+                      value: 3
+              meta_attrs:
+                - attrs:
+                    - name: target-role
+                      value: Started
+              operations:
+                - action: start
+                  attrs:
+                    - name: interval
+                      value: 0
+                    - name: timeout
+                      value: 180
 
       sap_ha_pacemaker_cluster_sbd_enabled:
         type: bool
@@ -200,10 +231,12 @@ argument_specs:
         example:
           sap_ha_pacemaker_cluster_sbd_enabled: true
           sap_ha_pacemaker_cluster_stonith_custom:
-            - name: rsc_stonith_sbd
+            - id: stonith_sbd
               agent: stonith:external/sbd
-              options:
-                pcmk_delay_max: 15
+              instance_attrs:
+                - attrs:
+                    - name: pcmk_delay_max
+                      value: 15
           sap_ha_pacemaker_cluster_sbd_devices:
             - /dev/disk/by-id/scsi-3600
 
@@ -221,7 +254,7 @@ argument_specs:
         type: list
         description:
           - Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
-          - Provide list SBD specific options that are added into SBD configuration file.
+          - Provide list of SBD specific options that are added into SBD configuration file.
 
         example:
           sap_ha_pacemaker_cluster_sbd_options:
@@ -230,6 +263,7 @@ argument_specs:
 
       sap_ha_pacemaker_cluster_sbd_watchdog:
         type: str
+        default: /dev/watchdog
         description:
           - Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
           - Provide watchdog name to override default /dev/watchdog
@@ -239,6 +273,10 @@ argument_specs:
         description:
           - Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
           - Provide list of watchdog kernel modules to be loaded (creates /dev/watchdog* devices).
+
+        example:
+          sap_ha_pacemaker_cluster_sbd_watchdog_modules:
+            - softdog
 
       sap_ha_pacemaker_cluster_cluster_properties:
         type: dict

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
@@ -29,6 +29,18 @@
 # __sap_ha_pacemaker_cluster_resource_primitives    ha_cluster_resource_primitives
 # __sap_ha_pacemaker_cluster_corosync_totem                  ha_cluster_totem
 
+# Combines SBD stonith options with ha_cluster if it was not imported as extra var.
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Include SBD config into 'ha_cluster'"  # noqa jinja[spacing]
+  when:
+    - __sap_ha_pacemaker_cluster_ha_cluster_stonith is defined and __sap_ha_pacemaker_cluster_ha_cluster_stonith | length > 0
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_ha_cluster: >-
+      {%- if __sap_ha_pacemaker_cluster_ha_cluster is defined and __sap_ha_pacemaker_cluster_ha_cluster | length > 0 -%}
+      {{ __sap_ha_pacemaker_cluster_ha_cluster | combine(__sap_ha_pacemaker_cluster_ha_cluster_stonith) }}
+      {%- else -%}
+      {{ __sap_ha_pacemaker_cluster_ha_cluster_stonith }}
+      {%- endif -%}
+
 - name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster'"
   when: __sap_ha_pacemaker_cluster_ha_cluster is defined
   ansible.builtin.set_fact:
@@ -110,3 +122,13 @@
   when: __sap_ha_pacemaker_cluster_corosync_totem is defined
   ansible.builtin.set_fact:
     ha_cluster_totem: "{{ __sap_ha_pacemaker_cluster_corosync_totem }}"
+
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_options'"
+  when: __sap_ha_pacemaker_cluster_sbd_options is defined
+  ansible.builtin.set_fact:
+    ha_cluster_sbd_options: "{{ __sap_ha_pacemaker_cluster_sbd_options }}"
+
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_enabled'"
+  when: __sap_ha_pacemaker_cluster_sbd_enabled is defined
+  ansible.builtin.set_fact:
+    ha_cluster_sbd_enabled: "{{ __sap_ha_pacemaker_cluster_sbd_enabled }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -22,7 +22,25 @@
     __sap_ha_pacemaker_cluster_hacluster_user_password: "{{ sap_ha_pacemaker_cluster_hacluster_user_password }}"
   no_log: true  # secure the credential
 
+# sap_ha_pacemaker_cluster_ha_cluster   -> user-defined or default inherited from {{ ha_cluster }}
+- name: "SAP HA Prepare Pacemaker - Register sap_ha_pacemaker_cluster_ha_cluster"
+  when:
+    - __sap_ha_pacemaker_cluster_ha_cluster is not defined
+    - sap_ha_pacemaker_cluster_ha_cluster is defined
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_ha_cluster: "{{ sap_ha_pacemaker_cluster_ha_cluster }}"
 
+- name: "SAP HA Prepare Pacemaker - Generate default sap_ha_pacemaker_cluster_ha_cluster"
+  when:
+    - not __sap_ha_pacemaker_cluster_ha_cluster is defined
+    - not sap_ha_pacemaker_cluster_ha_cluster is defined
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_ha_cluster:
+      node_name: "{{ ansible_hostname }}"
+      pcs_address: "{{ ansible_default_ipv4.address }}"
+
+
+# Combine following extra packages together:
 # sap_ha_pacemaker_cluster_extra_packages             -> user-defined, empty by global default
 # __sap_ha_pacemaker_cluster_sap_extra_packages       -> included from vars/*
 # __sap_ha_pacemaker_cluster_platform_extra_packages  -> included from vars/platform*
@@ -36,17 +54,32 @@
       | unique | select() }}"
   # remove duplicates and empty elements
 
-# sap_ha_pacemaker_cluster_fence_agent_minimal_packages -> global default
-# sap_ha_pacemaker_cluster_fence_agent_packages         -> global default
-# __sap_ha_pacemaker_cluster_fence_agent_packages       -> internal default (vars/main.yml)
 
+# Combine following fence packages together:
+# __sap_ha_pacemaker_cluster_fence_agent_packages_minimal -> os default
+# __sap_ha_pacemaker_cluster_fence_agent_packages_platform -> platform defaults from dict
+# sap_ha_pacemaker_cluster_fence_agent_packages         -> user input or default []
+
+# __sap_ha_pacemaker_cluster_fence_agent_packages loaded from ha_cluster is not included,
+# because it would still not be used due to precedence.
+# TODO: Remove Tech debt conditionals in future.
 - name: "SAP HA Prepare Pacemaker - Combine fence agent packages lists"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_fence_agent_packages: "{{
-      (sap_ha_pacemaker_cluster_fence_agent_minimal_packages
-      + sap_ha_pacemaker_cluster_fence_agent_packages
-      + __sap_ha_pacemaker_cluster_fence_agent_packages)
+      (__sap_ha_pacemaker_cluster_fence_agent_packages_minimal_combined
+      + __sap_ha_pacemaker_cluster_fence_agent_packages_platform
+      + sap_ha_pacemaker_cluster_fence_agent_packages)
       | unique }}"
+  vars:
+    # Tech debt for sap_ha_pacemaker_cluster_fence_agent_minimal_packages
+    __sap_ha_pacemaker_cluster_fence_agent_packages_minimal_combined:
+      "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_minimal
+       + sap_ha_pacemaker_cluster_fence_agent_minimal_packages
+        if (sap_ha_pacemaker_cluster_fence_agent_minimal_packages is defined
+          and sap_ha_pacemaker_cluster_fence_agent_minimal_packages | length > 0
+          and sap_ha_pacemaker_cluster_fence_agent_minimal_packages is iterable)
+        else __sap_ha_pacemaker_cluster_fence_agent_packages_minimal }}"
+
 
 # Prepare corosync totem variable with either:
 # - User provided sap_ha_pacemaker_cluster_corosync_totem if present

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -62,7 +62,7 @@
 
 # __sap_ha_pacemaker_cluster_fence_agent_packages loaded from ha_cluster is not included,
 # because it would still not be used due to precedence.
-# TODO: Remove Tech debt conditionals in future.
+# TODO: Remove Tech debt conditionals in future for deprecated var 'sap_ha_pacemaker_cluster_fence_agent_minimal_packages'
 - name: "SAP HA Prepare Pacemaker - Combine fence agent packages lists"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_fence_agent_packages: "{{

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -89,13 +89,11 @@
           {{ attrs }}
 
 
-# Combine the default stonith resource config from
-# - assembled pcmk_host_map
-#   (see platform tasks: __sap_ha_pacemaker_cluster_pcmk_host_map)
-# - fence agent specific required options
-#   (see platform vars: __sap_ha_pacemaker_cluster_stonith_default)
-# - generic pacemaker fence resource options
-#   (see defaults: sap_ha_pacemaker_cluster_fence_options)
+# Prepare default stonith method based on __sap_ha_pacemaker_cluster_stonith_default loaded
+# from platform __sap_ha_pacemaker_cluster_stonith_default_dict dictionary.
+# Resulting primitive stonith resource is combination of:
+# 1. platform specific default: id, agent and options
+# 2. pcmk_host_map: string of hosts assembled in include_vars_platform
 
 # Note: the 'ha_cluster' LSR only calls the stonith creation for ONE host
 #       -> the definition must contain the resources for all hosts, if multiple
@@ -106,51 +104,16 @@
     - __sap_ha_pacemaker_cluster_stonith_default | length > 0
     - sap_ha_pacemaker_cluster_stonith_custom is not defined
       or sap_ha_pacemaker_cluster_stonith_custom | length == 0
-    - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([])| map(attribute='id'))
+    - (hostvars[stonith_host_item].__sap_ha_pacemaker_cluster_stonith_default).id
+     not in (__sap_ha_pacemaker_cluster_stonith_resource | default([])| map(attribute='id'))
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [__stonith_resource_element] }}"
-  vars:
-    __stonith_resource_element:
-      id: "{{ __sap_ha_pacemaker_cluster_stonith_default.id + __plug_suffix }}"
-      agent: "{{ __sap_ha_pacemaker_cluster_stonith_default.agent }}"
-      instance_attrs:
-        - attrs: >-
-            {% set attrs = [] -%}
-            {% if __sap_ha_pacemaker_cluster_pcmk_host_map | length > 0 -%}
-              {% set map = attrs.extend([
-                {
-                  'name': 'pcmk_host_map',
-                  'value': __sap_ha_pacemaker_cluster_pcmk_host_map
-                }]) -%}
-            {%- else -%}
-              {% set map = attrs.extend([
-                {
-                  'name': 'plug',
-                  'value': stonith_host_item
-                }]) -%}
-            {%- endif %}
-            {%- if __sap_ha_pacemaker_cluster_stonith_default.options is defined
-                and __sap_ha_pacemaker_cluster_stonith_default.options | length > 0 -%}
-              {%- for agent_opt in (__sap_ha_pacemaker_cluster_stonith_default.options | default({}) | dict2items) -%}
-                {% set aopts = attrs.extend([
-                  {
-                    'name': agent_opt.key,
-                    'value': agent_opt.value
-                  }]) -%}
-              {%- endfor %}
-            {%- endif -%}
-            {{ attrs }}
-
-    __plug_suffix: >-
-      {%- if __sap_ha_pacemaker_cluster_pcmk_host_map | length == 0 -%}
-        _{{ stonith_host_item }}
-      {%- else %}{% endif -%}
-
+    __sap_ha_pacemaker_cluster_stonith_resource:
+      "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([])
+       + [hostvars[stonith_host_item].__sap_ha_pacemaker_cluster_stonith_default] }}"
   loop: "{{ ansible_play_hosts_all }}"
   loop_control:
     loop_var: stonith_host_item
     label: "{{ stonith_host_item }}"
-
 
 # Requirements to run SBD block:
 # sap_ha_pacemaker_cluster_sbd_enabled is true
@@ -247,6 +210,8 @@
         __sap_ha_pacemaker_cluster_sbd_enabled: true
 
 
+# sap_ha_pacemaker_cluster_stonith_custom input was redesigned to use ha_cluster structure.
+# Following task will remain until next release to ensure compatibility with previous structure.
 - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
   when:
     - sap_ha_pacemaker_cluster_stonith_custom is defined

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -21,17 +21,17 @@
       or
       (
         sap_ha_pacemaker_cluster_stonith_custom is not defined
-        and sap_ha_pacemaker_cluster_stonith_default is defined
+        and __sap_ha_pacemaker_cluster_stonith_default is defined
         and
         (
-          sap_ha_pacemaker_cluster_stonith_default == ''
-          or sap_ha_pacemaker_cluster_stonith_default | length == 0
+          __sap_ha_pacemaker_cluster_stonith_default == ''
+          or __sap_ha_pacemaker_cluster_stonith_default | length == 0
         )
       )
       or
       (
         sap_ha_pacemaker_cluster_stonith_custom is not defined
-        and sap_ha_pacemaker_cluster_stonith_default is not defined
+        and __sap_ha_pacemaker_cluster_stonith_default is not defined
       )
   block:
 
@@ -59,9 +59,9 @@
   ansible.builtin.set_fact:
     sap_ha_pacemaker_cluster_cluster_properties:
       "{{ sap_ha_pacemaker_cluster_cluster_properties | combine({'priority-fencing-delay':
-          sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max | int * 2})
-        if sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max is defined
-        and sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max | int != 0
+          __sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max | int * 2})
+        if __sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max is defined
+        and __sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max | int != 0
         else sap_ha_pacemaker_cluster_cluster_properties }}"
 
 - name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
@@ -88,11 +88,12 @@
           {%- endfor %}
           {{ attrs }}
 
+
 # Combine the default stonith resource config from
 # - assembled pcmk_host_map
 #   (see platform tasks: __sap_ha_pacemaker_cluster_pcmk_host_map)
 # - fence agent specific required options
-#   (see platform vars: sap_ha_pacemaker_cluster_stonith_default)
+#   (see platform vars: __sap_ha_pacemaker_cluster_stonith_default)
 # - generic pacemaker fence resource options
 #   (see defaults: sap_ha_pacemaker_cluster_fence_options)
 
@@ -101,16 +102,17 @@
 
 - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resource definition from platform default"
   when:
-    - sap_ha_pacemaker_cluster_stonith_default is defined
-    - sap_ha_pacemaker_cluster_stonith_default | length > 0
+    - __sap_ha_pacemaker_cluster_stonith_default is defined
+    - __sap_ha_pacemaker_cluster_stonith_default | length > 0
     - sap_ha_pacemaker_cluster_stonith_custom is not defined
+      or sap_ha_pacemaker_cluster_stonith_custom | length == 0
     - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([])| map(attribute='id'))
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [__stonith_resource_element] }}"
   vars:
     __stonith_resource_element:
-      id: "{{ sap_ha_pacemaker_cluster_stonith_default.id + __plug_suffix }}"
-      agent: "{{ sap_ha_pacemaker_cluster_stonith_default.agent }}"
+      id: "{{ __sap_ha_pacemaker_cluster_stonith_default.id + __plug_suffix }}"
+      agent: "{{ __sap_ha_pacemaker_cluster_stonith_default.agent }}"
       instance_attrs:
         - attrs: >-
             {% set attrs = [] -%}
@@ -127,9 +129,9 @@
                   'value': stonith_host_item
                 }]) -%}
             {%- endif %}
-            {%- if sap_ha_pacemaker_cluster_stonith_default.options is defined
-                and sap_ha_pacemaker_cluster_stonith_default.options | length > 0 -%}
-              {%- for agent_opt in (sap_ha_pacemaker_cluster_stonith_default.options | default({}) | dict2items) -%}
+            {%- if __sap_ha_pacemaker_cluster_stonith_default.options is defined
+                and __sap_ha_pacemaker_cluster_stonith_default.options | length > 0 -%}
+              {%- for agent_opt in (__sap_ha_pacemaker_cluster_stonith_default.options | default({}) | dict2items) -%}
                 {% set aopts = attrs.extend([
                   {
                     'name': agent_opt.key,
@@ -150,15 +152,114 @@
     label: "{{ stonith_host_item }}"
 
 
+# Requirements to run SBD block:
+# sap_ha_pacemaker_cluster_sbd_enabled is true
+# sap_ha_pacemaker_cluster_sbd_devices is defined, list and not empty
+# sap_ha_pacemaker_cluster_stonith_custom is defined, list and not empty
+# __sap_ha_pacemaker_cluster_sbd_enabled is not defined
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Prepare SBD configuration"
+  when:
+    - sap_ha_pacemaker_cluster_sbd_enabled is defined
+     and sap_ha_pacemaker_cluster_sbd_enabled
+    - sap_ha_pacemaker_cluster_sbd_devices is defined
+     and sap_ha_pacemaker_cluster_sbd_devices | length > 0
+     and sap_ha_pacemaker_cluster_sbd_devices is iterable
+     and sap_ha_pacemaker_cluster_sbd_devices is not string
+    - sap_ha_pacemaker_cluster_stonith_custom is defined
+     and sap_ha_pacemaker_cluster_stonith_custom | length > 0
+     and sap_ha_pacemaker_cluster_stonith_custom is iterable
+     and sap_ha_pacemaker_cluster_stonith_custom is not string
+    - __sap_ha_pacemaker_cluster_sbd_enabled is not defined
+  block:
+    # Create sbd_options for ha_cluster_sbd_options when
+    # ha_cluster_sbd_options is not defined or it is empty or not List
+    # ha_cluster_sbd_options is defined but it does not contain required startmode
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create sbd_options"
+      when:
+        - not sap_ha_pacemaker_cluster_sbd_options is defined
+          or sap_ha_pacemaker_cluster_sbd_options | length == 0
+          or not sap_ha_pacemaker_cluster_sbd_options is iterable
+          or (sap_ha_pacemaker_cluster_sbd_options is defined
+           and sap_ha_pacemaker_cluster_sbd_options | selectattr('name', 'equalto', 'startmode') | list | length == 0)
+        # Skip if startmode is already present
+        - not (sap_ha_pacemaker_cluster_sbd_options is defined
+            and sap_ha_pacemaker_cluster_sbd_options | selectattr('name', 'equalto', 'startmode') | list | length > 0)
+        # Skip if ha_cluster_sbd_options are provided
+        - __sap_ha_pacemaker_cluster_sbd_options is not defined
+          or __sap_ha_pacemaker_cluster_sbd_options | length == 0
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_sbd_options: >-
+          {%- if sap_ha_pacemaker_cluster_sbd_options is defined
+           and (sap_ha_pacemaker_cluster_sbd_options | selectattr('name', 'equalto', 'startmode') | list | length == 0) -%}
+            {{ sap_ha_pacemaker_cluster_sbd_options + [{'name': 'startmode', 'value': __sbd_startmode}]}}
+          {%- else -%}
+            {{ [{'name': 'startmode', 'value': __sbd_startmode}] }}
+          {%- endif -%}
+      vars:
+        __sbd_startmode: "{{ 'clean' if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0 else 'always' }}"
+
+
+    # Create dictionary with SBD specific parameters for ha_cluster
+    # Omit parameters if they are already present in provided dictionary sap_ha_pacemaker_cluster_ha_cluster
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
+          {{
+            dict(
+              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices if sap_ha_pacemaker_cluster_sbd_devices is defined
+                and sap_ha_pacemaker_cluster_sbd_devices | length > 0 and not __sap_ha_pacemaker_cluster_ha_cluster_sbd_devices_exists
+                else omit),
+              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog if sap_ha_pacemaker_cluster_sbd_watchdog is defined
+                and sap_ha_pacemaker_cluster_sbd_watchdog | length > 0 and not __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_exists
+                else omit),
+              sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
+                if sap_ha_pacemaker_cluster_sbd_watchdog_modules is defined
+                and sap_ha_pacemaker_cluster_sbd_watchdog_modules | length > 0
+                and not __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_modules_exists
+                else omit)
+            )
+          }}
+      vars:
+        # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
+        __sap_ha_pacemaker_cluster_ha_cluster_sbd_devices_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster is defined
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices is defined
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | length > 0
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices is iterable else false }}"
+        __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster is defined
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog is defined
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | length > 0 else false }}"
+        __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_modules_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster is defined
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules is defined
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | length > 0
+           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules is iterable else false }}"
+
+
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_fence_agent_packages:
+          "{{ __sap_ha_pacemaker_cluster_fence_agent_packages + ['sbd'] }}"
+
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set __sap_ha_pacemaker_cluster_sbd_enabled"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_sbd_enabled: true
+
+
 - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
   when:
     - sap_ha_pacemaker_cluster_stonith_custom is defined
+     and sap_ha_pacemaker_cluster_stonith_custom | length > 0
+     and sap_ha_pacemaker_cluster_stonith_custom is iterable
+     and sap_ha_pacemaker_cluster_stonith_custom is not string
     - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([]) | map(attribute='id'))
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [__stonith_resource_element] }}"
   vars:
     __stonith_resource_element:
-      id: "res_{{ item.name }}"
+      # Ensure that resource name conforms with naming convention rsc_
+      id: "{{ item.name if item.name.startswith('rsc_') else 'rsc_' ~ item.name }}"  # "rsc_{{ item.name }}"
       agent: "{{ item.agent }}"
       instance_attrs:
         - attrs: |-

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -91,12 +91,6 @@
 
 # Prepare default stonith method based on __sap_ha_pacemaker_cluster_stonith_default loaded
 # from platform __sap_ha_pacemaker_cluster_stonith_default_dict dictionary.
-# Resulting primitive stonith resource is combination of:
-# 1. platform specific default: id, agent and options
-# 2. pcmk_host_map: string of hosts assembled in include_vars_platform
-
-# Note: the 'ha_cluster' LSR only calls the stonith creation for ONE host
-#       -> the definition must contain the resources for all hosts, if multiple
 
 - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resource definition from platform default"
   when:
@@ -212,24 +206,30 @@
 
 # sap_ha_pacemaker_cluster_stonith_custom input was redesigned to use ha_cluster structure.
 # Following task will remain until next release to ensure compatibility with previous structure.
-- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
+
+# TODO: Remove Tech debt task in future release, once options and name are no longer supported.
+- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition - Legacy"
   when:
     - sap_ha_pacemaker_cluster_stonith_custom is defined
-     and sap_ha_pacemaker_cluster_stonith_custom | length > 0
-     and sap_ha_pacemaker_cluster_stonith_custom is iterable
-     and sap_ha_pacemaker_cluster_stonith_custom is not string
+      and sap_ha_pacemaker_cluster_stonith_custom | length > 0
+      and sap_ha_pacemaker_cluster_stonith_custom is iterable
+      and sap_ha_pacemaker_cluster_stonith_custom is not string
+    # Tech Debt: Execute only if name and options are provided, previously required parameters.
+    - stonith_item.name is defined and stonith_item.name | length > 0
+      and stonith_item.options is defined and stonith_item.options | length > 0
+    # Keep following conditional after removing Tech Debt
     - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([]) | map(attribute='id'))
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [__stonith_resource_element] }}"
   vars:
     __stonith_resource_element:
       # Ensure that resource name conforms with naming convention rsc_
-      id: "{{ item.name if item.name.startswith('rsc_') else 'rsc_' ~ item.name }}"  # "rsc_{{ item.name }}"
-      agent: "{{ item.agent }}"
+      id: "{{ stonith_item.name if stonith_item.name.startswith('rsc_') else 'rsc_' ~ stonith_item.name }}"  # "rsc_{{ stonith_item.name }}"
+      agent: "{{ stonith_item.agent }}"
       instance_attrs:
         - attrs: |-
             {% set attrs = [] -%}
-            {%- for option in (item.options | dict2items) -%}
+            {%- for option in (stonith_item.options | dict2items) -%}
               {% set aopts = attrs.extend([
                 {
                   'name': option.key,
@@ -240,7 +240,25 @@
             {{ attrs }}
   loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
   loop_control:
-    label: "{{ item.name }}"
+    label: "{{ stonith_item.name if stonith_item.name is defined else stonith_item.id }}"
+    loop_var: stonith_item
+
+
+- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom is defined
+     and sap_ha_pacemaker_cluster_stonith_custom | length > 0
+     and sap_ha_pacemaker_cluster_stonith_custom is iterable
+     and sap_ha_pacemaker_cluster_stonith_custom is not string
+    - stonith_item.id is defined and stonith_item.id | length > 0
+    - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([]) | map(attribute='id'))
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_stonith_resource:
+      "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [stonith_item] }}"
+  loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
+  loop_control:
+    label: "{{ stonith_item.name if stonith_item.name is defined else stonith_item.id }}"
+    loop_var: stonith_item
 
 
 # The STONITH resource is an element in the cluster_resource_primitives list
@@ -254,4 +272,4 @@
         +
         (__sap_ha_pacemaker_cluster_stonith_resource | from_yaml)
       }}
-  no_log: true  # stonith resources usually contain secrets
+  no_log: true  # stonith resources can contain secrets

--- a/roles/sap_ha_pacemaker_cluster/tasks/import_hacluster_vars_from_inventory.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/import_hacluster_vars_from_inventory.yml
@@ -101,3 +101,18 @@
   when: ha_cluster_totem is defined
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_corosync_totem: "{{ ha_cluster_totem }}"
+
+# ha_cluster_sbd_options
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Register parameter 'ha_cluster_sbd_options'"
+  when:
+    - ha_cluster_sbd_options is defined
+     and ha_cluster_sbd_options | length > 0
+     and ha_cluster_sbd_options is iterable
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_sbd_options: "{{ ha_cluster_sbd_options }}"
+
+# ha_cluster_sbd_enabled
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Register parameter 'ha_cluster_sbd_enabled'"
+  when: ha_cluster_sbd_enabled is defined and ha_cluster_sbd_enabled | bool
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_sbd_enabled: "{{ ha_cluster_sbd_enabled }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_aws_ec2_vs.yml
@@ -20,7 +20,16 @@
     owner: root
     path: /root/.aws/config
 
+# New variable to disable default saving of AWS credentials file.
+# Reason: It overrides attached IAM Role or IAM Instance Profile.
 - name: "SAP HA Prepare Pacemaker - AWS EC2 VS - Store awscli credentials"
+  when:
+    - sap_ha_pacemaker_cluster_aws_credentials_setup is defined
+      and sap_ha_pacemaker_cluster_aws_credentials_setup
+    - sap_ha_pacemaker_cluster_aws_access_key_id is defined
+      and sap_ha_pacemaker_cluster_aws_access_key_id | length > 0
+    - sap_ha_pacemaker_cluster_aws_secret_access_key is defined
+      and sap_ha_pacemaker_cluster_aws_secret_access_key | length > 0
   ansible.builtin.blockinfile:
     backup: true
     block: |

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_aws_ec2_vs.yml
@@ -41,3 +41,20 @@
     owner: root
     path: /root/.aws/credentials
   no_log: true
+
+# Notification about dependency on IAM Attachment if
+# sap_ha_pacemaker_cluster_aws_credentials_setup is not set to true
+- name: "SAP HA Prepare Pacemaker - AWS EC2 VS - awscli credentials warning"
+  when:
+    - sap_ha_pacemaker_cluster_aws_credentials_setup is not defined
+     or (sap_ha_pacemaker_cluster_aws_credentials_setup is defined
+      and not sap_ha_pacemaker_cluster_aws_credentials_setup)
+  ansible.builtin.debug:
+    msg: "{{ __awscli_message.splitlines() }}"
+  vars:
+    __awscli_message: |
+      Notification: AWS CLI credentials were not stored because the variable
+      sap_ha_pacemaker_cluster_aws_credentials_setup is not defined or it is not true.
+
+      Please ensure that your instances have IAM Role or Instance Profile attached, per AWS documentation
+      You can ignore this message if provisioning was completed using community.sap_infrastructure.

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -31,6 +31,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
     agent: "stonith:fence_aws"
     instance_attrs:
       - attrs:
+          # String of cluster hosts defined in include_vars_platform
           - name: pcmk_host_map
             value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_delay_max
@@ -69,6 +70,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
     agent: "stonith:fence_aws"
     instance_attrs:
       - attrs:
+          # String of cluster hosts defined in include_vars_platform
           - name: pcmk_host_map
             value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_delay_max

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -4,37 +4,57 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws | default([]) }}"
+# Package definition
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform:
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws_ec2_vs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws_ec2_vs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
-    name: High Availability
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_aws_ec2_vs | default([]) }}"
 
-# Predefine
-__sap_ha_pacemaker_cluster_aws_instances: []
 
-# When aws credentials and region are not defined it will
-# default to using the aws cli configuration.
-# The aws cli is currently configured anyway for the standard AWS VIP resource.
-sap_ha_pacemaker_cluster_stonith_default:
-  id: "rsc_fence_aws"
-  # SUSE officially supports only stonith:external/ec2 for AWS.
-  agent: "{{ 'stonith:fence_aws' if ansible_os_family != 'Suse' else 'stonith:external/ec2' }}"
-  options:
-    # Fencing action delay is recommended. Default: 0
-    pcmk_delay_max: "{{ 0 if ansible_os_family != 'Suse' else 15 }}"
-#    access_key: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
-#    secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
-#    region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
+# Stonith dictionary for default stonith agents.
+# Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  fence_aws:
+    id: "rsc_fence_aws"
+    # AWS Fence agent is not recommended.
+    agent: "stonith:fence_aws"
+    options:
+      # Fencing action delay is recommended. Default: 0
+      # Production pcmk_delay_max is recommended 30-60
+      pcmk_delay_max: 15
+      # AWS Credentials are not defined here, because they override attached
+      # IAM Role or IAM Instance Profile
+      # access_key: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
+      # secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
+      # region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
+
+  external_ec2:
+    id: "rsc_fence_aws"
+    # SUSE Recommends stonith:external/ec2 instead of fence_aws
+    agent: "stonith:external/ec2"
+    options:
+      # Fencing action delay is recommended. Default: 0
+      # Production pcmk_delay_max is recommended 30-60
+      pcmk_delay_max: 15
+      tag: pacemaker  # tag instance with pacemaker: {{ ansible_hostname }}
+      # profile: default  # Additional tag to use awscli config
+
+# Select __sap_ha_pacemaker_cluster_stonith_default
+# SUSE does not support stonith:fence_aws
+__sap_ha_pacemaker_cluster_stonith_default:
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.external_ec2 if ansible_os_family == 'Suse'
+   else __sap_ha_pacemaker_cluster_stonith_default_dict.fence_aws }}"
+
 
 # Default corosync options - Platform specific
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
   options:
     token: 30000
+
 
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: aws_vpc_move_ip

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -17,37 +17,165 @@ __sap_ha_pacemaker_cluster_repos:
 
 # Stonith dictionary for default stonith agents.
 # Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
-__sap_ha_pacemaker_cluster_stonith_default_dict:
-  fence_aws:
-    id: "rsc_fence_aws"
-    # AWS Fence agent is not recommended.
-    agent: "stonith:fence_aws"
-    options:
-      # Fencing action delay is recommended. Default: 0
-      # Production pcmk_delay_max is recommended 30-60
-      pcmk_delay_max: 15
-      # AWS Credentials are not defined here, because they override attached
-      # IAM Role or IAM Instance Profile
-      # access_key: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
-      # secret_key: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
-      # region: "{{ sap_ha_pacemaker_cluster_aws_region }}"
+# Documentation sources:
+# HANA:
+#   SLES: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-stonith-device.html
+#   RHEL: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-resources-1.html
+# NWAS:
+#   SLES: https://docs.aws.amazon.com/sap/latest/sap-netweaver/sles-netweaver-ha-cluster-resources.html#create-stonith
+#   RHEL: https://docs.aws.amazon.com/sap/latest/sap-netweaver/rhel-netweaver-ha-cluster-resources.html#create-stonith
 
-  external_ec2:
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  redhat_hana:
     id: "rsc_fence_aws"
-    # SUSE Recommends stonith:external/ec2 instead of fence_aws
+    agent: "stonith:fence_aws"
+    instance_attrs:
+      - attrs:
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+          - name: pcmk_delay_max
+            value: 45
+          - name: power_timeout
+            value: 600
+          # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
+          - name: pcmk_reboot_action
+            value: 'off'
+          - name: pcmk_reboot_timeout
+            value: 600
+          - name: pcmk_reboot_retries
+            value: 4
+          # AWS Credentials are not defined here, because they override attached
+          # IAM Role or IAM Instance Profile
+          # - name: access_key
+          #   value: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
+          # - name: secret_key
+          #   value: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
+          # - name: region
+          #   value: "{{ sap_ha_pacemaker_cluster_aws_region }}"
+    operations:
+      - action: start
+        attrs:
+          - name: timeout
+            value: 600
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 300
+          - name: timeout
+            value: 60
+
+  redhat_nwas:
+    id: "rsc_fence_aws"
+    agent: "stonith:fence_aws"
+    instance_attrs:
+      - attrs:
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+          - name: pcmk_delay_max
+            value: 30
+          - name: power_timeout
+            value: 240
+          # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
+          - name: pcmk_reboot_action
+            value: 'off'
+          - name: pcmk_reboot_timeout
+            value: 300
+          - name: pcmk_reboot_retries
+            value: 2
+    operations:
+      - action: start
+        attrs:
+          - name: timeout
+            value: 180
+      - action: stop
+        attrs:
+          - name: timeout
+            value: 180
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 180
+          - name: timeout
+            value: 60
+
+  # SUSE Recommends stonith:external/ec2 instead of fence_aws
+  suse_hana:
+    id: "rsc_fence_aws"
     agent: "stonith:external/ec2"
-    options:
-      # Fencing action delay is recommended. Default: 0
-      # Production pcmk_delay_max is recommended 30-60
-      pcmk_delay_max: 15
-      tag: pacemaker  # tag instance with pacemaker: {{ ansible_hostname }}
-      # profile: default  # Additional tag to use awscli config
+    instance_attrs:
+      - attrs:
+          - name: pcmk_delay_max
+            value: 45
+          - name: tag
+            value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
+          # Use AWS config profile if AWS credentials are used.
+          # - name: profile
+          #   value: cluster
+    meta_attrs:
+      - attrs:
+          - name: target-role
+            value: Started
+    operations:
+      - action: start
+        attrs:
+          - name: interval
+            value: 0
+          - name: timeout
+            value: 180
+      - action: stop
+        attrs:
+          - name: interval
+            value: 0
+          - name: timeout
+            value: 180
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 120
+          - name: timeout
+            value: 60
+
+  suse_nwas:
+    id: "rsc_fence_aws"
+    agent: "stonith:external/ec2"
+    instance_attrs:
+      - attrs:
+          - name: pcmk_delay_max
+            value: 30
+          - name: tag
+            value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
+          # Use AWS config profile if AWS credentials are used.
+          # - name: profile
+          #   value: cluster
+    meta_attrs:
+      - attrs:
+          - name: target-role
+            value: Started
+    operations:
+      - action: start
+        attrs:
+          - name: interval
+            value: 0
+          - name: timeout
+            value: 180
+      - action: stop
+        attrs:
+          - name: interval
+            value: 0
+          - name: timeout
+            value: 180
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 120
+          - name: timeout
+            value: 60
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
-# SUSE does not support stonith:fence_aws
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.external_ec2 if ansible_os_family == 'Suse'
-   else __sap_ha_pacemaker_cluster_stonith_default_dict.fence_aws }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower ~ '_hana']
+    if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
+   else __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower ~ '_nwas'] }}"
 
 
 # Default corosync options - Platform specific

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -26,13 +26,17 @@ __sap_ha_pacemaker_cluster_repos:
 # NOTE: fence_gce parameters are identical across all listed documents.
 
 __sap_ha_pacemaker_cluster_stonith_default_dict:
-  fence_gce:
+  generic:
+    # fence_gce agent is created for every host in cluster
     id: "rsc_fence_gce_{{ ansible_hostname }}"
     agent: "stonith:fence_gce"
     instance_attrs:
       - attrs:
+          # GCP does not use pcmk_host_map, instead it specifies port
+          # fence_gce supports plug parameter, but all documentations mention only port.
           - name: port
             value: "{{ ansible_hostname }}"
+
           - name: project
             value: "{{ sap_ha_pacemaker_cluster_gcp_project }}"
           - name: zone
@@ -59,7 +63,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_gce }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
 # GCP needs haproxy and ports defined

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -4,32 +4,33 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp | default([]) }}"
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform:
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp_ce_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp_ce_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
-    name: High Availability
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_gcp_ce_vm | default([]) }}"
 
-# Predefine
-__sap_ha_pacemaker_cluster_gcp_hosts: []
 
-sap_ha_pacemaker_cluster_stonith_default:
-  id: "res_fence_gce"
-  agent: "stonith:fence_gce"
-  options:
-    project: "{{ sap_ha_pacemaker_cluster_gcp_project }}"
-    zone: "{{ sap_ha_pacemaker_cluster_gcp_region_zone }}"
-    pcmk_reboot_timeout: 300
-    pcmk_monitor_retries: 4
-    pcmk_delay_max: 30
+# Stonith dictionary for default stonith agents.
+# Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  fence_gce:
+    id: "rsc_fence_gce"
+    agent: "stonith:fence_gce"
+    options:
+      project: "{{ sap_ha_pacemaker_cluster_gcp_project }}"
+      zone: "{{ sap_ha_pacemaker_cluster_gcp_region_zone }}"
+      pcmk_reboot_timeout: 300
+      pcmk_monitor_retries: 4
+      pcmk_delay_max: 30
 
-# Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: gcp_nlb_reserved_ip_haproxy # gcp_vpc_move_route
-sap_ha_pacemaker_cluster_vip_group_prefix: group_
+# Select __sap_ha_pacemaker_cluster_stonith_default
+__sap_ha_pacemaker_cluster_stonith_default:
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_gce }}"
+
 
 # GCP needs haproxy and ports defined
 sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
@@ -42,6 +43,7 @@ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: "620{{ sap_ha_pacemaker
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
+
 # Default corosync options - Platform specific
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
   options:
@@ -49,6 +51,11 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
     token_retransmits_before_loss_const: 10
     join: 60
     max_messages: 20
+
+
+# Platform specific VIP handling
+sap_ha_pacemaker_cluster_vip_method: gcp_nlb_reserved_ip_haproxy # gcp_vpc_move_route
+sap_ha_pacemaker_cluster_vip_group_prefix: group_
 
 __sap_ha_pacemaker_cluster_available_vip_agents:
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -16,16 +16,46 @@ __sap_ha_pacemaker_cluster_repos:
 
 # Stonith dictionary for default stonith agents.
 # Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+# Documentation sources:
+# HANA:
+#   SLES: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#set_up_fencing
+#   RHEL: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-rhel#set_up_fencing
+# NWAS:
+#   SLES: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#set_up_fencing
+#   RHEL: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#set_up_fencing
+# NOTE: fence_gce parameters are identical across all listed documents.
+
 __sap_ha_pacemaker_cluster_stonith_default_dict:
   fence_gce:
-    id: "rsc_fence_gce"
+    id: "rsc_fence_gce_{{ ansible_hostname }}"
     agent: "stonith:fence_gce"
-    options:
-      project: "{{ sap_ha_pacemaker_cluster_gcp_project }}"
-      zone: "{{ sap_ha_pacemaker_cluster_gcp_region_zone }}"
-      pcmk_reboot_timeout: 300
-      pcmk_monitor_retries: 4
-      pcmk_delay_max: 30
+    instance_attrs:
+      - attrs:
+          - name: port
+            value: "{{ ansible_hostname }}"
+          - name: project
+            value: "{{ sap_ha_pacemaker_cluster_gcp_project }}"
+          - name: zone
+            value: "{{ sap_ha_pacemaker_cluster_gcp_region_zone }}"
+          - name: pcmk_delay_max
+            value: 30
+          - name: pcmk_monitor_retries
+            value: 4
+          - name: pcmk_reboot_timeout
+            value: 300
+    operations:
+      - action: start
+        attrs:
+          - name: interval
+            value: 0
+          - name: timeout
+            value: 60
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 300
+          - name: timeout
+            value: 120
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -20,29 +20,39 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
   fence_ibm_powervs:
     id: "rsc_fence_ibm_powervs"
     agent: "stonith:fence_ibm_powervs"
-    options:
-      token: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
-      region: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
-      crn: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_crn }}"
+    instance_attrs:
+      - attrs:
+          - name: token
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
+          - name: region
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
+          - name: crn
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_crn }}"
 
-      # Identified during execution initial tasks, populated when variables are imported
-      instance: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_guid }}"
+          # Identified during execution initial tasks, populated when variables are imported
+          - name: instance
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_guid }}"
 
-      # Identified during execution initial tasks, populated when variables are imported.
-      # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
-      # plug: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_instance_id }}"
+          # Identified during execution initial tasks, populated when variables are imported.
+          # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
+          # plug: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_instance_id }}"
 
-      # Dependent on network interface attachments, if no public network interface
-      # then 'private' value must be provided.
-      api-type: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type | default('public') }}"
+          # Dependent on network interface attachments, if no public network interface
+          # then 'private' value must be provided.
+          - name: api-type
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type | default('public') }}"
 
-      # Dependent on network interface attachments, if no public network interface
-      # then a valid HTTP Proxy URL value must be provided.
-      proxy: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | default('') }}"
+          # Dependent on network interface attachments, if no public network interface
+          # then a valid HTTP Proxy URL value must be provided.
+          - name: proxy
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | default('') }}"
 
-      pcmk_reboot_timeout: 600
-      pcmk_monitor_timeout: 600
-      pcmk_status_timeout: 60
+          - name: pcmk_reboot_timeout
+            value: 600
+          - name: pcmk_monitor_timeout
+            value: 600
+          - name: pcmk_status_timeout
+            value: 60
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -17,7 +17,7 @@ __sap_ha_pacemaker_cluster_repos:
 # Stonith dictionary for default stonith agents.
 # Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
 __sap_ha_pacemaker_cluster_stonith_default_dict:
-  fence_ibm_powervs:
+  generic:
     id: "rsc_fence_ibm_powervs"
     agent: "stonith:fence_ibm_powervs"
     instance_attrs:
@@ -47,6 +47,9 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
           - name: proxy
             value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | default('') }}"
 
+          # String of cluster hosts defined in include_vars_platform
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_reboot_timeout
             value: 600
           - name: pcmk_monitor_timeout
@@ -56,7 +59,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_ibm_powervs }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -4,50 +4,49 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform:
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
   "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
-    name: High Availability E4S (4-Year) for Power, little endian
-#  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
-#    name: High Availability EUS (2-Year) for Power, little endian
-#  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
-#    name: High Availability for Power, little endian
-
-# Predefine
-__sap_ha_pacemaker_cluster_ibmcloud_powervs_hosts: []
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_ibmcloud_powervs | default([]) }}"
 
 
-sap_ha_pacemaker_cluster_stonith_default:
-  id: "res_fence_ibm_powervs"
-  agent: "stonith:fence_ibm_powervs"
-  options:
-    token: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
-    region: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
-    crn: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_crn }}"
+# Stonith dictionary for default stonith agents.
+# Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  fence_ibm_powervs:
+    id: "rsc_fence_ibm_powervs"
+    agent: "stonith:fence_ibm_powervs"
+    options:
+      token: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
+      region: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
+      crn: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_crn }}"
 
-    # Identified during execution initial tasks, populated when variables are imported
-    instance: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_guid }}"
+      # Identified during execution initial tasks, populated when variables are imported
+      instance: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_guid }}"
 
-    # Identified during execution initial tasks, populated when variables are imported.
-    # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
-    # plug: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_instance_id }}"
+      # Identified during execution initial tasks, populated when variables are imported.
+      # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
+      # plug: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_instance_id }}"
 
-    # Dependent on network interface attachments, if no public network interface
-    # then 'private' value must be provided.
-    api-type: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type | default('public') }}"
+      # Dependent on network interface attachments, if no public network interface
+      # then 'private' value must be provided.
+      api-type: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type | default('public') }}"
 
-    # Dependent on network interface attachments, if no public network interface
-    # then a valid HTTP Proxy URL value must be provided.
-    proxy: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | default('') }}"
+      # Dependent on network interface attachments, if no public network interface
+      # then a valid HTTP Proxy URL value must be provided.
+      proxy: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | default('') }}"
 
-    pcmk_reboot_timeout: 600
-    pcmk_monitor_timeout: 600
-    pcmk_status_timeout: 60
+      pcmk_reboot_timeout: 600
+      pcmk_monitor_timeout: 600
+      pcmk_status_timeout: 60
+
+# Select __sap_ha_pacemaker_cluster_stonith_default
+__sap_ha_pacemaker_cluster_stonith_default:
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_ibm_powervs }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -4,30 +4,31 @@
 #
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs | default([]) }}"
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform:
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
   "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_vs | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
-    name: High Availability E4S (4-Year)
-#  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
-#    name: High Availability EUS (2-Year)
-#  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
-#    name: High Availability
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_ibmcloud_vs | default([]) }}"
 
-# Predefine
-__sap_ha_pacemaker_cluster_ibmcloud_hosts: []
 
-sap_ha_pacemaker_cluster_stonith_default:
-  id: "res_fence_ibm_vpc"
-  agent: "stonith:fence_ibm_vpc"
-  options:
-    apikey: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
-    region: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
-    pcmk_monitor_timeout: 600
+# Stonith dictionary for default stonith agents.
+# Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  fence_ibm_vpc:
+    id: "rsc_fence_ibm_vpc"
+    agent: "stonith:fence_ibm_vpc"
+    options:
+      apikey: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
+      region: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
+      pcmk_monitor_timeout: 600
+
+# Select __sap_ha_pacemaker_cluster_stonith_default
+__sap_ha_pacemaker_cluster_stonith_default:
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_ibm_vpc }}"
+
 
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: ibmcloud_alb_haproxy

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -20,10 +20,14 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
   fence_ibm_vpc:
     id: "rsc_fence_ibm_vpc"
     agent: "stonith:fence_ibm_vpc"
-    options:
-      apikey: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
-      region: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
-      pcmk_monitor_timeout: 600
+    instance_attrs:
+      - attrs:
+          - name: apikey
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
+          - name: region
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
+          - name: pcmk_monitor_timeout
+            value: 600
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -17,7 +17,7 @@ __sap_ha_pacemaker_cluster_repos:
 # Stonith dictionary for default stonith agents.
 # Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
 __sap_ha_pacemaker_cluster_stonith_default_dict:
-  fence_ibm_vpc:
+  generic:
     id: "rsc_fence_ibm_vpc"
     agent: "stonith:fence_ibm_vpc"
     instance_attrs:
@@ -26,12 +26,16 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
             value: "{{ sap_ha_pacemaker_cluster_ibmcloud_api_key }}"
           - name: region
             value: "{{ sap_ha_pacemaker_cluster_ibmcloud_region }}"
+
+          # String of cluster hosts defined in include_vars_platform
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_monitor_timeout
             value: 600
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_ibm_vpc }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -19,18 +19,79 @@ __sap_ha_pacemaker_cluster_repos:
 
 # Stonith dictionary for default stonith agents.
 # Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+# Documentation sources:
+# HANA:
+#   SLES: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#create-a-fencing-device-on-the-pacemaker-cluster
+#   RHEL: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-rhel-pacemaker?tabs=msi#azure-fence-agent-as-fencing-device
+# NWAS:
+#   NOTE: There is no separate documentation for NWAS stonith setup.
+
 __sap_ha_pacemaker_cluster_stonith_default_dict:
-  fence_azure_arm:
+  redhat:
     id: "rsc_fence_azure_arm"
     agent: "stonith:fence_azure_arm"
-    options:
-      msi: true
-      subscriptionId: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
-      resourceGroup: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+    instance_attrs:
+      - attrs:
+          - name: msi
+            value: true
+          - name: subscriptionId
+            value: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
+          - name: resourceGroup
+            value: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+          - name: pcmk_action_limit
+            value: 3
+          - name: pcmk_delay_max
+            value: 15
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+          - name: pcmk_monitor_retries
+            value: 4
+          - name: pcmk_monitor_timeout
+            value: 120
+          - name: pcmk_reboot_timeout
+            value: 900
+          - name: power_timeout
+            value: 240
+    operations:
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 3600
+
+  suse:
+    id: "rsc_fence_azure_arm"
+    agent: "stonith:fence_azure_arm"
+    instance_attrs:
+      - attrs:
+          - name: msi
+            value: true
+          - name: subscriptionId
+            value: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
+          - name: resourceGroup
+            value: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+          - name: pcmk_action_limit
+            value: 3
+          - name: pcmk_delay_max
+            value: 15
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+          - name: pcmk_monitor_retries
+            value: 4
+          - name: pcmk_reboot_timeout
+            value: 900
+          - name: power_timeout
+            value: 240
+    operations:
+      - action: monitor
+        attrs:
+          - name: interval
+            value: 3600
+          - name: timeout
+            value: 120
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_azure_arm }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower] }}"
 
 
 # Default corosync options - Platform specific

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -38,12 +38,14 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
             value: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
           - name: resourceGroup
             value: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+
+          # String of cluster hosts defined in include_vars_platform
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_action_limit
             value: 3
           - name: pcmk_delay_max
             value: 15
-          - name: pcmk_host_map
-            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_monitor_retries
             value: 4
           - name: pcmk_monitor_timeout
@@ -69,12 +71,14 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
             value: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
           - name: resourceGroup
             value: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+
+          # String of cluster hosts defined in include_vars_platform
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_action_limit
             value: 3
           - name: pcmk_delay_max
             value: 15
-          - name: pcmk_host_map
-            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_monitor_retries
             value: 4
           - name: pcmk_reboot_timeout

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -7,29 +7,31 @@
 # The packages of the following lists will be installed by the 'ha_cluster' Linux System Role.
 # Any packages that are pre-requisites for variable construction must be installed before, e.g.
 # in the preconfigure-* tasks.
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm | default([]) }}"
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform:
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
   "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_msazure_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
-    name: High Availability
-  - id: "rhui-microsoft-azure-rhel8-sap-ha"
-    name: Microsoft Azure RPMs for Red Hat Enterprise Linux 8 (rhel8-sap-ha)
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_msazure_vm | default([]) }}"
 
-# Predefine
-__sap_ha_pacemaker_cluster_msazure_hosts: []
 
-# Fencing via MS Azure Managed Service Identity (MSI) per cluster node
-sap_ha_pacemaker_cluster_stonith_default:
-  id: "res_fence_azure_arm"
-  agent: "stonith:fence_azure_arm"
-  options:
-    msi: true
-    subscriptionId: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
-    resourceGroup: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+# Stonith dictionary for default stonith agents.
+# Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  fence_azure_arm:
+    id: "rsc_fence_azure_arm"
+    agent: "stonith:fence_azure_arm"
+    options:
+      msi: true
+      subscriptionId: "{{ sap_ha_pacemaker_cluster_msazure_subscription_id }}"
+      resourceGroup: "{{ sap_ha_pacemaker_cluster_msazure_resource_group }}"
+
+# Select __sap_ha_pacemaker_cluster_stonith_default
+__sap_ha_pacemaker_cluster_stonith_default:
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_azure_arm }}"
+
 
 # Default corosync options - Platform specific
 __sap_ha_pacemaker_cluster_corosync_totem_platform:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -4,44 +4,43 @@
 # TODO: rename this file to match the actual "chassis_asset_tag" output
 # TODO: make sure to first respect 'ha_cluster' native variables
 
-sap_ha_pacemaker_cluster_fence_agent_packages:
-  "{{ sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm | default([]) }}"
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform:
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
   "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.hyp_ibmpower_vm | default([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
-    name: High Availability E4S (4-Year) for Power, little endian
-#  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
-#    name: High Availability EUS (2-Year) for Power, little endian
-#  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
-#    name: High Availability for Power, little endian
-
-# Predefine
-__sap_ha_pacemaker_cluster_ibmpower_vm_hosts: []
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.hyp_ibmpower_vm | default([]) }}"
 
 
-sap_ha_pacemaker_cluster_stonith_default:
-  id: "res_fence_lpar"
-  agent: "stonith:fence_lpar"
-  options:
-    ip: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host }}"
-    ipport: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port }}"
-    username: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login }}"
-    password: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password }}"
-    hmc_version: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version | default('4') }}"
-    managed: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_host_mtms }}"
-    # Identified during execution initial tasks, populated when variables are imported
+# Stonith dictionary for default stonith agents.
+# Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
+__sap_ha_pacemaker_cluster_stonith_default_dict:
+  fence_lpar:
+    id: "rsc_fence_lpar"
+    agent: "stonith:fence_lpar"
+    options:
+      ip: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host }}"
+      ipport: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port }}"
+      username: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login }}"
+      password: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password }}"
+      hmc_version: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version | default('4') }}"
+      managed: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_host_mtms }}"
+      # Identified during execution initial tasks, populated when variables are imported
 
-    # plug: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}"
-    # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
+      # plug: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}"
+      # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
 
-    pcmk_reboot_retries: 4
-    pcmk_reboot_timeout: 600
-    pcmk_monitor_timeout: 600
-    pcmk_status_timeout: 60
-    power_timeout: 240
+      pcmk_reboot_retries: 4
+      pcmk_reboot_timeout: 600
+      pcmk_monitor_timeout: 600
+      pcmk_status_timeout: 60
+      power_timeout: 240
+
+# Select __sap_ha_pacemaker_cluster_stonith_default
+__sap_ha_pacemaker_cluster_stonith_default:
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_lpar }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -20,23 +20,35 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
   fence_lpar:
     id: "rsc_fence_lpar"
     agent: "stonith:fence_lpar"
-    options:
-      ip: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host }}"
-      ipport: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port }}"
-      username: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login }}"
-      password: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password }}"
-      hmc_version: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version | default('4') }}"
-      managed: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_host_mtms }}"
-      # Identified during execution initial tasks, populated when variables are imported
+    instance_attrs:
+      - attrs:
+          - name: ip
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host }}"
+          - name: ipport
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port }}"
+          - name: username
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login }}"
+          - name: password
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password }}"
+          - name: hmc_version
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version | default('4') }}"
+          - name: managed
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_host_mtms }}"
 
-      # plug: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}"
-      # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
+          # Identified during execution initial tasks, populated when variables are imported
 
-      pcmk_reboot_retries: 4
-      pcmk_reboot_timeout: 600
-      pcmk_monitor_timeout: 600
-      pcmk_status_timeout: 60
-      power_timeout: 240
+          # plug: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}"
+          # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
+          - name: pcmk_reboot_retries
+            value: 4
+          - name: pcmk_reboot_timeout
+            value: 600
+          - name: pcmk_monitor_timeout
+            value: 600
+          - name: pcmk_status_timeout
+            value: 60
+          - name: power_timeout
+            value: 240
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -17,7 +17,7 @@ __sap_ha_pacemaker_cluster_repos:
 # Stonith dictionary for default stonith agents.
 # Custom stonith resource can be defined using sap_ha_pacemaker_cluster_stonith_custom
 __sap_ha_pacemaker_cluster_stonith_default_dict:
-  fence_lpar:
+  generic:
     id: "rsc_fence_lpar"
     agent: "stonith:fence_lpar"
     instance_attrs:
@@ -39,6 +39,9 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
 
           # plug: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}"
           # Unnecessary when using pcmk_host_map. Identified during execution initial tasks, populated when variables are imported
+          # String of cluster hosts defined in include_vars_platform
+          - name: pcmk_host_map
+            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
           - name: pcmk_reboot_retries
             value: 4
           - name: pcmk_reboot_timeout
@@ -52,7 +55,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.fence_lpar }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -1,10 +1,45 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Overwrite HA_CLUSTER repository ID to use E4S repository
-# - an alternative logic could be to enable the repo before running ha_cluster
+# Default repositories if platform does not override them.
+# This selection does not affect imported __ha_cluster_repos due to precedence.
 __sap_ha_pacemaker_cluster_repos:
   - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
     name: High Availability
+
+# Dictionary with repos for each platform
+__sap_ha_pacemaker_cluster_repos_dict:
+  cloud_aws_ec2_vs:
+    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
+      name: High Availability
+  cloud_gcp_ce_vm:
+    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
+      name: High Availability
+  cloud_ibmcloud_powervs:
+    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+      name: High Availability E4S (4-Year) for Power, little endian
+    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
+    #   name: High Availability EUS (2-Year) for Power, little endian
+    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
+    #   name: High Availability for Power, little endian
+  cloud_ibmcloud_vs:
+    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+      name: High Availability E4S (4-Year)
+    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
+    #   name: High Availability EUS (2-Year)
+    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
+    #   name: High Availability
+  cloud_msazure_vm:
+    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
+      name: High Availability
+    - id: "rhui-microsoft-azure-rhel8-sap-ha"
+      name: Microsoft Azure RPMs for Red Hat Enterprise Linux 8 (rhel8-sap-ha)
+  hyp_ibmpower_vm:
+    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+      name: High Availability E4S (4-Year) for Power, little endian
+    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
+    #   name: High Availability EUS (2-Year) for Power, little endian
+    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
+    #   name: High Availability for Power, little endian
 
 __sap_ha_pacemaker_cluster_halib_package: sap-cluster-connector
 
@@ -28,14 +63,14 @@ __sap_ha_pacemaker_cluster_corosync_totem_default:
 
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
-sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
+__sap_ha_pacemaker_cluster_fence_agent_packages_minimal:
   - fence-agents-all
 
 # Dictionary with fence packages for each platform
-sap_ha_pacemaker_cluster_fence_agent_packages_dict:
-  cloud_aws:
+__sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+  cloud_aws_ec2_vs:
     - fence-agents-aws
-  cloud_gcp:
+  cloud_gcp_ce_vm:
     - fence-agents-gce
   cloud_ibmcloud_powervs:
     - fence-agents-ibm-powervs
@@ -48,9 +83,9 @@ sap_ha_pacemaker_cluster_fence_agent_packages_dict:
 
 # Dictionary with extra platform specific packages
 __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
-  cloud_aws:
+  cloud_aws_ec2_vs:
     - awscli
-  cloud_gcp:
+  cloud_gcp_ce_vm:
     - resource-agents-gcp
   cloud_msazure_vm:
     - socat

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Default repositories are tied to subscription for SLES4SAP, no need to specify them.
+# __sap_ha_pacemaker_cluster_repos:
+# __sap_ha_pacemaker_cluster_repos_dict:
+
 __sap_ha_pacemaker_cluster_halib_package: sap-suse-cluster-connector
 
 # List of configuration lines that must be added to the instance profiles.
@@ -27,16 +31,16 @@ __sap_ha_pacemaker_cluster_corosync_totem_default:
 
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
-sap_ha_pacemaker_cluster_fence_agent_minimal_packages:
+__sap_ha_pacemaker_cluster_fence_agent_packages_minimal:
   - fence-agents
 
 # Dictionary with fence packages for each platform
-# fence-agents are defined in sap_ha_pacemaker_cluster_fence_agent_minimal_packages already.
-# sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+# fence-agents are defined in __sap_ha_pacemaker_cluster_fence_agent_packages_minimal already.
+# __sap_ha_pacemaker_cluster_fence_agent_packages_dict:
 
 # Dictionary with extra platform specific packages
 __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
-  cloud_aws:
+  cloud_aws_ec2_vs:
     - awscli
   cloud_msazure_vm:
     - socat
@@ -121,6 +125,7 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleout: []
 __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 
 # Overwrite resource clone name for SAP HANA
+# SAPHanaSR-angi uses different variables, so it applies only to classic HANA.
 sap_ha_pacemaker_cluster_hana_resource_clone_name:
   "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
 


### PR DESCRIPTION
**New features:**

- **Stonith SBD fence method added with all extra variables required for `ha_cluster`**

- Significant changes to Stonith task file, adding lot of extra validations to avoid execution if:
  - `ha_cluster` variables are provided, just skip them because you cannot override precedence anyway
  - variables are empty, not required list or string where list is expected (iterable check fails to differentiate between string and list)

- New repository dictionaries:
  - `__sap_ha_pacemaker_cluster_repos_dict` defined inside OS vars
  - Each platform vars loads `__sap_ha_pacemaker_cluster_repos` from dictionary
  - Dictionary is empty for SUSE as it comes with subscription.

- New fence agent dictionaries for each platform
  - `__sap_ha_pacemaker_cluster_stonith_default_dict` defined in each platform vars, then selected correct entry into `__sap_ha_pacemaker_cluster_stonith_default`
  - This serves as baseline for future if we have different fence agents like AWS, where RHEL and SLES have different agents.
  - There is potential for future to shift these dictionaries into new OS_stonith.yml var files if need arises for different OS parameters under same agents.

- Variable `sap_ha_pacemaker_cluster_aws_credentials_setup` that can be enabled to store AWS credentials. It is undefined by default to use attached IAM Role/Instance Profile done by AP4S.
  - Keeping AWS Credentials together with attached IAM, results in credentials overriding IAM permissions, requiring API user inside of AWS credentials to have fencing permissions.

- Default `ha_cluster` definition from AP4S moved inside of vars code, to create baseline nodes for `ha_cluster`
  - `pcs_address` is required only for `pcs`, but it does not harm `crmsh`
```yaml
    __sap_ha_pacemaker_cluster_ha_cluster:
      node_name: "{{ ansible_hostname }}"
      pcs_address: "{{ ansible_default_ipv4.address }}"
```

- Readme and argument_specs update with new variables and increased baseline version for required collections.



**Tested on:**

- AWS
  - SLES4SAP 15: SBD and default fencing
  - RHEL4SAP 8.6: Several tests executed, currently running SBD and default fence agent testing again.