### PR TITLE
sap_hana_install: Implement an SAP HANA installation check only feature

### DIFF
--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -10,6 +10,7 @@
     sap_hana_install_restrict_max_mem: "{{ sap_hana_install_mem_restrict | d(sap_hana_install_restrict_max_mem) }}"
   tags:
     - sap_hana_install_check_hana_exists
+    - sap_hana_install_check_installation
     - sap_hana_install_preinstall
     - sap_hana_install_set_log_mode
     - sap_hana_install_configure_firewall


### PR DESCRIPTION
Fixes #844.

With this change, the role sap_hana_install can be used to perform an SAP HANA installation check without performing an installation.