### PR TITLE
feat(.github/ISSUE_TEMPLATE): add bug and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,7 +35,7 @@ body:
   - type: dropdown
     id: os-family
     attributes:
-      label: OS
+      label: OS Family
       description: What operating system are you using to run the role?
       options:
         - RHEL (7.x, 8.x, 9.x)
@@ -48,7 +48,7 @@ body:
   - type: textarea
     id: python-version
     attributes:
-      label: Python
+      label: Python version
       description: Please provide the python version you are using
       placeholder: 3.9.7
     validations:
@@ -57,7 +57,7 @@ body:
   - type: textarea
     id: ansible-version
     attributes:
-      label: Ansible-core
+      label: Ansible-core version
       description: Please provide the ansible-core version you are using
       placeholder: 2.12.0
     validations:
@@ -66,7 +66,7 @@ body:
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction
+      label: How to reproduce the bug
       description: Please provide a way for us to be able to reproduce the problem you ran into.
       placeholder: Reproduction
     validations:
@@ -88,19 +88,12 @@ body:
     id: additional
     attributes:
       label: Additional information
-      description: Do you intend to submit a pr to solve this bug?
+      description: Do you intend to submit a **Pull Request** to solve this bug?
       options:
-        - "Yes"
-        - "No"
-      default: 1
+        - I can solve this bug
+        - I can't solve this bug
     validations:
       required: true
-
-  - type: textarea
-    id: additonal
-    attributes:
-      label: Additional context
-      description: If applicable, add any other context about the problem here
 
   - type: checkboxes
     id: required-info
@@ -110,5 +103,5 @@ body:
       options:
         - label: I've read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme).
           required: true
-        - label: I've already check for existing duplicated [issues](https://github.com/sap-linuxlab/community.sap_install/issues?q=is%3Aissue+label%3Abug).
+        - label: I've already checked for existing duplicated [issues](https://github.com/sap-linuxlab/community.sap_install/issues?q=is%3Aissue+label%3Abug).
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,30 @@ body:
         Please carefully read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme) before creating a bug report
 
   - type: dropdown
+    id: role
+    attributes:
+      label: Role
+      description: For what role is the feature you want to propose meant to be?
+      options:
+        - All
+        - sap_anydb_install_oracle
+        - sap_general_preconfigure
+        - sap_ha_install_anydb_ibmdb2
+        - sap_ha_install_hana_hsr
+        - sap_ha_pacemaker_cluster
+        - sap_hana_install
+        - sap_hana_preconfigure
+        - sap_hostagent
+        - sap_install_media_detect
+        - sap_maintain_etc_hosts
+        - sap_netweaver_preconfigure
+        - sap_storage_setup
+        - sap_swpm
+        - None of them (or I don't know)
+    validations:
+      required: true
+
+  - type: dropdown
     id: os-family
     attributes:
       label: OS

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Create a report to help us improve
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please carefully read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme) before creating a bug report
+
+  - type: dropdown
+    id: os-family
+    attributes:
+      label: OS
+      description: What operating system are you using to run the role?
+      options:
+        - RHEL (7.x, 8.x, 9.x)
+        - SLES (15 SPx)
+        - None of the above (specify in the description area below)
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: python-version
+    attributes:
+      label: Python
+      description: Please provide the python version you are using
+      placeholder: 3.9.7
+    validations:
+      required: true
+
+  - type: textarea
+    id: ansible-version
+    attributes:
+      label: Ansible-core
+      description: Please provide the ansible-core version you are using
+      placeholder: 2.12.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a way for us to be able to reproduce the problem you ran into.
+      placeholder: Reproduction
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      placeholder: Bug description
+    validations:
+      required: true
+
+  - type: dropdown
+    id: additional
+    attributes:
+      label: Additional information
+      description: Do you intend to submit a pr to solve this bug?
+      options:
+        - "Yes"
+        - "No"
+      default: 1
+    validations:
+      required: true
+
+  - type: textarea
+    id: additonal
+    attributes:
+      label: Additional context
+      description: If applicable, add any other context about the problem here
+
+  - type: checkboxes
+    id: required-info
+    attributes:
+      label: Final checks
+      description: Before submitting, please make sure you do the following
+      options:
+        - label: I've read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme).
+          required: true
+        - label: I've already check for existing duplicated [issues](https://github.com/sap-linuxlab/community.sap_install/issues?q=is%3Aissue+label%3Abug).
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,7 +35,7 @@ body:
   - type: dropdown
     id: os-family
     attributes:
