### PR TITLE
sap_ha_pacemaker_cluster/SLES: New azure fence agent package

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -36,7 +36,11 @@ __sap_ha_pacemaker_cluster_fence_agent_packages_minimal:
 
 # Dictionary with fence packages for each platform
 # fence-agents are defined in __sap_ha_pacemaker_cluster_fence_agent_packages_minimal already.
-# __sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+__sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+  # Separate agent because of https://www.suse.com/support/kb/doc/?id=000021504
+  # This package is present in SLES4SAP 15 SP4 and higher
+  cloud_msazure_vm:
+    - fence-agents-azure-arm
 
 # Dictionary with extra platform specific packages
 __sap_ha_pacemaker_cluster_platform_extra_packages_dict:


### PR DESCRIPTION
Description:

- Added package `fence-agents-azure-arm` to dictionary `__sap_ha_pacemaker_cluster_fence_agent_packages_dict` in SUSE variable files.

Reason:

- Azure fence agent was separated from main package as part of https://www.suse.com/support/kb/doc/?id=000021504

```yaml
# Dictionary with fence packages for each platform
# fence-agents are defined in __sap_ha_pacemaker_cluster_fence_agent_packages_minimal already.
__sap_ha_pacemaker_cluster_fence_agent_packages_dict:
  # Separate agent because of https://www.suse.com/support/kb/doc/?id=000021504
  # This package is present in SLES4SAP 15 SP4 and higher
  cloud_msazure_vm:
    - fence-agents-azure-arm
 ```