### PR TITLE
sap_ha_pacemaker_cluster: fix(RHEL): packages on AWS

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -84,7 +84,8 @@ __sap_ha_pacemaker_cluster_fence_agent_packages_dict:
 # Dictionary with extra platform specific packages
 __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
   cloud_aws_ec2_vs:
-    - awscli
+    - "{{ 'resource-agents-cloud' if ansible_distribution_major_version is version('9', '>=') else 'awscli' }}"
+    - "{{ 'awscli2' if ansible_distribution_version is version('9.5', '>=') else '' }}"
   cloud_gcp_ce_vm:
     - resource-agents-gcp
   cloud_msazure_vm:


### PR DESCRIPTION
In RHEL 9 the package `awscli` was moved into a bundle with the fence-agents and the AWS platform resource agents are shipped in a separate package that automatically pulls in the dependency to `ha-cloud-support`, which contains the aws binary as well.

Verified on RHEL 8.6 that it still behaves as before and installs the `awscli` (version 1) package.
Tested on RHEL 9.2. The fix installs the right packages and the aws cli is present through the HA packages.

```
ha-cloud-support-4.10.0-43.el9_2.7.x86_64
resource-agents-cloud-4.10.0-34.el9_2.5.x86_64
```

`aws` is now in a dedicated path, for use by the AWS fence and resource agents.
```
# /usr/lib/fence-agents/support/awscli/bin/aws --version
aws-cli/2.2.15 Python/3.9.16 Linux/5.14.0-284.82.1.el9_2.x86_64 source/x86_64.rhel.9 prompt/off
```

The dedicated package `awscli2` will be part of RHEL through AppStream from 9.5 onwards. 
The empty list element resulting from the conditional for anything <9.5 is removed from the list in the task that processes the list.