-      label: OS Family
+      label: OS family
       description: What operating system are you using to run the role?
       options:
         - RHEL (7.x, 8.x, 9.x)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -95,6 +95,16 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: additional-duplicated-issue
+    attributes:
+      label: I've already checked for existing duplicated [issues](https://github.com/sap-linuxlab/community.sap_install/issues?q=is%3Aissue+label%3Abug).
+      description: |
+        Is there any related [issues](https://github.com/sap-linuxlab/community.sap_install/issues?q=is%3Aissue+label%3Abug) that you think is linked to this bug? 
+
+        Add link to the issue or leave empty if there are none!
+      placeholder: Issue duplicated
+
   - type: checkboxes
     id: required-info
     attributes:
@@ -102,6 +112,4 @@ body:
       description: Before submitting, please make sure you do the following
       options:
         - label: I've read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme).
-          required: true
-        - label: I've already checked for existing duplicated [issues](https://github.com/sap-linuxlab/community.sap_install/issues?q=is%3Aissue+label%3Abug).
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,7 +36,7 @@ body:
   - type: dropdown
     id: os-family
     attributes:
-      label: OS
+      label: OS family
       description: For what operating systems family is the feature you want to propose meant to be?
       options:
         - RHEL (7.x, 8.x, 9.x)
@@ -62,7 +62,7 @@ body:
       description: Do you want to implement this feature by yourself?
       options:
         - I can implement this feature
-        - I can't implement by myself this feature
+        - I can't/won't implement this feature
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a feature that will improve this role
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request!
+
+        Please carefully read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme) before creating a feature request
+
+  - type: dropdown
+    id: os-family
+    attributes:
+      label: OS
+      description: For what operating systems family is the feature you want to propose meant to be?
+      options:
+        - RHEL (7.x, 8.x, 9.x)
+        - SLES (15 SPx)
+        - All
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of what you think would be a helpful addition to this role, including the possible use cases and alternatives you have considered.
+      placeholder: Feature description
+    validations:
+      required: true
+
+  - type: dropdown
+    id: additional
+    attributes:
+      label: Additional information
+      description: Do you want to implement this feature by yourself?
+      options:
+        - I can implement this feature
+        - I can't implement by myself this feature
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: final-checks
+    attributes:
+      label: Final checks
+      description: Before submitting, please make sure you do the following
+      options:
+        - label: I've read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme).
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,6 +11,29 @@ body:
         Please carefully read [the documentation](https://github.com/sap-linuxlab/community.sap_install/tree/main/docs#readme) before creating a feature request
 
   - type: dropdown
+    id: role
+    attributes:
+      label: Role
+      description: For what role is the feature you want to propose meant to be?
+      options:
+        - All
+        - sap_anydb_install_oracle
+        - sap_general_preconfigure
+        - sap_ha_install_anydb_ibmdb2
+        - sap_ha_install_hana_hsr
+        - sap_ha_pacemaker_cluster
+        - sap_hana_install
+        - sap_hana_preconfigure
+        - sap_hostagent
+        - sap_install_media_detect
+        - sap_maintain_etc_hosts
+        - sap_netweaver_preconfigure
+        - sap_storage_setup
+        - sap_swpm
+    validations:
+      required: true
+
+  - type: dropdown
     id: os-family
     attributes:
       label: OS

--- a/.github/workflows/issue_checker.yml
+++ b/.github/workflows/issue_checker.yml
@@ -1,0 +1,22 @@
+---
+
+name: Issue automation title filler
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+jobs:
+  check_outdate_dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Run issue check
+        uses: ./workflows/issue_checker
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/workflows/issue_checker/Dockerfile
+++ b/workflows/issue_checker/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:slim
+
+COPY issue_checker.py /run.py
+RUN chmod +x /run.py
+
+RUN pip3 install requests; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git
+
+ENTRYPOINT [ "/run.py" ]

--- a/workflows/issue_checker/action.yml
+++ b/workflows/issue_checker/action.yml
@@ -1,0 +1,7 @@
+---
+
+name: 'Issue automation title filler'
+description: 'This action is trigger whenever a new issue is open and it update the title with the standard'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/workflows/issue_checker/issue_checker.py
+++ b/workflows/issue_checker/issue_checker.py
@@ -13,51 +13,39 @@ HEADERS = {
     "Authorization": f"token {TOKEN}",
     "Accept": "application/vnd.github+json"
 }
+URL_ISSUE = f"https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}"
+API_ISSUE = f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}"
 
 ISSUE_STANDARD_TITLE = r'^\[Bug|Feature\](?: [\w\s]+)?(?: on [\w\s]+)?: .+$'
 ISSUE_ROLE_BODY = r'### Role\s+([\w_]+)'
