### PR TITLE
sap_netweaver_preconfigure/SUSE: Fix for issue 868 specific to SLES4SAP15 SP6

### DIFF
--- a/roles/sap_hana_preconfigure/defaults/main.yml
+++ b/roles/sap_hana_preconfigure/defaults/main.yml
@@ -166,18 +166,15 @@ sap_hana_preconfigure_run_grub2_mkconfig: true
 # It will be used to configure process limits as per step "Configuring Process Resource Limits" of SAP note 2772999.
 # Example: See README.md
 
-sap_hana_preconfigure_saptune_version: ''
-# Version of saptune to install (SLES for SAP Applications).
+# (SUSE specific) Version of saptune to install.
 # It is recommended to install latest version by keeping this variable empty.
 # This will replace the current installed version if present, even downgrade if necessary.
+sap_hana_preconfigure_saptune_version: ''
 
+# (SUSE specific) Saptune solution to be applied.
+# Available options for HANA are: HANA, NETWEAVER+HANA, S4HANA-APP+DB, S4HANA-DBSERVER
 sap_hana_preconfigure_saptune_solution: 'HANA'
-# The saptune solution to apply (SLES for SAP Applications).
-# Possible Values:
-# - HANA
-# - NETWEAVER+HANA
-# - S4HANA-APP+DB
-# - S4HANA-DBSERVER
+
 
 sap_hana_preconfigure_saptune_azure: false
 # On Azure, TCP timestamps, reuse and recycle should be disabled (SLES for SAP Applications).

--- a/roles/sap_hana_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_hana_preconfigure/meta/argument_specs.yml
@@ -353,7 +353,7 @@ argument_specs:
       sap_hana_preconfigure_saptune_version:
         default: ''
         description:
-          - Version of saptune to install (SLES for SAP Applications).
+          - (SUSE specific) Version of saptune to install.
           - This will replace the current installed version if present, even downgrade if necessary.
         required: false
         type: str
@@ -361,7 +361,7 @@ argument_specs:
       sap_hana_preconfigure_saptune_solution:
         default: HANA
         description:
-          - The saptune solution to apply (SLES for SAP Applications).
+          - (SUSE specific) Saptune solution to be applied.
         choices:
           - 'HANA'
           - 'NETWEAVER+HANA'

--- a/roles/sap_hana_preconfigure/tasks/main.yml
+++ b/roles/sap_hana_preconfigure/tasks/main.yml
@@ -5,12 +5,18 @@
   ansible.builtin.debug:
     var: role_path
 
+# Load variable file starting with actual version up to OS family.
+# Example for SUSE Linux Enterprise Server for SAP Applications 15 SP6:
+# 1. SLES_SAP_15.6.yml
+# 2. SLES_SAP_15.yml
+# 3. SLES_15.yml
+# 4. Suse.yml
 - name: Include OS specific vars
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
-    - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml'
     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_os_family }}.yml'
 
 - name: Set filename prefix to empty string if role is run in normal mode

--- a/roles/sap_netweaver_preconfigure/defaults/main.yml
+++ b/roles/sap_netweaver_preconfigure/defaults/main.yml
@@ -3,30 +3,24 @@
 # defaults file for sap_netweaver_preconfigure
 
 # Perform an assertion run:
-sap_netweaver_preconfigure_assert: no
+sap_netweaver_preconfigure_assert: false
 
 # In case of an assertion run, if set to "yes", the role will abort for any assertion error:
-sap_netweaver_preconfigure_assert_ignore_errors: no
+sap_netweaver_preconfigure_assert_ignore_errors: false
 
 sap_netweaver_preconfigure_min_swap_space_mb: '20480'
 
-sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: yes
+sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: true
 
 sap_netweaver_preconfigure_rpath: '/usr/sap/lib'
 
-sap_netweaver_preconfigure_use_adobe_doc_services: no
+sap_netweaver_preconfigure_use_adobe_doc_services: true
 
-#SLES Only
-sap_netweaver_preconfigure_saptune_version: '3.0.2'
+# (SUSE specific) Version of saptune to install.
+# It is recommended to install latest version by keeping this variable empty.
+# This will replace the current installed version if present, even downgrade if necessary.
+sap_netweaver_preconfigure_saptune_version: ''
 
-## The following variables control aspects of saptune and are only relevant for SLES for SAP Application
-
-# The saptune solution to apply.  For netweaver, the only appropriate options are:
-#NETWEAVER
-#NETWEAVER+HANA
-#S4HANA-APP+DB
-#S4HANA-APPSERVER
-#S4HANA-DBSERVER
-# The default value is NETWEAVER
-
+# (SUSE specific) Saptune solution to be applied.
+# Available options for Netweaver are: NETWEAVER, NETWEAVER+HANA, S4HANA-APP+DB, S4HANA-APPSERVER, S4HANA-DBSERVER
 sap_netweaver_preconfigure_saptune_solution: NETWEAVER

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -96,16 +96,17 @@ argument_specs:
         type: bool
 
       sap_netweaver_preconfigure_saptune_version:
