### PR TITLE
sap_hana_preconfigure: Add RHEL 8.10

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_8.yml
@@ -9,6 +9,7 @@ __sap_hana_preconfigure_supported_rhel_minor_releases:
   - "8.4"
   - "8.6"
   - "8.8"
+  - "8.10"
 
 # required repos for RHEL 8:
 __sap_hana_preconfigure_req_repos_redhat_8_0_x86_64:
@@ -123,13 +124,13 @@ __sap_hana_preconfigure_req_repos_redhat_8_10_ppc64le:
 
 # required SAP notes for RHEL 8:
 __sap_hana_preconfigure_sapnotes_versions_x86_64:
-  - { number: '2777782', version: '40' }
+  - { number: '2777782', version: '49' }
   - { number: '2382421', version: '40' }
   - { number: '3024346', version: '10' }
 
 __sap_hana_preconfigure_sapnotes_versions_ppc64le:
   - { number: '2055470', version: '87' }
-  - { number: '2777782', version: '40' }
+  - { number: '2777782', version: '49' }
   - { number: '2382421', version: '40' }
   - { number: '3024346', version: '10' }
 
@@ -187,6 +188,16 @@ __sap_hana_preconfigure_min_packages_8_8_x86_64:
 
 __sap_hana_preconfigure_min_packages_8_8_ppc64le:
   - [ 'kernel', '4.18.0-477.13.1.el8_8' ]
+
+__sap_hana_preconfigure_min_packages_8_9_x86_64:
+
+__sap_hana_preconfigure_min_packages_8_9_ppc64le:
+
+__sap_hana_preconfigure_min_packages_8_10_x86_64:
+  - [ 'kernel', '4.18.0-553.16.1.el8_10' ]
+
+__sap_hana_preconfigure_min_packages_8_10_ppc64le:
+  - [ 'kernel', '4.18.0-553.16.1.el8_10' ]
 
 __sap_hana_preconfigure_min_pkgs: "{{ lookup('vars', '__sap_hana_preconfigure_min_packages_' + ansible_distribution_version | string | replace(\".\", \"_\") + '_' + ansible_architecture) }}"
 


### PR DESCRIPTION
Solves issue #867.

Successfully tested against `x86_64` and `ppc64le` managed nodes.