-ISSUE_OS_BODY = r'### OS Family\s+([\w_]+)'
+ISSUE_OS_BODY = r'### OS family\s+([\w_]+)'
 
-COMMENT_FOLLOW_STANDARD = """
-Hi,
+COMMENT_STANDARD = ("Hi,\n\n"
+                    "The standard for the issue title should be like this:\n"
+                    "```\n"
+                    "[Bug|Feature]: <short_description>\n"
+                    "```\n\n"
+                    "Please update the issue title to follow this standard.\n"
+                    "\nExample: `[Bug]: pacemaker stop working on sles15`\n\n"
+                    "Thanks")
 
-The standard for the issue title should be like this: `[Bug|Feature]: <short_description>`. Please update the issue title to follow this standard.
-
-Example:
-`[Bug]: pacemaker stop working on sles15`
-
-Thanks
-"""
-COMMENT_TITLE_NOT_ALIGNED = """
-Hi,
-
-It seems that the title and the labels are not aligned. Check if the label `bug` is selected if the issue is a Bug and the label `enhancement` is selected if is a Feature.
-
-Thanks
-"""
-COMMENT_MISS_SHORT_DESCRIPTION = """
-Hi,
-
-It seems that the title miss a short description.
-
-Could you please update the tile by adding something after the issue specification?
-
-Example:
-`[Bug]: pacemaker stop working on sles15`
-
-Thanks
-"""
+COMMENT_NOT_ALIGNED = ("Hi,\n\n"
+                       "It seems that the title and the labels are not "
+                       "aligned. Check if the label `bug` is selected if the "
+                       "issue is a Bug and the label `enhancement` is selected"
+                       " if is a Feature.\n\n"
+                       "Thanks")
 
 
 def get_issue_descriptor():
     response = requests.get(
-        f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}",
+        API_ISSUE,
         headers=HEADERS)
     if response.status_code == 200:
-        print(f"INFO: Issue found -> https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}")
+        print(f"INFO: Issue found -> {URL_ISSUE}")
         return response.json()
     else:
-        print(f"ERROR: Failed to update the issue. Status code: {response.status_code}.")
+        print(f"ERROR: Issue not found. Status code: {response.status_code}.")
         return {}
 
 
@@ -87,13 +75,13 @@ def post_comment_on_issue(body):
         "body": body
     }
     response = requests.post(
-        f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}/comments",
+        f"{API_ISSUE}/comments",
         headers=HEADERS,
         data=json.dumps(comment_data))
     if response.status_code == 201:
-        print(f"INFO: Comment done in -> https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}")
+        print(f"INFO: Comment done in -> {URL_ISSUE}")
     else:
-        print(f"ERROR: Failed to create comment. Status code: {response.status_code}.")
+        print(f"ERROR: Failed to create comment with {response.status_code}.")
 
 
 def update_title_on_issue(title):
@@ -101,13 +89,13 @@ def update_title_on_issue(title):
         "title": title
     }
     response = requests.post(
-        f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}",
+        API_ISSUE,
         headers=HEADERS,
         data=json.dumps(title_data))
     if response.status_code == 200:
-        print(f"INFO: Title updated -> https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}")
+        print(f"INFO: Title updated -> {URL_ISSUE}")
     else:
