### PR TITLE
sap_ha_pacemaker_cluster: GCP haproxy handling and new platform VIP dictionary

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
@@ -1,155 +1,158 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+- name: "SAP HA Install Pacemaker - GCP CE VM - haproxy block"
+  when: sap_ha_pacemaker_cluster_vip_method == 'gcp_nlb_reserved_ip_haproxy'
+  block:
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Install haproxy"
-  ansible.builtin.package:
-    name: haproxy
-    state: present
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Install haproxy"
+      ansible.builtin.package:
+        name: haproxy
+        state: present
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Check if haproxy service template exists"
-  ansible.builtin.stat:
-    path: /etc/systemd/system/haproxy@.service
-  register: __sap_ha_pacemaker_cluster_register_haproxy_template
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Check if haproxy service template exists"
+      ansible.builtin.stat:
+        path: /etc/systemd/system/haproxy@.service
+      register: __sap_ha_pacemaker_cluster_register_haproxy_template
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy service template"
-  ansible.builtin.copy:
-    dest: /etc/systemd/system/haproxy@.service
-    remote_src: true
-    src: /usr/lib/systemd/system/haproxy.service
-    mode: '0644'
-  when:
-    - not __sap_ha_pacemaker_cluster_register_haproxy_template.stat.exists
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy service template"
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/haproxy@.service
+        remote_src: true
+        src: /usr/lib/systemd/system/haproxy.service
+        mode: '0644'
+      when:
+        - not __sap_ha_pacemaker_cluster_register_haproxy_template.stat.exists
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template description"
-  ansible.builtin.lineinfile:
-    backup: true
-    path: /etc/systemd/system/haproxy@.service
-    regexp: '^Description='
-    line: 'Description=HAProxy Load Balancer %i'
-    state: present
-    insertafter: '^[Unit]$'
-  notify: "systemd daemon-reload"
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template description"
+      ansible.builtin.lineinfile:
+        backup: true
+        path: /etc/systemd/system/haproxy@.service
+        regexp: '^Description='
+        line: 'Description=HAProxy Load Balancer %i'
+        state: present
+        insertafter: '^[Unit]$'
+      notify: "systemd daemon-reload"
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template environment"
-  ansible.builtin.lineinfile:
-    backup: true
-    path: /etc/systemd/system/haproxy@.service
-    regexp: '^Environment='
-    line: 'Environment="CONFIG=/etc/haproxy/haproxy-%i.cfg" "PIDFILE=/run/haproxy-%i.pid"'
-    state: present
-    insertafter: '^[Service]$'
-  notify: "systemd daemon-reload"
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template environment"
+      ansible.builtin.lineinfile:
+        backup: true
+        path: /etc/systemd/system/haproxy@.service
+        regexp: '^Environment='
+        line: 'Environment="CONFIG=/etc/haproxy/haproxy-%i.cfg" "PIDFILE=/run/haproxy-%i.pid"'
+        state: present
+        insertafter: '^[Service]$'
+      notify: "systemd daemon-reload"
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for HANA"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_healthcheck_list_hana:
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
-        port: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_port }}"
-    # If no custom port is defined, calculate the port for the secondary
-    # by adding 10, to avoid a conflict with the port for the primary hc port.
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
-        port: >-
-          {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
-            {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port }}
-          {%- else %}0{%- endif %}
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for HANA"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_healthcheck_list_hana:
+          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
+            port: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_port }}"
+        # If no custom port is defined, calculate the port for the secondary
+        # by adding 10, to avoid a conflict with the port for the primary hc port.
+          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
+            port: >-
+              {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
+                {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port }}
+              {%- else %}0{%- endif %}
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for NW ASCS/ERS"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_healthcheck_list_ascs:
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}"
-        port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port }}"
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}"
-        port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port }}"
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
-
-
-- name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for HANA instances"
-  ansible.builtin.blockinfile:
-    backup: false
-    create: true
-    path: "/etc/haproxy/haproxy-{{ haproxy_item.name }}.cfg"
-    mode: "0644"
-    owner: root
-    group: root
-    marker: "# {mark} Created by Ansible role sap_ha_pacemaker_cluster"
-    block: |
-      global
-          chroot      /var/lib/haproxy
-          pidfile     /var/run/haproxy-%i.pid
-          user        haproxy
-          group       haproxy
-          daemon
-
-      defaults
-          mode                    tcp
-          log                     global
-          option                  dontlognull
-          option                  redispatch
-          retries                 3
-          timeout queue           1m
-          timeout connect         10s
-          timeout client          1m
-          timeout server          1m
-          timeout check           10s
-          maxconn                 3000
-
-      # Listener for SAP healthcheck
-      listen healthcheck
-          bind *:{{ haproxy_item.port }}
-  loop: "{{ __sap_ha_pacemaker_cluster_healthcheck_list_hana }}"
-  loop_control:
-    loop_var: haproxy_item
-    label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
-    - haproxy_item.port | length > 4
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for NW ASCS/ERS"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_healthcheck_list_ascs:
+          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}"
+            port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port }}"
+          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}"
+            port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port }}"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
 
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for NWAS ASCS/ERS instances"
-  ansible.builtin.blockinfile:
-    create: true
-    path: "/etc/haproxy/haproxy-{{ haproxy_item.name }}.cfg"
-    mode: "0644"
-    owner: root
-    group: root
-    marker: "# {mark} Created by Ansible role sap_ha_pacemaker_cluster"
-    block: |
-      global
-          chroot      /var/lib/haproxy
-          pidfile     /var/run/haproxy-%i.pid
-          user        haproxy
-          group       haproxy
-          daemon
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for HANA instances"
+      ansible.builtin.blockinfile:
+        backup: false
+        create: true
+        path: "/etc/haproxy/haproxy-{{ haproxy_item.name }}.cfg"
+        mode: "0644"
+        owner: root
+        group: root
+        marker: "# {mark} Created by Ansible role sap_ha_pacemaker_cluster"
+        block: |
+          global
+              chroot      /var/lib/haproxy
+              pidfile     /var/run/haproxy-%i.pid
+              user        haproxy
+              group       haproxy
+              daemon
 
