### PR TITLE
fix: vip resources must be first in ASCS/ERS resource groups

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
@@ -256,9 +256,9 @@
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
+          sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name,
           sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name,
           sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name,
           sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
@@ -288,9 +288,9 @@
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
+          sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name,
           sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name,
           sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name,
           sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}


### PR DESCRIPTION
Fixing the order of the resources in ASCS and ERS resource groups.

The VIP resource has to be the first to be started and the last to be stopped.
This will align the automation with the documentation by all providers.

### Tested
RHEL 9.4 on AWS