### PR TITLE
sap_storage_setup: Add exact size disk check on top of approximate check

### DIFF
--- a/roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml
@@ -50,6 +50,8 @@
 # defined already that is to be enhanced with single disk definitions, if
 # applicable.
 
+# First pass assigns disks based on exact size.
+# Second pass assigns disks based on approximate size -8GB and +8GB
 - name: SAP Storage Setup - Set fact for target filesystem device mapping
   ansible.builtin.set_fact:
     filesystem_device_map: "{{ filesystem_device_map | default([]) + __single_disk_to_fs_device_map }}"
@@ -68,7 +70,21 @@
           -%}
 
           {%- for dev in av_dev -%}
+            {%- if dev.value.size | regex_search('.*TB$') -%}
+              {% set disk_size_gb = (((( dev.value.size | replace(' TB','') | float * 1024) /8) | round(0,'ceil') * 8) | int) -%}
+            {%- else -%}
+              {% set disk_size_gb = (dev.value.size | regex_replace('(\.\d+\s*)', '') | replace('GB','') | int) -%}
+            {%- endif -%}
+            {%- if disk_size_gb == fs.disk_size
+                and dev.key not in assigned_dev
+                and dev.value.holders | length == 0
+                and matching_dev | length < (fs.lvm_lv_stripes | d('1') | int) -%}
+                {%- set assigned = assigned_dev.append(dev.key) -%}
+                {%- set add = matching_dev.append('/dev/' + dev.key) -%}
+            {%- endif -%}
+          {%- endfor -%}
 
+          {%- for dev in av_dev -%}
             {%- if dev.value.size | regex_search('.*TB$') -%}
               {% set disk_size_gb = (((( dev.value.size | replace(' TB','') | float * 1024) /8) | round(0,'ceil') * 8) | int) -%}
             {%- else -%}
@@ -82,7 +98,6 @@
                 {%- set assigned = assigned_dev.append(dev.key) -%}
                 {%- set add = matching_dev.append('/dev/' + dev.key) -%}
             {%- endif -%}
-
           {%- endfor -%}
 
           {%- if matching_dev | length > 0 -%}


### PR DESCRIPTION
## Problem:
- Current disk assignment works on approximate validation with `(disk_size_gb-8) <= fs.disk_size <= (disk_size_gb+8)` which invalidates this role when filesystems with less than 8 GB differences are used.

- Current loop will pick first found, invalidating correct entries, causing cascading failure during LV creation because of `device: ""`

## Example:
Disks with sizes 15, 20 and 25 are used.

**/hana/shared will never be loaded, because `/hana/log` will find 25GB disk, use it and `/hana/shared` would be left without entry in following list of disks.`volume_map`**

```yaml
    sap_storage_setup_definition: [
      {
        "disk_size": 15,
        "filesystem_type": "xfs",
        "mountpoint": "/hana/data",
        "name": "hana_data"
      },
      {
        "disk_size": 20,
        "filesystem_type": "xfs",
        "mountpoint": "/hana/log",
        "name": "hana_log"
      },
      {
        "disk_size": 25,
        "filesystem_type": "xfs",
        "mountpoint": "/hana/shared",
        "name": "hana_shared"
      }
    ]
```

## Solution:
Add initial check for exact sizes, followed up by original approximate check which will run empty if all disk sizes were correctly found during first pass.

- First pass: `disk_size_gb == fs.disk_size`
- Second pass: `(disk_size_gb-8) <= fs.disk_size <= (disk_size_gb+8)`