-      defaults
-          mode                    tcp
-          log                     global
-          option                  dontlognull
-          option                  redispatch
-          retries                 3
-          timeout queue           1m
-          timeout connect         10s
-          timeout client          1m
-          timeout server          1m
-          timeout check           10s
-          maxconn                 3000
+          defaults
+              mode                    tcp
+              log                     global
+              option                  dontlognull
+              option                  redispatch
+              retries                 3
+              timeout queue           1m
+              timeout connect         10s
+              timeout client          1m
+              timeout server          1m
+              timeout check           10s
+              maxconn                 3000
 
-      # Listener for SAP healthcheck
-      listen healthcheck
-          bind *:{{ haproxy_item.port }}
-  loop: "{{ __sap_ha_pacemaker_cluster_healthcheck_list_ascs }}"
-  loop_control:
-    loop_var: haproxy_item
-    label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+          # Listener for SAP healthcheck
+          listen healthcheck
+              bind *:{{ haproxy_item.port }}
+      loop: "{{ __sap_ha_pacemaker_cluster_healthcheck_list_hana }}"
+      loop_control:
+        loop_var: haproxy_item
+        label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
+        - haproxy_item.port | length > 4
 
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Ensure that haproxy service is running"
-  ansible.builtin.service:
-    name: haproxy
-    enabled: false
-    state: started
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for NWAS ASCS/ERS instances"
+      ansible.builtin.blockinfile:
+        create: true
+        path: "/etc/haproxy/haproxy-{{ haproxy_item.name }}.cfg"
+        mode: "0644"
+        owner: root
+        group: root
+        marker: "# {mark} Created by Ansible role sap_ha_pacemaker_cluster"
+        block: |
+          global
+              chroot      /var/lib/haproxy
+              pidfile     /var/run/haproxy-%i.pid
+              user        haproxy
+              group       haproxy
+              daemon
+
+          defaults
+              mode                    tcp
+              log                     global
+              option                  dontlognull
+              option                  redispatch
+              retries                 3
+              timeout queue           1m
+              timeout connect         10s
+              timeout client          1m
+              timeout server          1m
+              timeout check           10s
+              maxconn                 3000
+
+          # Listener for SAP healthcheck
+          listen healthcheck
+              bind *:{{ haproxy_item.port }}
+      loop: "{{ __sap_ha_pacemaker_cluster_healthcheck_list_ascs }}"
+      loop_control:
+        loop_var: haproxy_item
+        label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+
+
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Ensure that haproxy service is running"
+      ansible.builtin.service:
+        name: haproxy
+        enabled: false
+        state: started

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -219,7 +219,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: aws_vpc_move_ip
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_aws_ec2_vs | default('aws_vpc_move_ip') }}"
 sap_ha_pacemaker_cluster_vip_group_prefix: ''  # the default supported VIP agent is a single resource only
 
 __sap_ha_pacemaker_cluster_available_vip_agents:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -103,7 +103,15 @@ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: gcp_nlb_reserved_ip_haproxy # gcp_vpc_move_route
