### PR TITLE
sap_hana_install: Add tag for only creating the hdblcm configfile

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -358,6 +358,9 @@ With the following tags, the role can be called to perform certain activities on
 - tag `sap_hana_install_hdblcm_commandline`: Only show the hdblcm command line, without processing
   the hdblcm template. This can be useful for checking the hdblcm command line options, especially
   when using the `addhosts` function.
+- tag `sap_hana_install_create_hdblcm_configfile`: Only create the hdblcm configfile, without
+  performing any additional preinstallation checks. The configfile will be created using hdblcm,
+  so the SAP HANA software will be extracted if not already done.
 - tag `sap_hana_install_preinstall`: Only perform pre-install activities. This includes selecting
   the SAPCAR EXE file, extracting the SAR files if necessary, searching for hdblcm, and creating
   the hdblcm configfile.

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -13,6 +13,7 @@
     - sap_hana_install_preinstall
     - sap_hana_install_set_log_mode
     - sap_hana_install_configure_firewall
+    - sap_hana_install_create_hdblcm_configfile
 
 - name: Fail if necessary variable 'sap_hana_install_sid' is not defined
   ansible.builtin.fail:
@@ -21,6 +22,7 @@
   tags:
     - sap_hana_install_check_hana_exists
     - sap_hana_install_preinstall
+    - sap_hana_install_create_hdblcm_configfile
 
 - name: Validate SAP HANA System ID - 'sap_hana_install_sid' consists of 3 characters
   ansible.builtin.assert:
@@ -30,6 +32,7 @@
   tags:
     - sap_hana_install_check_hana_exists
     - sap_hana_install_preinstall
+    - sap_hana_install_create_hdblcm_configfile
 
 - name: Validate SAP HANA System ID - 'sap_hana_install_sid' is not in the list of reserved SAP SIDs
   ansible.builtin.assert:
@@ -39,6 +42,7 @@
   tags:
     - sap_hana_install_check_hana_exists
     - sap_hana_install_preinstall
+    - sap_hana_install_create_hdblcm_configfile
 
 - name: Fail if necessary variable 'sap_hana_install_number' is not defined
   ansible.builtin.fail:
@@ -47,6 +51,7 @@
   tags:
     - sap_hana_install_check_hana_exists
     - sap_hana_install_preinstall
+    - sap_hana_install_create_hdblcm_configfile
 
 - name: SAP HANA existence checking
   ansible.builtin.import_tasks: hana_exists.yml

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -55,6 +55,7 @@
     - name: SAP HANA Pre Install - Normalize directory path
       ansible.builtin.set_fact:
         __sap_hana_install_fact_software_directory: "{{ sap_hana_install_software_directory | regex_replace('\\/$', '') }}"
+      tags: sap_hana_install_create_hdblcm_configfile
 
     - name: SAP HANA Pre Install - Check availability of software directory '{{ __sap_hana_install_fact_software_directory }}'
       ansible.builtin.stat:
@@ -138,6 +139,7 @@
       check_mode: no
       register: __sap_hana_install_register_stat_software_extract_directory
       failed_when: no
+      tags: sap_hana_install_create_hdblcm_configfile
 
     - name: SAP HANA Pre Install - Change ownership of software extract directory '{{ sap_hana_install_software_extract_directory }}'
       ansible.builtin.file:
@@ -164,11 +166,13 @@
         patterns: 'SAP_HANA_DATABASE'
       register: __sap_hana_install_register_find_directory_sap_hana_database_initial
       when: __sap_hana_install_register_stat_software_extract_directory.stat.exists
+      tags: sap_hana_install_create_hdblcm_configfile
 
     - name: SAP HANA Pre Install - Set directory of 'hdblcm' from successful find result
       when:
         - __sap_hana_install_register_stat_software_extract_directory.stat.exists
         - __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0] is defined
+      tags: sap_hana_install_create_hdblcm_configfile
       block:
 
         - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer directory if found initially
@@ -190,6 +194,7 @@
 
     - name: SAP HANA Pre Install - Extract SAR files if file 'hdblcm' was not found initially
       when: __sap_hana_install_register_find_directory_sap_hana_database_initial.files[0] is not defined
+      tags: sap_hana_install_create_hdblcm_configfile
       block:
 
         - name: SAP HANA Pre Install - Run hdblcm prepare
@@ -248,6 +253,7 @@
   tags:
     - sap_hana_install_hdblcm_commandline
     - sap_hana_install_check_installation
+    - sap_hana_install_create_hdblcm_configfile
 
 - name: SAP HANA Pre Install - Fill variable __sap_hana_install_register_tmpdir for check mode only
   ansible.builtin.set_fact:

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
@@ -30,6 +30,7 @@
     group: 'root'
     mode: '0755'
   when: __sap_hana_install_register_stat_hdblcm_configfile.stat.exists
+  tags: sap_hana_install_create_hdblcm_configfile
 
 - name: Create the hdblcm configfile dynamically
   when: not __sap_hana_install_register_stat_hdblcm_configfile.stat.exists

--- a/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
+++ b/roles/sap_hana_install/tasks/pre_install/hdblcm_configfile.yml
@@ -6,17 +6,20 @@
     path: "{{ sap_hana_install_configfile_directory }}"
     state: directory
     mode: '0755'
+  tags: sap_hana_install_create_hdblcm_configfile
 
 - name: SAP HANA Pre Install - Check if file '{{ sap_hana_install_configfile_directory }}/configfile.cfg' exists
   ansible.builtin.stat:
     path: "{{ sap_hana_install_configfile_directory }}/configfile.cfg"
   check_mode: no
   register: __sap_hana_install_register_stat_hdblcm_configfile
+  tags: sap_hana_install_create_hdblcm_configfile
 
 - name: SAP HANA Pre Install - Notify about existing hdblcm configfile
   ansible.builtin.debug:
     msg: "INFO: Using existing static hdblcm configfile '{{ sap_hana_install_configfile_directory }}/configfile.cfg'."
   when: __sap_hana_install_register_stat_hdblcm_configfile.stat.exists
+  tags: sap_hana_install_create_hdblcm_configfile
 
 - name: SAP HANA Pre Install - Make the existing static hdblcm configfile available for the SAP HANA installation
   ansible.builtin.copy:
@@ -30,6 +33,7 @@
 
 - name: Create the hdblcm configfile dynamically
   when: not __sap_hana_install_register_stat_hdblcm_configfile.stat.exists
+  tags: sap_hana_install_create_hdblcm_configfile
   block:
 
     - name: SAP HANA Pre Install - Create the hdblcm configfile template '{{ sap_hana_install_configfile_directory }}/{{ sap_hana_install_configfile_template_prefix }}.cfg'
@@ -91,3 +95,4 @@
 - name: SAP HANA Pre Install - Display the path name of the hdblcm configfile
   ansible.builtin.debug:
     msg: "The hdblcm configfile is: '{{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg'"
+  tags: sap_hana_install_create_hdblcm_configfile


### PR DESCRIPTION
With the additional tag `sap_hana_install_create_hdblcm_configfile` the role can be used for creating the hdblcm configfile only. This can be useful for error analysis.