### PR TITLE
  sap_ha_install_hana_hsr: fixes to work for multiple secondaries

### DIFF
--- a/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
@@ -32,6 +32,7 @@
 
 # looping through cluster definition to run on secondary node
 # and apply the respective 'site' value
+# - 'throttle' to avoid simultaneous run for multiple secondaries as this confuses the primary
 - name: "SAP HSR - Register secondary node to HANA System Replication"
   ansible.builtin.shell: |
     source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.sapenv.sh && \
@@ -51,6 +52,7 @@
   loop_control:
     label: "{{ item.node_name }}"
   changed_when: true
+  throttle: 1
 
 - name: "SAP HSR - Start HANA instance on secondary"
   ansible.builtin.shell: |

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -20,12 +20,19 @@
       node_ip: "{{ item.node_ip }}"
       node_role: "{{ item.node_role | default('secondary') }}"
       hana_site: "{{ item.hana_site }}"
-  loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
+  loop: "{{ sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_name', 'contains', ansible_hostname) }}"
   loop_control:
     label: "{{ item.node_name }}"
   when:
     - item.node_ip in ansible_all_ipv4_addresses
   tags: always
+
+- name: SAP HSR - Verify provided node roles
+  ansible.builtin.assert:
+    that:
+      - sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'primary') | length == 1
+      - sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'secondary') | length >= 1
+    fail_msg: "Node roles not valid. There must be 1 primary and at least 1 node defined with the secondary role."
 
 - name: SAP HSR - Check that hsr interface is configured on host
   ansible.builtin.assert:
@@ -38,16 +45,10 @@
 
 - name: "SAP HSR - Pick up primary node name from definition"
   ansible.builtin.set_fact:
-    __sap_ha_install_hana_hsr_primary_node: "{{ item.node_name }}"
-    __sap_ha_install_hana_hsr_primary_node_name: "{{ item.node_name.split('.')[0] }}"
-    __sap_ha_install_hana_hsr_primary_node_domain: "{{ item.node_name.split('.')[1:] | join('.') }}"
-    __sap_ha_install_hana_hsr_primary_node_ip: "{{ item.node_ip }}"
-  when:
-    - item.node_role is defined
-    - item.node_role == 'primary'
-  loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
-  loop_control:
-    label: "{{ item.node_name }}"
+    __sap_ha_install_hana_hsr_primary_node: "{{ (sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'primary'))[0].node_name }}"
+    __sap_ha_install_hana_hsr_primary_node_name: "{{ (sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'primary'))[0].node_name.split('.')[0] }}"
+    __sap_ha_install_hana_hsr_primary_node_domain: "{{ (sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'primary'))[0].node_name.split('.')[1:] | join('.') }}"
+    __sap_ha_install_hana_hsr_primary_node_ip: "{{ (sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'primary'))[0].node_ip }}"
   tags: always
 
 - name: "SAP HSR - Verify that Ansible can connect to the defined primary node by name"

--- a/roles/sap_ha_install_hana_hsr/tasks/pki_files.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pki_files.yml
@@ -23,10 +23,8 @@
           cat ~/.ssh/hsr_temp.pub || \
           (ssh-keygen -t rsa -f ~/.ssh/hsr_temp -N "" -q && \
           cat ~/.ssh/hsr_temp.pub)
-      args:
-        creates: ~/.ssh/hsr_temp.pub
       register: __sap_ha_install_hana_hsr_pubkey
-      failed_when: false
+      changed_when: true
 
     - name: "SAP HSR - Create .ssh on primary node if missing"
       ansible.builtin.file:
@@ -35,6 +33,7 @@
         mode: "0700"
       register: __sap_ha_install_hana_hsr_create_ssh_prim
       delegate_to: "{{ __sap_ha_install_hana_hsr_primary_node }}"
+      run_once: true
 
     - name: "SAP HSR - Authorize pub key on primary node"
       ansible.builtin.lineinfile:
@@ -45,6 +44,7 @@
         path: ~/.ssh/authorized_keys
       register: __sap_ha_install_hana_hsr_addauth
       delegate_to: "{{ __sap_ha_install_hana_hsr_primary_node }}"
+      throttle: 1
 
     # ansible-lint:
     # The synchronize module is not part of ansible-core collections.
@@ -106,6 +106,7 @@
       when:
         - __sap_ha_install_hana_hsr_addauth.backup is defined
         - __sap_ha_install_hana_hsr_addauth.backup|length == 0
+      throttle: 1
 
     - name: "SAP HSR - Primary: Restore authorized_keys from backup"
       ansible.builtin.copy:
@@ -117,6 +118,7 @@
       when:
         - __sap_ha_install_hana_hsr_addauth.backup is defined
         - __sap_ha_install_hana_hsr_addauth.backup|length > 0
+      run_once: true
 
     - name: "SAP HSR - Primary: Remove .ssh if it was created"
       ansible.builtin.file:
@@ -126,3 +128,4 @@
         - __sap_ha_install_hana_hsr_create_ssh_prim.changed is defined
         - __sap_ha_install_hana_hsr_create_ssh_prim.changed
       delegate_to: "{{ __sap_ha_install_hana_hsr_primary_node }}"
+      run_once: true


### PR DESCRIPTION
- improved some loops over the cluster nodes list using `selectattr`
- new task to validate that exactly 1 primary is defined and at least 1 secondary
- throttle 'secondary' tasks that execute on the primary at the same time otherwise and lead to conflicts
- some tasks only need to run once

This enables the base setup of Multi-Target System Replication.

Tested with 1 primary and 2 secondaries:
```
 sap_ha_install_hana_hsr_cluster_nodes:
      - hana_site: DC1
        node_name: su1hana1
        node_ip: <private node ip>
        node_role: primary
      - hana_site: DC2
        node_name: su1hana2
        node_ip: <private node ip>
        node_role: secondary
      - hana_site: DC3
        node_name: su1hana3
        node_ip: <private node ip>
        node_role: secondary
```