### PR TITLE
feat(requirements): update requirements with ansible 9.5.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,13 +90,13 @@ N.B. The Ansible Collection works with SLES from version 15 SP3 and upwards, for
 ### Execution/Controller host - Operating System requirements
 
 Execution of Ansible Playbooks using this Ansible Collection have been tested with:
-- Python 3.9.7 and above (i.e. CPython distribution)
-- Ansible Core 2.12.0 and above _(included with optional installation of Ansible Community Edition 5.0 and above)_
+- Python 3.10.14 and above (i.e. CPython distribution)
+- Ansible Core 2.16.9 and above _(included with optional installation of Ansible Community Edition 5.0 and above)_
 - OS: macOS with Homebrew, RHEL, SLES, and containers in Task Runners (e.g. Azure DevOps)
 
 #### Ansible Core version
 
-This Ansible Collection was designed for maximum backwards compatibility, with full compatibility starting from Ansible Core 2.12.0 and above.
+This Ansible Collection was designed for maximum backwards compatibility, with full compatibility starting from Ansible Core 2.16.9 and above.
 
 **Note 1:** Ansible 2.9 was the last release before the Ansible project was split into Ansible Core and Ansible Community Edition, and was before Ansible Collections functionality was introduced. This Ansible Collection should execute when Ansible 2.9 is used, but it is not recommended and errors should be expected (and will not be resolved).
 

--- a/requirements-workflow.txt
+++ b/requirements-workflow.txt
@@ -1,4 +1,4 @@
-ansible==9.1.0
-ansible-compat==4.1.10
-ansible-core==2.16.2
-ansible-lint==6.22.1
+ansible==9.5.1
+ansible-compat==24.7.0
+ansible-core==2.16.9
+ansible-lint==24.7.0


### PR DESCRIPTION
ansible 9.5.1 (core 2.16.9) require minimal version of python 3.10.14

Closes #710 (not update to latest, but worth clean history of issue)
Closes #711
Closes #712 (not update to latest, but worth clean history of issue)
Closes #713

***Once this PR is merged, the above issues will also be closed, after that, the first week of next month the automation will create new ones with clean logs***