-        print(f"ERROR: Failed to update title. Status code: {response.status_code}.")
+        print(f"ERROR: Failed to update title with {response.status_code}.")
 
 
 def title_composer(issue_descriptor):
@@ -132,24 +120,23 @@ def title_composer(issue_descriptor):
     return object_title + role_selected + os_selected + ":" + description_title
 
 
-def is_short_description_filled(title):
-    return True if str.split(title, ':')[-1].strip(" ") else False
-
 if __name__ == '__main__':
     issue_descriptor = get_issue_descriptor()
     if issue_descriptor:
-        if not is_title_standardise(issue_descriptor['title']):
-            post_comment_on_issue(COMMENT_FOLLOW_STANDARD)
-            sys.exit(1)
-
-        is_bug_not_bug = "Bug" in issue_descriptor['title'] and not is_a_bug(issue_descriptor['labels'])
-        is_feat_not_feat = "Feature" in issue_descriptor['title'] and not is_a_feature(issue_descriptor['labels'])
+        is_bug_not_bug = (
+            "Bug" in issue_descriptor['title'] and
+            not is_a_bug(issue_descriptor['labels'])
+        )
+        is_feat_not_feat = (
+            "Feature" in issue_descriptor['title'] and
+            not is_a_feature(issue_descriptor['labels'])
+        )
         if is_bug_not_bug or is_feat_not_feat:
-            post_comment_on_issue(COMMENT_TITLE_NOT_ALIGNED)
+            post_comment_on_issue(COMMENT_NOT_ALIGNED)
             sys.exit(1)
 
-        if not is_short_description_filled(issue_descriptor['title']):
-            post_comment_on_issue(COMMENT_MISS_SHORT_DESCRIPTION)
+        if not is_title_standardise(issue_descriptor['title']):
+            post_comment_on_issue(COMMENT_STANDARD)
             sys.exit(1)
 
         title = title_composer(issue_descriptor)

