### PR TITLE
sap_ha_pacemaker_cluster: Corosync Totem platform dictionary

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -181,9 +181,41 @@ __sap_ha_pacemaker_cluster_stonith_default:
 
 
 # Default corosync options - Platform specific
+# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
+# Documentation sources:
+# HANA:
+#   SLES: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html#sap-hana-on-aws-create-the-corosync-configuration-file
+#         https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-perfopt-15-aws/index.html#id-example-for-etccorosynccorosync-conf
+#   RHEL: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration-1.html#sap-hana-on-aws-corosync-increase
+# NWAS:
+#   SLES: https://docs.aws.amazon.com/sap/latest/sap-netweaver/sap-netweaver-ha-setup.html#associations
+#   RHEL: https://docs.aws.amazon.com/sap/latest/sap-netweaver/rhel-sap-netweaver-ha-setup.html#associations
+__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
+  redhat_hana:
+    options:
+      token: 30000
+
+  redhat_nwas:
+    options:
+      token: 30000
+
+  suse_hana:
+    options:
+      token: 30000
+      consensus: 36000
+      token_retransmits_before_loss_const: 6
+      clear_node_high_bit: 'yes'
+
+  suse_nwas:
+    options:
+      token: 30000
+      consensus: 36000
+      clear_node_high_bit: 'yes'
+
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
-  options:
-    token: 30000
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_hana']
+    if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
+   else __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_nwas'] }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -66,6 +66,30 @@ __sap_ha_pacemaker_cluster_stonith_default:
   "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
+# Default corosync options - Platform specific
+# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
+# Documentation sources:
+# HANA:
+#   SLES: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+#   RHEL: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-rhel#edit_the_corosyncconf_default_settings
+# NWAS:
+#   SLES: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#create_the_corosync_configuration_files
+#   RHEL: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#update_the_corosync_configuration_files
+__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
+  redhat:
+    options:
+      token: 20000
+      token_retransmits_before_loss_const: 10
+      join: 60
+      max_messages: 20
+  suse:
+    options:
+      token: 20000
+
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower] }}"
+
+
 # GCP needs haproxy and ports defined
 sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
@@ -76,15 +100,6 @@ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port: "620{{ sap_ha_pacemake
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
-
-
-# Default corosync options - Platform specific
-__sap_ha_pacemaker_cluster_corosync_totem_platform:
-  options:
-    token: 20000
-    token_retransmits_before_loss_const: 10
-    join: 60
-    max_messages: 20
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -62,6 +62,17 @@ __sap_ha_pacemaker_cluster_stonith_default:
   "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
+# Default corosync options - Platform specific
+# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
+__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
+  generic:
+    options:
+      token: 30000
+
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict.generic }}"
+
+
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: ipaddr_custom
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -38,6 +38,17 @@ __sap_ha_pacemaker_cluster_stonith_default:
   "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
+# Default corosync options - Platform specific
+# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
+__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
+  generic:
+    options:
+      token: 30000
+
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict.generic }}"
+
+
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: ibmcloud_alb_haproxy
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -99,9 +99,23 @@ __sap_ha_pacemaker_cluster_stonith_default:
 
 
 # Default corosync options - Platform specific
+# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
+# Documentation sources:
+#   SLES: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#install-the-cluster 15.A
+#   RHEL: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#install-the-cluster
+# NOTE: Azure does not differentiate between HANA and ASCS pacemaker setup.
+__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
+  redhat:
+    options:
+      token: 30000
+  suse:
+    options:
+      token: 30000
+      consensus: 36000
+
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
-  options:
-    token: 30000
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower] }}"
+
 
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: azure_lb

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -58,6 +58,17 @@ __sap_ha_pacemaker_cluster_stonith_default:
   "{{ __sap_ha_pacemaker_cluster_stonith_default_dict.generic }}"
 
 
+# Default corosync options - Platform specific
+# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
+__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
+  generic:
+    options:
+      token: 30000
+
+__sap_ha_pacemaker_cluster_corosync_totem_platform:
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict.generic }}"
+
+
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: ipaddr
 


### PR DESCRIPTION
**Description:**

- Enhanced corosync totem variables for each platform based on Cloud providers
- Switch to dictionary, similar to stonith dictionary
- Added documentation links


**Important:**

- Some dictionaries are simplified because there are no differences either between OS or HANA/NWAS - Similar to stonith dictionaries.


**Example for AWS, which includes differences for both OS and host type:**
```yaml
# Default corosync options - Platform specific
# These options combined with __sap_ha_pacemaker_cluster_corosync_totem_default (Same options are overwritten).
# Documentation sources:
# HANA:
#   SLES: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html#sap-hana-on-aws-create-the-corosync-configuration-file
#         https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-perfopt-15-aws/index.html#id-example-for-etccorosynccorosync-conf
#   RHEL: https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration-1.html#sap-hana-on-aws-corosync-increase
# NWAS:
#   SLES: https://docs.aws.amazon.com/sap/latest/sap-netweaver/sap-netweaver-ha-setup.html#associations
#   RHEL: https://docs.aws.amazon.com/sap/latest/sap-netweaver/rhel-sap-netweaver-ha-setup.html#associations
__sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
  redhat_hana:
    options:
      token: 30000

  redhat_nwas:
    options:
      token: 30000

  suse_hana:
    options:
      token: 30000
      consensus: 36000
      token_retransmits_before_loss_const: 6
      clear_node_high_bit: 'yes'

  suse_nwas:
    options:
      token: 30000
      consensus: 36000
      clear_node_high_bit: 'yes'

__sap_ha_pacemaker_cluster_corosync_totem_platform:
  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_hana']
    if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
   else __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_nwas'] }}"
```