+# Google documentation differs for each OS:
+# SUSE - VIP: IPaddr2, Healthcheck: No pacemaker resources, but directly as part of NLB healthcheck
+#   HANA: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_a_local_cluster_ip_resource_for_the_vip_address
+#   NWAS: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#create_the_vip_resources
+# RHEL - VIP: IPaddr2, Healthcheck: haproxy
+#   HANA: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-rhel#create_a_virtual_ip_address_resource
+#   NWAS: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#create_a_virtual_ip_address_resource
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_gcp_ce_vm | default('gcp_nlb_reserved_ip_haproxy') }}"
+
 sap_ha_pacemaker_cluster_vip_group_prefix: group_
 
 __sap_ha_pacemaker_cluster_available_vip_agents:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -74,7 +74,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: ipaddr_custom
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_ibmcloud_powervs | default('ipaddr_custom') }}"
 
 __sap_ha_pacemaker_cluster_available_vip_agents:
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -50,7 +50,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: ibmcloud_alb_haproxy
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_ibmcloud_vs | default('ibmcloud_alb_haproxy') }}"
 
 # For HAPROXY an non-empty port default is required to enter the resource creation flow.
 # TODO: task logic that configures actual haproxy listening ports,

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -118,7 +118,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: azure_lb
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_msazure_vm | default('azure_lb') }}"
 
 # The VIP layer consists of 2 components - the VIP and the health check resource
 sap_ha_pacemaker_cluster_vip_group_prefix: group_

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -70,7 +70,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: ipaddr
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.hyp_ibmpower_vm | default('ipaddr') }}"
 
 __sap_ha_pacemaker_cluster_available_vip_agents:
 

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -100,6 +100,9 @@ __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
   nwas:
     - resource-agents-sap
 
+# Dictionary with preferred platform specific VIP method that differs from default
+# __sap_ha_pacemaker_cluster_vip_method_dict:
+
 # Resource agents - fully qualified names
 __sap_ha_pacemaker_cluster_resource_agents:
   saphanatopology: "ocf:heartbeat:SAPHanaTopology"

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -64,6 +64,10 @@ __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
     - sap-suse-cluster-connector
     - sapstartsrv-resource-agents
 
+# Dictionary with preferred platform specific VIP method that differs from default
+__sap_ha_pacemaker_cluster_vip_method_dict:
+  cloud_gcp_ce_vm: ipaddr
+
 # Resource agents - fully qualified names
 __sap_ha_pacemaker_cluster_resource_agents:
   saphanatopology: "ocf:suse:SAPHanaTopology"


### PR DESCRIPTION
### Changes
1. GCP Preconfigure task was moved to block to execute only if proper `gcp_nlb_reserved_ip_haproxy` method is used. This is not necessary for `ipaddr` method.
2. New `__sap_ha_pacemaker_cluster_sap_extra_packages_dict` dictionary in OS var files to accommodate override over default VIP method. This is similar dictionary implementation as done before for stonith, extra packages and others.

### Reason
haproxy is not documented method to be used on SUSE as per documentation from Google.
```yaml
# SUSE - VIP: IPaddr2, Healthcheck: No pacemaker resources, but directly as part of NLB healthcheck
#   HANA: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_a_local_cluster_ip_resource_for_the_vip_address
#   NWAS: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#create_the_vip_resources
# RHEL - VIP: IPaddr2, Healthcheck: haproxy
#   HANA: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-rhel#create_a_virtual_ip_address_resource
#   NWAS: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#create_a_virtual_ip_address_resource
```