--- a/workflows/issue_checker/issue_checker.py
+++ b/workflows/issue_checker/issue_checker.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import requests
+import re
+import json
+
+TOKEN = str(os.environ.get("GITHUB_TOKEN"))
+REPOSITORY = str(os.environ.get("GITHUB_REPOSITORY"))
+ISSUE_NUMBER = str(os.environ.get("GITHUB_ISSUE_NUMBER"))
+HEADERS = {
+    "Authorization": f"token {TOKEN}",
+    "Accept": "application/vnd.github+json"
+}
+
+ISSUE_STANDARD_TITLE = r'^\[Bug|Feature\](?: [\w\s]+)?(?: on [\w\s]+)?: .+$'
+ISSUE_ROLE_BODY = r'### Role\s+([\w_]+)'
+ISSUE_OS_BODY = r'### OS Family\s+([\w_]+)'
+
+COMMENT_FOLLOW_STANDARD = """
+Hi,
+
+The standard for the issue title should be like this: `[Bug|Feature]: <short_description>`. Please update the issue title to follow this standard.
+
+Example:
+`[Bug]: pacemaker stop working on sles15`
+
+Thanks
+"""
+COMMENT_TITLE_NOT_ALIGNED = """
+Hi,
+
+It seems that the title and the labels are not aligned. Check if the label `bug` is selected if the issue is a Bug and the label `enhancement` is selected if is a Feature.
+
+Thanks
+"""
+COMMENT_MISS_SHORT_DESCRIPTION = """
+Hi,
+
+It seems that the title miss a short description.
+
+Could you please update the tile by adding something after the issue specification?
+
+Example:
+`[Bug]: pacemaker stop working on sles15`
+
+Thanks
+"""
+
+
+def get_issue_descriptor():
+    response = requests.get(
+        f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}",
+        headers=HEADERS)
+    if response.status_code == 200:
+        print(f"INFO: Issue found -> https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}")
+        return response.json()
+    else:
+        print(f"ERROR: Failed to update the issue. Status code: {response.status_code}.")
+        return {}
+
+
+def is_a_feature(labels):
+    for label in labels:
+        if label['name'] == 'enhancement':
+            return True
+    return False
+
+
+def is_a_bug(labels):
+    for label in labels:
+        if label['name'] == 'bug':
+            return True
+    return False
+
+
+def is_title_standardise(title):
+    regex_pattern = re.compile(ISSUE_STANDARD_TITLE)
+    matches = regex_pattern.findall(title)
+
+    return False if not matches else True
+
+
+def post_comment_on_issue(body):
+    comment_data = {
+        "body": body
+    }
+    response = requests.post(
+        f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}/comments",
+        headers=HEADERS,
+        data=json.dumps(comment_data))
+    if response.status_code == 201:
+        print(f"INFO: Comment done in -> https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}")
+    else:
+        print(f"ERROR: Failed to create comment. Status code: {response.status_code}.")
+
+
+def update_title_on_issue(title):
+    title_data = {
+        "title": title
+    }
+    response = requests.post(
+        f"https://api.github.com/repos/{REPOSITORY}/issues/{ISSUE_NUMBER}",
+        headers=HEADERS,
+        data=json.dumps(title_data))
+    if response.status_code == 200:
+        print(f"INFO: Title updated -> https://github.com/{REPOSITORY}/issues/{ISSUE_NUMBER}")
+    else:
+        print(f"ERROR: Failed to update title. Status code: {response.status_code}.")
+
+
+def title_composer(issue_descriptor):
+    role_body = re.search(ISSUE_ROLE_BODY, issue_descriptor['body'])
+    os_body = re.search(ISSUE_OS_BODY, issue_descriptor['body'])
+    title_body = str.split(issue_descriptor['title'], ':')
+
+    object_title = ""
+    description_title = ""
+    if title_body:
+        object_title = "" + str.split(title_body[0], ' ')[0]
+        description_title = "" + title_body[1]
+
+    role_selected = ""
+    if role_body:
+        role_selected = " " + role_body.group(1)
+
+    os_selected = ""
+    if os_body:
+        os_selected = " on " + os_body.group(1)
+
+    return object_title + role_selected + os_selected + ":" + description_title
+
+
+def is_short_description_filled(title):
+    return True if str.split(title, ':')[-1].strip(" ") else False
+
+if __name__ == '__main__':
+    issue_descriptor = get_issue_descriptor()
+    if issue_descriptor:
+        if not is_title_standardise(issue_descriptor['title']):
+            post_comment_on_issue(COMMENT_FOLLOW_STANDARD)
+            sys.exit(1)
+
+        is_bug_not_bug = "Bug" in issue_descriptor['title'] and not is_a_bug(issue_descriptor['labels'])
+        is_feat_not_feat = "Feature" in issue_descriptor['title'] and not is_a_feature(issue_descriptor['labels'])
+        if is_bug_not_bug or is_feat_not_feat:
+            post_comment_on_issue(COMMENT_TITLE_NOT_ALIGNED)
+            sys.exit(1)
+
+        if not is_short_description_filled(issue_descriptor['title']):
+            post_comment_on_issue(COMMENT_MISS_SHORT_DESCRIPTION)
+            sys.exit(1)
+
+        title = title_composer(issue_descriptor)
+        if title != issue_descriptor['title']:
+            update_title_on_issue(title)


### PR DESCRIPTION
# Description

Since the contributions are increasing it might be helpful to have a templates to apply a bug report or feature request.

If this pr will be merged when someone want to open a pr can choose between:

- bug report
- feature request
- blank issue (by config we can also remove this possibility)

![Screenshot 2024-08-05 at 18 06 26](https://github.com/user-attachments/assets/ff995ef6-79df-4649-88d8-2d28c5701cf7)

If for example the user want to apply a **bug report** this is the form that he/she/they have:

![image](https://github.com/user-attachments/assets/23169a19-a007-40c9-9c5e-1abc5dc7304b)

He/she/they have to fill out all the required elements in order to submit.

# How to try the templates

Just use my fork: https://github.com/Wabri/community.sap_install/issues/new/choose

# Example of submit

You can find at this link => https://github.com/Wabri/community.sap_install/issues/142

# Additional infos

To start using it you will need to merge to main.

# Question

Can be useful also for the other repositories?