-        default: '3.0.2'
+        default: ''
         description:
-          - On SLES systems, specifies the saptune version
+          - (SUSE specific) Version of saptune to install.
+          - This will replace the current installed version if present, even downgrade if necessary.
         required: false
         type: str
 
       sap_netweaver_preconfigure_saptune_solution:
         default: 'NETWEAVER'
         description:
-          - On SLES systems, specifies the saptune solution to apply.
+          - (SUSE specific) Saptune solution to be applied.
         choices:
           - 'NETWEAVER'
           - 'NETWEAVER+HANA'

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
@@ -20,15 +20,30 @@
     - '"SLES" in sles_baseproduct.stat.lnk_target'
     - ansible_os_family == 'Suse'
 
-# The use of zypper here allows exact saptune version to be declared and used.
-- name: Ensure saptune is installed
-  community.general.zypper:
-    type: package
-    name: "saptune={{ sap_netweaver_preconfigure_saptune_version }}"
-    state: present
-    force: true
+
+- name: Prepare saptune
   when:
     - __sap_netweaver_preconfigure_run_saptune
+  block:
+    - name: Ensure latest saptune is installed
+      community.general.zypper:
+        type: package
+        name: saptune
+        state: present
+      when:
+        - sap_netweaver_preconfigure_saptune_version is undefined
+         or sap_netweaver_preconfigure_saptune_version | length == 0
+
+    - name: Ensure specific saptune version is installed
+      community.general.zypper:
+        type: package
+        name: "saptune={{ sap_netweaver_preconfigure_saptune_version }}"
+        state: present
+        force: true
+      when:
+        - sap_netweaver_preconfigure_saptune_version is defined
+        - sap_netweaver_preconfigure_saptune_version | length > 0
+
 
 - name: Ensure sapconf is installed
   community.general.zypper:

--- a/roles/sap_netweaver_preconfigure/tasks/main.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/main.yml
@@ -5,12 +5,18 @@
   ansible.builtin.debug:
     var: role_path
 
+# Load variable file starting with actual version up to OS family.
+# Example for SUSE Linux Enterprise Server for SAP Applications 15 SP6:
+# 1. SLES_SAP_15.6.yml
+# 2. SLES_SAP_15.yml
+# 3. SLES_15.yml
+# 4. Suse.yml
 - name: Include OS specific vars
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
-    - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml'
     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_distribution.split("_")[0] }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_os_family }}.yml'
 
 - name: Set filename prefix to empty string if role is run in normal mode

--- a/roles/sap_netweaver_preconfigure/vars/SLES_SAP_15.6.yml
+++ b/roles/sap_netweaver_preconfigure/vars/SLES_SAP_15.6.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# required SAP Notes for SLES 15
+
+__sap_netweaver_preconfigure_sapnotes:
+  - "1275776"
+
+__sap_netweaver_preconfigure_packages:
+  - libstdc++6
+  - libatomic1
+  - libgcc_s1
+  - libltdl7
+  - insserv-compat
+  - cpupower
+  - hicolor-icon-theme
+  - libcpupower1
+  - libsensors4
+  - patterns-base-basesystem
+  - patterns-server-enterprise-sap_server
+  - patterns-yast-yast2_basis
+  - procmail
+  - sysstat
+  - system-user-uuidd
+  - uuidd
+  - yast2-auth-client
+  - yast2-auth-server
+  - yast2-theme
+  - yast2-vpn
+  - tcsh
+  - acl
+
+# SLES_SAP is using saptune, but SLES is using sapconf.
+# Default value true runs saptune, but installation.yml auto-detects base product and adjusts.
+__sap_netweaver_preconfigure_run_saptune: true


### PR DESCRIPTION
Several changes were added to both `sap_netweaver_preconfigure` and `sap_hana_preconfigure` roles to resolve issue reported in https://github.com/sap-linuxlab/community.sap_install/issues/868

- Add new var file for `SLES_SAP_15.6`
- Change order for var file loading to ensure that actual version is loaded first, instead of major distribution that was used before.</br> **Major + Minor combination var file would be ignored without this change!**
- Update saptune version flow in `sap_netweaver_preconfigure` to align with changes done in `sap_hana_preconfigure` before.
- Fix `yes/no` values in `sap_netweaver_preconfigure` defaults file causing linting errors.