### PR TITLE
sap_ha_pacemaker_cluster: JAVA HA scenarios and complete refactor

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/DEPRECATED_VARIABLES.md
+++ b/roles/sap_ha_pacemaker_cluster/DEPRECATED_VARIABLES.md
@@ -1,0 +1,53 @@
+# sap_ha_pacemaker_cluster Deprecated input variables
+
+This deprecation of input variables is part of an ongoing effort to improve the codebase by removing unnecessary elements and streamlining the overall design.
+
+These variables fall into a few categories:
+- **Obsolete or unused**
+  - These variables are no longer used and are being removed to reduce technical debt and potential confusion.
+- **Renamed**
+  - These variables are being renamed to better reflect their current purpose and improve code readability.
+  - This is especially important when the variable's functionality has evolved over time.
+
+## Backwards compatibility
+All deprecated variables offer time limited backwards compatibility that will be removed in future.
+
+## List of deprecated input variables
+| Old variable | New variable | Backwards compatible | Reason |
+| -------- | --------- | --------- | --------- |
+| sap_ha_pacemaker_cluster_nwas_abap_sid | sap_ha_pacemaker_cluster_nwas_sid | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | sap_ha_pacemaker_cluster_nwas_ers_instance_nr | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string | sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string | sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name | sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name | sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name | sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name | sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name | sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name | sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness | sap_ha_pacemaker_cluster_nwas_cs_group_stickiness | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1 | sap_ha_pacemaker_cluster_nwas_cs_ensa1 | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount | sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name | sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name | sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name | sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name | sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name | sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name | sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id | sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id | sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | :heavy_check_mark: | Removal of `_abap_` |
+| sap_ha_pacemaker_cluster_storage_nfs_filesytem_type | sap_ha_pacemaker_cluster_storage_nfs_filesystem_type | :heavy_check_mark: | Typo |
+
+
+## Status explanation:
+- :heavy_check_mark: - Variable is removed from defaults and readme, but still supported.
+- :x: - Variable is completely removed and not supported

--- a/roles/sap_ha_pacemaker_cluster/DEPRECATED_VARIABLES.md
+++ b/roles/sap_ha_pacemaker_cluster/DEPRECATED_VARIABLES.md
@@ -13,41 +13,42 @@ These variables fall into a few categories:
 All deprecated variables offer time limited backwards compatibility that will be removed in future.
 
 ## List of deprecated input variables
-| Old variable | New variable | Backwards compatible | Reason |
-| -------- | --------- | --------- | --------- |
-| sap_ha_pacemaker_cluster_nwas_abap_sid | sap_ha_pacemaker_cluster_nwas_sid | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | sap_ha_pacemaker_cluster_nwas_ers_instance_nr | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string | sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string | sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name | sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name | sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name | sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name | sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name | sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name | sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout | sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness | sap_ha_pacemaker_cluster_nwas_cs_group_stickiness | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1 | sap_ha_pacemaker_cluster_nwas_cs_ensa1 | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount | sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name | sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name | sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name | sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name | sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name | sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name | sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id | sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id | sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | :heavy_check_mark: | Removal of `_abap_` |
-| sap_ha_pacemaker_cluster_storage_nfs_filesytem_type | sap_ha_pacemaker_cluster_storage_nfs_filesystem_type | :heavy_check_mark: | Typo |
+| ~~Old variable~~<br>New variable | Backwards compatible | Reason |
+| --------- | --------- | --------- |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_sid~~<br>sap_ha_pacemaker_cluster_nwas_sid | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr~~<br>sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr~~<br>sap_ha_pacemaker_cluster_nwas_ers_instance_nr | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name~~<br>sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name~~<br>sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string~~<br>sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string~~<br>sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name~~<br>sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name~~<br>sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name~~<br>sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name~~<br>sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name~~<br>sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name~~<br>sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool~~<br>sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness~~<br>sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold~~<br>sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout~~<br>sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness~~<br>sap_ha_pacemaker_cluster_nwas_cs_group_stickiness | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1~~<br>sap_ha_pacemaker_cluster_nwas_cs_ensa1 | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount~~<br>sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address~~<br>sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name~~<br>sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address~~<br>sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name~~<br>sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name~~<br>sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name~~<br>sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name~~<br>sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name~~<br>sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id~~<br>sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id~~<br>sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | :heavy_check_mark: | Removal of `_abap_` |
+| ~~sap_ha_pacemaker_cluster_storage_nfs_filesytem_type~~<br>sap_ha_pacemaker_cluster_storage_nfs_filesystem_type | :heavy_check_mark: | Typo |
 
 
 ## Status explanation:
+- Strikethrough - Name of deprecated variable
 - :heavy_check_mark: - Variable is removed from defaults and readme, but still supported.
 - :x: - Variable is completely removed and not supported

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -166,18 +166,8 @@ Minimum required parameters for all clusters:
 
 Additional minimum requirements depend on the type of cluster setup and on the target platform.
 
-### sap_ha_pacemaker_cluster_hacluster_user_password
-
-- _Type:_ `string`
-
-**Mandatory Input Parameter.**</br>
-The password of the `hacluster` user which is created during pacemaker installation.<br>
-Inherits the value of `ha_cluster_hacluster_password`, when defined.<br>
-
-
 ### sap_ha_pacemaker_cluster_aws_access_key_id
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 AWS access key to allow control of instances (for example for fencing operations).<br>
 Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
@@ -185,8 +175,7 @@ Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
 2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`<br>
 
 ### sap_ha_pacemaker_cluster_aws_credentials_setup
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Set this parameter to 'true' to store AWS credentials into /root/.aws/credentials.<br>
 Requires: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`<br>
@@ -194,15 +183,13 @@ Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
 1. IAM Role or Instance profile is not attached to EC2 instance.<br>
 
 ### sap_ha_pacemaker_cluster_aws_region
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The AWS region in which the instances to be used for the cluster setup are located.<br>
 Mandatory for cluster nodes setup on AWS EC2 instances.<br>
 
 ### sap_ha_pacemaker_cluster_aws_secret_access_key
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 AWS secret key, paired with the access key for instance control.<br>
 Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
@@ -210,24 +197,21 @@ Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
 2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`<br>
 
 ### sap_ha_pacemaker_cluster_aws_vip_update_rt
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 List one more routing table IDs for managing Virtual IP failover through routing table changes.<br>
 Multiple routing tables must be defined as a comma-separated string (no spaces).<br>
 Mandatory for the VIP resource configuration in AWS EC2 environments.<br>
 
 ### sap_ha_pacemaker_cluster_cluster_name
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The name of the pacemaker cluster.<br>
 Inherits the `ha_cluster` LSR native parameter `ha_cluster_cluster_name` if not defined.<br>
 If not defined, the `ha_cluster` Linux System Role default will be used.<br>
 
 ### sap_ha_pacemaker_cluster_cluster_nodes
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 List of cluster nodes and associated attributes to describe the target SAP HA environment.<br>
 This is required for the HANA System Replication configuration.<br>
@@ -235,16 +219,16 @@ Synonym for this parameter is `sap_hana_cluster_nodes`.<br>
 Mandatory to be defined for HANA clusters.<br>
 
 - **hana_site**<br>
-    Site of the cluster and/or SAP HANA System Replication node (for example 'DC01').<br>Mandatory for HANA clusters (sudo config for system replication).
+Site of the cluster and/or SAP HANA System Replication node (for example 'DC01').<br>Mandatory for HANA clusters (sudo config for system replication).
 - **node_ip**<br>
-    IP address of the node used for HANA System Replication.<br>_Optional. Currently not needed/used in cluster configuration._
+IP address of the node used for HANA System Replication.<br>_Optional. Currently not needed/used in cluster configuration._
 - **node_name**<br>
-    Name of the cluster node, should match the remote systems' hostnames.<br>_Optional. Currently not needed/used in cluster configuration._
+Hostname of the cluster node.<br>_Optional. Currently not needed/used in cluster configuration._
 - **node_role**<br>
-    Role of the defined `node_name` in the SAP HANA cluster setup.<br>There must be only **one** primary, but there can be multiple secondary nodes.<br>_Optional. Currently not needed/used in cluster configuration._
+_Choices:_ `primary, secondary`<br>
+Role of the defined `node_name` in the SAP HANA cluster setup.<br>There must be only **one** primary, but there can be multiple secondary nodes.<br>_Optional. Currently not needed/used in cluster configuration._
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_cluster_nodes:
 - hana_site: DC01
@@ -253,28 +237,23 @@ sap_ha_pacemaker_cluster_cluster_nodes:
   node_role: primary
 - hana_site: DC02
 ```
-
 ### sap_ha_pacemaker_cluster_cluster_properties
-
-- _Type:_ `dict`
-- _Default:_ `{'concurrent-fencing': True, 'stonith-enabled': True, 'stonith-timeout': 900}`
+- _Type:_ `dict`<br>
+- _Default:_ `{'concurrent-fencing': True, 'stonith-enabled': True, 'stonith-timeout': 900}`<br>
 
 Standard pacemaker cluster properties are configured with recommended settings for cluster node fencing.<br>
 When no STONITH resource is defined, STONITH will be disabled and a warning displayed.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_cluster_properties:
   concurrent-fencing: true
   stonith-enabled: true
   stonith-timeout: 900
 ```
-
 ### sap_ha_pacemaker_cluster_create_config_dest
-
-- _Type:_ `string`
-- _Default:_ `review_resource_config.yml`
+- _Type:_ `string`<br>
+- _Default:_ `review_resource_config.yml`<br>
 
 The pacemaker cluster resource configuration optionally created by this role will be saved in a Yaml file in the current working directory.<br>
 Requires `sap_ha_pacemaker_cluster_create_config_varfile` to be enabled for generating the output file.<br>
@@ -282,9 +261,8 @@ Specify a path/filename to save the file in a custom location.<br>
 The file can be used as input vars file for an Ansible playbook running the 'ha_cluster' Linux System Role.<br>
 
 ### sap_ha_pacemaker_cluster_create_config_varfile
-
-- _Type:_ `bool`
-- _Default:_ `False`
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
 
 When enabled, all cluster configuration parameters this role constructs for executing the 'ha_cluster' Linux System role will be written into a file in Yaml format.<br>
 This allows using the output file later as input file for additional custom steps using the 'ha_cluster' role and covering the resource configuration in a cluster that was set up using this 'sap_ha_pacemaker_cluster' role.<br>
@@ -292,23 +270,20 @@ When enabled this parameters file is also created when the playbook is run in ch
 WARNING! This report may include sensitive details like secrets required for certain cluster resources!<br>
 
 ### sap_ha_pacemaker_cluster_enable_cluster_connector
-
-- _Type:_ `bool`
-- _Default:_ `True`
+- _Type:_ `bool`<br>
+- _Default:_ `True`<br>
 
 Enables/Disables the SAP HA Interface for SAP ABAP application server instances, also known as `sap_cluster_connector`.<br>
 Set this parameter to 'false' if the SAP HA interface should not be installed and configured.<br>
 
 ### sap_ha_pacemaker_cluster_extra_packages
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 Additional extra packages to be installed, for instance specific resource packages.<br>
 For SAP clusters configured by this role, the relevant standard packages for the target scenario are automatically included.<br>
 
 ### sap_ha_pacemaker_cluster_fence_agent_packages
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 Additional fence agent packages to be installed.<br>
 This is automatically combined with default packages in:<br>
@@ -316,22 +291,19 @@ This is automatically combined with default packages in:<br>
 `__sap_ha_pacemaker_cluster_fence_agent_packages_platform`<br>
 
 ### sap_ha_pacemaker_cluster_gcp_project
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Google Cloud project name in which the target instances are installed.<br>
 Mandatory for the cluster setup on GCP instances.<br>
 
 ### sap_ha_pacemaker_cluster_gcp_region_zone
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Google Cloud Platform region zone ID.<br>
 Mandatory for the cluster setup on GCP instances.<br>
 
 ### sap_ha_pacemaker_cluster_ha_cluster
-
-- _Type:_ `dict`
+- _Type:_ `dict`<br>
 
 The `ha_cluster` LSR native parameter `ha_cluster` can be used as a synonym.<br>
 Optional _**host_vars**_ parameter - if defined it must be set for each node.<br>
@@ -340,7 +312,6 @@ Supported options can be reviewed in the `ha_cluster` Linux System Role [https:/
 If not defined, the `ha_cluster` Linux System Role default will be used.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_ha_cluster:
   corosync_addresses:
@@ -348,33 +319,35 @@ sap_ha_pacemaker_cluster_ha_cluster:
   - 192.168.2.10
   node_name: nodeA
 ```
+### sap_ha_pacemaker_cluster_hacluster_user_password <sup>required</sup>
+- **Required**<br>
+- _Type:_ `string`<br>
+
+The password of the `hacluster` user which is created during pacemaker installation.<br>
+Inherits the value of `ha_cluster_hacluster_password`, when defined.<br>
 
 ### sap_ha_pacemaker_cluster_hana_automated_register
-
-- _Type:_ `bool`
-- _Default:_ `True`
+- _Type:_ `bool`<br>
+- _Default:_ `True`<br>
 
 Parameter for the 'SAPHana' cluster resource.<br>
 Define if a former primary should be re-registered automatically as secondary.<br>
 
 ### sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name
-
-- _Type:_ `string`
-- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_primary`
+- _Type:_ `string`<br>
+- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_primary`<br>
 
 Customize the cluster constraint name for VIP and SAPHana primary clone colocation.<br>
 
 ### sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name
-
-- _Type:_ `string`
-- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_readonly`
+- _Type:_ `string`<br>
+- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_readonly`<br>
 
 Customize the cluster constraint name for VIP and SAPHana secondary clone colocation.<br>
 
 ### sap_ha_pacemaker_cluster_hana_duplicate_primary_timeout
-
-- _Type:_ `int`
-- _Default:_ `7200`
+- _Type:_ `int`<br>
+- _Default:_ `7200`<br>
 
 Parameter for the 'SAPHana' cluster resource.<br>
 Time difference needed between to primary time stamps, if a dual-primary situation occurs.<br>
@@ -382,46 +355,40 @@ If the time difference is less than the time gap, then the cluster holds one or 
 This is to give an admin a chance to react on a failover. A failed former primary will be registered after the time difference is passed.<br>
 
 ### sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name
-
-- _Type:_ `string`
-- _Default:_ `cln_SAPHanaFil_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `cln_SAPHanaFil_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA Filesystem clone.<br>
 
 ### sap_ha_pacemaker_cluster_hana_filesystem_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPHanaFil_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPHanaFil_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA Filesystem.<br>
 
 ### sap_ha_pacemaker_cluster_hana_global_ini_path
-
-- _Type:_ `string`
-- _Default:_ `/usr/sap/<SID>/SYS/global/hdb/custom/config/global.ini`
+- _Type:_ `string`<br>
+- _Default:_ `/usr/sap/<SID>/SYS/global/hdb/custom/config/global.ini`<br>
 
 Path with location of global.ini for srHook update<br>
 
 ### sap_ha_pacemaker_cluster_hana_hook_chksrv
-
-- _Type:_ `bool`
-- _Default:_ `False`
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
 
 Controls if ChkSrv srHook is enabled during srHook creation.<br>
 It is ignored when sap_ha_pacemaker_cluster_hana_hooks is defined.<br>
 
 ### sap_ha_pacemaker_cluster_hana_hook_tkover
-
-- _Type:_ `bool`
-- _Default:_ `False`
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
 
 Controls if TkOver srHook is enabled during srHook creation.<br>
 It is ignored when sap_ha_pacemaker_cluster_hana_hooks is defined.<br>
 
 ### sap_ha_pacemaker_cluster_hana_hooks
-
-- _Type:_ `list`
-- _Default:_ `[]`
+- _Type:_ `list`<br>
+- _Default:_ `[]`<br>
 
 Customize required list of SAP HANA Hooks<br>
 Mandatory to include SAPHanaSR srHook in list.<br>
@@ -429,753 +396,771 @@ Mandatory attributes are provider and path.<br>
 Example below shows mandatory SAPHanaSR, TkOver and ChkSrv hooks.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_hana_hooks:
-- options:
-  - name: execution_order
-    value: 1
-  path: /usr/share/SAPHanaSR/
-  provider: SAPHanaSR
-- options:
-  - name: execution_order
-    value: 2
-  path: /usr/share/SAPHanaSR/
-  provider: susTkOver
-- options:
-  - name: execution_order
-    value: 3
-  - name: action_on_lost
-    value: stop
-  path: /usr/share/SAPHanaSR/
-  provider: susChkSrv
+  - options:
+    - name: execution_order
+      value: 1
+    path: /usr/share/SAPHanaSR/
+    provider: SAPHanaSR
+  - options:
+    - name: execution_order
+      value: 2
+    path: /usr/share/SAPHanaSR/
+    provider: susTkOver
+  - options:
+    - name: execution_order
+      value: 3
+    - name: action_on_lost
+      value: stop
+    path: /usr/share/SAPHanaSR/
+    provider: susChkSrv
 ```
-
 ### sap_ha_pacemaker_cluster_hana_instance_nr
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The instance number of the SAP HANA database which this role will configure in the cluster.<br>
 Inherits the value of `sap_hana_instance_number`, when defined.<br>
-Mandatory for SAP HANA cluster setups.<br>
+Mandatory for SAP HANA cluster scenarios.<br>
 
 ### sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name
-
-- _Type:_ `string`
-- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_primary`
+- _Type:_ `string`<br>
+- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_primary`<br>
 
 Customize the cluster constraint name for VIP and SAPHana primary clone order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name
-
-- _Type:_ `string`
-- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_readonly`
+- _Type:_ `string`<br>
+- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_readonly`<br>
 
 Customize the cluster constraint name for VIP and SAPHana secondary clone order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_order_topology_hana_name
-
-- _Type:_ `string`
-- _Default:_ `ord_saphana_saphanatop_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `ord_saphana_saphanatop_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster constraint name for SAPHana and Topology order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_prefer_site_takeover
-
-- _Type:_ `bool`
-- _Default:_ `True`
+- _Type:_ `bool`<br>
+- _Default:_ `True`<br>
 
 Parameter for the 'SAPHana' cluster resource.<br>
 Set to "false" if the cluster should first attempt to restart the instance on the same node.<br>
 When set to "true" (default) a failover to secondary will be initiated on resource failure.<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_clone_msl_name
-
-- _Type:_ `string`
-- _Default:_ `msl_SAPHana_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `msl_SAPHana_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA DB resource master slave clone.<br>
 Master Slave clone is specific to Classic SAPHana resource on SUSE (non-angi).<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_clone_name
-
-- _Type:_ `string`
-- _Default:_ `cln_SAPHana_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `cln_SAPHana_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA DB resource clone.<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPHana_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPHana_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA DB resource.<br>
 
 ### sap_ha_pacemaker_cluster_hana_sid
+- _Type:_ `string`<br>
 
-- _Type:_ `string`
-
-The SAP HANA SID of the instance that will be configured in the cluster.<br>
+The SAP HANA System ID (SID) of the instance that will be configured in the cluster.<br>
 The SID must follow SAP specifications - see SAP Note 1979280.<br>
 Inherits the value of `sap_hana_sid`, when defined.<br>
-Mandatory for SAP HANA cluster setups.<br>
+Mandatory for SAP HANA cluster scenarios.<br>
 
 ### sap_ha_pacemaker_cluster_hana_topology_resource_clone_name
-
-- _Type:_ `string`
-- _Default:_ `cln_SAPHanaTop_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `cln_SAPHanaTop_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA Topology resource clone.<br>
 
 ### sap_ha_pacemaker_cluster_hana_topology_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPHanaTop_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPHanaTop_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA Topology resource.<br>
 
 ### sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
-
-- _Type:_ `string`
-- _Default:_ `cln_SAPHanaCon_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `cln_SAPHanaCon_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA Controller clone.<br>
 
 ### sap_ha_pacemaker_cluster_hanacontroller_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPHanaCon_<SID>_HDB<Instance Number>`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPHanaCon_<SID>_HDB<Instance Number>`<br>
 
 Customize the cluster resource name of the SAP HANA Controller.<br>
 
-### sap_ha_pacemaker_cluster_host_type
+### sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_HDB<Instance Number>_primary`<br>
 
-- _Type:_ `list`
-- _Default:_ `hana_scaleup_perf`
+Name of the Virtual IP Health Check resource for primary HANA instance.<br>
+
+### sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_HDB<Instance Number>_readonly`<br>
+
+Name of the Virtual IP Health Check resource for read-only HANA instance.<br>
+
+### sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_AAS<AAS-instance-number>`<br>
+
+Name of the Virtual IP Health Check resource for NetWeaver AAS.<br>
+
+### sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_PAS<PAS-instance-number>`<br>
+
+Name of the Virtual IP Health Check resource for NetWeaver PAS.<br>
+
+### sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_ASCS<ASCS-instance-number>`<br>
+
+Name of the Virtual IP Health Check resource for NetWeaver ABAP Central Services (ASCS).<br>
+
+### sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_ERS<ERS-instance-number>`<br>
+
+Name of the Virtual IP Health Check resource for NetWeaver Enqueue Replication Service (ERS).<br>
+
+### sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_health_check_<SID>_SCS<SCS-instance-number>`<br>
+
+Name of the Virtual IP Health Check resource for NetWeaver Central Services (SCS).<br>
+
+### sap_ha_pacemaker_cluster_host_type
+- _Type:_ `list`<br>
+- _Default:_ `hana_scaleup_perf`<br>
+- _Choices:_ `hana_scaleup_perf, nwas_abap_ascs_ers, nwas_java_scs_ers`<br>
 
 The SAP landscape to for which the cluster is to be configured.<br>
 The default is a 2-node SAP HANA scale-up cluster.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_api_key
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The API key which is required to allow the control of instances (for example for fencing operations).<br>
 Mandatory for the cluster setup on IBM Cloud Virtual Server instances or IBM Power Virtual Server on IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 IBM Power Virtual Server API Endpoint type (public or private) dependent on network interface attachments for the target instances.<br>
 Mandatory for the cluster setup on IBM Power Virtual Server from IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 IBM Power Virtual Server forward proxy url when IBM Power Virtual Server API Endpoint type is set to private.<br>
 When public network interface, can be ignored.<br>
 When private network interface, mandatory for the cluster setup on IBM Power Virtual Server from IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_crn
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 IBM Power Virtual Server Workspace service cloud resource name (CRN) identifier which contains the target instances<br>
 Mandatory for the cluster setup on IBM Power Virtual Server from IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_region
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The IBM Cloud VS region name in which the instances are running.<br>
 Mandatory for the cluster setup on IBM Cloud Virtual Server instances or IBM Power Virtual Server on IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_msazure_resource_group
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Resource group name/ID in which the target instances are defined.<br>
 Mandatory for the cluster setup on MS Azure instances.<br>
 
 ### sap_ha_pacemaker_cluster_msazure_subscription_id
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Subscription ID of the MS Azure environment containing the target instances.<br>
 Mandatory for the cluster setup on MS Azure instances.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Instance number of the NetWeaver ABAP AAS instance.<br>
 Mandatory for NetWeaver AAS cluster configuration.<br>
 
-### sap_ha_pacemaker_cluster_nwas_cs_ensa1
-
-- _Type:_ `bool`
-- _Default:_ `False`
-
-The standard NetWeaver Central Services (ASCS or SCS) cluster will be set up as ENSA2.<br>
-Set this parameter to 'true' to configure it as ENSA1.<br>
-
-### sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
-
-- _Type:_ `bool`
-- _Default:_ `True`
-
-Enables preferred method for Central Services (ASCS or SCS) ENSA2 clusters - Simple Mount.<br>
-Set this parameter to 'true' to configure ENSA2 Simple Mount.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_fs_<SID>_ASCS<ASCS-instance-number>`
-
-Name of the filesystem resource for the ASCS instance.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness
-
-- _Type:_ `string`
-- _Default:_ `3000`
-
-NetWeaver ASCS resource group stickiness to prefer the ASCS group to stay on the node it was started on.<br>
-
-### sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
-
-- _Type:_ `string`
-
-Instance number of the NetWeaver ABAP Central Services (ASCS) instance.<br>
-Mandatory for NetWeaver ASCS/ERS cluster configuration.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool
-
-- _Type:_ `bool`
-- _Default:_ `False`
-
-NetWeaver ASCS instance resource option "AUTOMATIC_RECOVER".<br>
-
-### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout
-
-- _Type:_ `string`
-- _Default:_ `60`
-
-NetWeaver Central Services (ASCS or SCS) instance failure-timeout attribute.<br>
-Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
-
-### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold
-
-- _Type:_ `string`
-- _Default:_ `1`
-
-NetWeaver Central Services (ASCS or SCS) instance migration-threshold setting attribute.<br>
-Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name
-
-- _Type:_ `string`
-
-The name of the ASCS instance, typically the profile name.<br>
-Mandatory for the NetWeaver ASCS/ERS cluster setup<br>
-Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname>.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>`
-
-Name of the ASCS instance resource.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness
-
-- _Type:_ `string`
-- _Default:_ `5000`
-
-NetWeaver ASCS instance resource stickiness attribute.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string
-
-- _Type:_ `string`
-
-The full path and name of the ASCS instance profile.<br>
-Mandatory for the NetWeaver ASCS/ERS cluster setup.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>`
-
-Name of the ASCS SAPStartSrv resource for simple mount.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_fs_<SID>_ERS<ERS-instance-number>`
-
-Name of the filesystem resource for the ERS instance.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr
-
-- _Type:_ `string`
-
-Instance number of the NetWeaver ABAP ERS instance.<br>
-Mandatory for NetWeaver ASCS/ERS cluster configuration.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool
-
-- _Type:_ `bool`
-- _Default:_ `False`
-
-NetWeaver ERS instance resource option "AUTOMATIC_RECOVER".<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name
-
-- _Type:_ `string`
-
-The name of the ERS instance, typically the profile name.<br>
-Mandatory for the NetWeaver ASCS/ERS cluster setup.<br>
-Recommended format <SID>_ERS<ERS-instance-number>_<ERS-hostname>.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPInstance_<SID>_ERS<ERS-instance-number>`
-
-Name of the ERS instance resource.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string
-
-- _Type:_ `string`
-
-The full path and name of the ERS instance profile.<br>
-Mandatory for the NetWeaver ASCS/ERS cluster.<br>
-
-### sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>`
-
-Name of the ERS SAPstartSrv resource for simple mount.<br>
-
 ### sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Instance number of the NetWeaver ABAP PAS instance.<br>
 Mandatory for NetWeaver PAS cluster configuration.<br>
 
-### sap_ha_pacemaker_cluster_nwas_sid
+### sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_fs_<SID>_ASCS<ASCS-instance-number>`<br>
 
-- _Type:_ `string`
+Name of the filesystem resource for the ASCS instance.<br>
 
-SID of the NetWeaver instances.<br>
-Mandatory for NetWeaver cluster configuration.<br>
-Uses `sap_swpm_sid` if defined.<br>
-Mandatory for NetWeaver cluster setups.<br>
+### sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
+- _Type:_ `string`<br>
+
+Instance number of the NetWeaver ABAP Central Services (ASCS) instance.<br>
+Mandatory for NetWeaver ASCS/ERS cluster configuration.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
+- _Type:_ `string`<br>
+
+The name of the ASCS instance, typically the profile name.<br>
+Mandatory for the NetWeaver ASCS/ERS cluster setup<br>
+Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname><br>
+
+### sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>`<br>
+
+Name of the ASCS instance resource.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string
+- _Type:_ `string`<br>
+
+The full path and name of the ASCS instance profile.<br>
+Mandatory for the NetWeaver ASCS/ERS cluster setup.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>`<br>
+
+Name of the ASCS SAPStartSrv resource for simple mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name
-
-- _Type:_ `string`
-- _Default:_ `col_ascs_separate_<SID>`
+- _Type:_ `string`<br>
+- _Default:_ `col_ascs_separate_<SID>`<br>
 
 Customize the cluster constraint name for ASCS and ERS separation colocation.<br>
 
-### sap_ha_pacemaker_cluster_nwas_order_ascs_first_name
+### sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name
+- _Type:_ `string`<br>
+- _Default:_ `col_ascs_separate_<SID>`<br>
 
-- _Type:_ `string`
-- _Default:_ `ord_ascs_first_<SID>`
+Customize the cluster constraint name for SCS and ERS separation colocation.<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_ensa1
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
+
+The standard NetWeaver Central Services cluster will be set up as ENSA2.<br>
+Set this parameter to 'true' to configure it as ENSA1.<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+- _Type:_ `bool`<br>
+- _Default:_ `True`<br>
+
+Enables preferred method for Central Services (ASCS or SCS) ENSA2 clusters - Simple Mount.<br>
+Set this parameter to 'true' to configure ENSA2 Simple Mount.<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_group_stickiness
+- _Type:_ `string`<br>
+- _Default:_ `3000`<br>
+
+NetWeaver Central Services (ASCS and SCS) resource group stickiness.<br>
+Defines how sticky is Central Services group to the node it was started on.<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
+
+NetWeaver Central Services (ASCS and SCS) instance resource option "AUTOMATIC_RECOVER".<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout
+- _Type:_ `string`<br>
+- _Default:_ `60`<br>
+
+NetWeaver Central Services (ASCS and SCS) instance failure-timeout attribute.<br>
+Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold
+- _Type:_ `string`<br>
+- _Default:_ `1`<br>
+
+NetWeaver Central Services (ASCS and SCS) instance migration-threshold setting attribute.<br>
+Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
+
+### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness
+- _Type:_ `string`<br>
+- _Default:_ `5000`<br>
+
+NetWeaver Central Services (ASCS and SCS) instance resource stickiness attribute.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_fs_<SID>_ERS<ERS-instance-number>`<br>
+
+Name of the filesystem resource for the ERS instance.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_instance_nr
+- _Type:_ `string`<br>
+
+Instance number of the NetWeaver Enqueue Replication Service (ERS) instance.<br>
+Mandatory for NetWeaver ASCS/ERS and SCS/ERS cluster configuration.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
+
+NetWeaver ERS instance resource option "AUTOMATIC_RECOVER".<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name
+- _Type:_ `string`<br>
+
+The name of the ERS instance, typically the profile name.<br>
+Mandatory for the NetWeaver ASCS/ERS and SCS/ERS clusters.<br>
+Recommended format <SID>_ERS<ERS-instance-number>_<ERS-hostname>.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPInstance_<SID>_ERS<ERS-instance-number>`<br>
+
+Name of the ERS instance resource.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string
+- _Type:_ `string`<br>
+
+The full path and name of the ERS instance profile.<br>
+Mandatory for the NetWeaver ASCS/ERS and SCS/ERS clusters.<br>
+
+### sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>`<br>
+
+Name of the ERS SAPstartSrv resource for simple mount.<br>
+
+### sap_ha_pacemaker_cluster_nwas_order_ascs_first_name
+- _Type:_ `string`<br>
+- _Default:_ `ord_ascs_first_<SID>`<br>
 
 Customize the cluster constraint name for ASCS starting before ERS order.<br>
 
-### sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name
+### sap_ha_pacemaker_cluster_nwas_order_scs_first_name
+- _Type:_ `string`<br>
+- _Default:_ `ord_ascs_first_<SID>`<br>
 
-- _Type:_ `string`
-- _Default:_ `cln_fs_<SID>_sapmnt`
+Customize the cluster constraint name for SCS starting before ERS order.<br>
+
+### sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name
+- _Type:_ `string`<br>
+- _Default:_ `cln_fs_<SID>_sapmnt`<br>
 
 Filesystem resource clone name for the shared filesystem /sapmnt.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_fs_<SID>_sapmnt`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_fs_<SID>_sapmnt`<br>
 
 Filesystem resource name for the shared filesystem /sapmnt.<br>
 Optional, this is typically managed by the OS, but can as well be added to the cluster configuration.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
-### sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
+### sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_fs_<SID>_SCS<SCS-instance-number>`<br>
 
-- _Type:_ `bool`
-- _Default:_ `False`
+Name of the filesystem resource for the SCS instance.<br>
+
+### sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+- _Type:_ `string`<br>
+
+Instance number of the NetWeaver Central Services (SCS) instance.<br>
+Mandatory for NetWeaver SCS/ERS cluster configuration.<br>
+
+### sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name
+- _Type:_ `string`<br>
+
+The name of the SCS instance, typically the profile name.<br>
+Mandatory for the NetWeaver SCS/ERS cluster setup<br>
+Recommended format <SID>_SCS<SCS-instance-number>_<SCS-hostname><br>
+
+### sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPInstance_<SID>_SCS<SCS-instance-number>`<br>
+
+Name of the SCS instance resource.<br>
+
+### sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string
+- _Type:_ `string`<br>
+
+The full path and name of the SCS instance profile.<br>
+Mandatory for the NetWeaver SCS/ERS cluster setup.<br>
+
+### sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_SAPStartSrv_<SID>_SCS<SCS-instance-number>`<br>
+
+Name of the SCS SAPStartSrv resource for simple mount.<br>
+
+### sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
+- _Type:_ `bool`<br>
+- _Default:_ `False`<br>
 
 Change this parameter to 'true' if the 3 shared filesystems `/usr/sap/trans`, `/usr/sap/<SID>/SYS` and '/sapmnt' shall be configured as cloned cluster resources.<br>
 
-### sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name
+### sap_ha_pacemaker_cluster_nwas_sid
+- _Type:_ `string`<br>
 
-- _Type:_ `string`
-- _Default:_ `cln_fs_<SID>_sys`
+System ID (SID) of the NetWeaver instances in Capital letters.<br>
+Defaults to `sap_swpm_sid` if defined.<br>
+Mandatory for NetWeaver cluster scenarios.<br>
+
+### sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name
+- _Type:_ `string`<br>
+- _Default:_ `cln_fs_<SID>_sys`<br>
 
 Filesystem resource clone name for the shared filesystem /usr/sap/<SID>/SYS.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_fs_<SID>_sys`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_fs_<SID>_sys`<br>
 
 Filesystem resource name for the transports filesystem /usr/sap/<SID>/SYS.<br>
 Optional, this is typically managed by the OS, but can as well be added to the cluster configuration.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name
-
-- _Type:_ `string`
-- _Default:_ `cln_fs_<SID>_trans`
+- _Type:_ `string`<br>
+- _Default:_ `cln_fs_<SID>_trans`<br>
 
 Filesystem resource clone name for the shared filesystem /usr/sap/trans.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_fs_<SID>_trans`
+- _Type:_ `string`<br>
+- _Default:_ `rsc_fs_<SID>_trans`<br>
 
 Filesystem resource name for the transports filesystem /usr/sap/trans.<br>
 Optional, this is typically managed by the OS, but can as well be added to the cluster configuration.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_operation_defaults
-
-- _Type:_ `dict`
-- _Default:_ `{'record-pending': True, 'timeout': 600}`
+- _Type:_ `dict`<br>
+- _Default:_ `{'record-pending': True, 'timeout': 600}`<br>
 
 Set default operation parameters that will be valid for all pacemaker resources.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_operation_defaults:
   record-pending: true
   timeout: 600
 ```
-
 ### sap_ha_pacemaker_cluster_resource_defaults
-
-- _Type:_ `dict`
-- _Default:_ `{'migration-threshold': 5000, 'resource-stickiness': 3000}`
+- _Type:_ `dict`<br>
+- _Default:_ `{'migration-threshold': 5000, 'resource-stickiness': 3000}`<br>
 
 Set default parameters that will be valid for all pacemaker resources.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_resource_defaults:
   migration-threshold: 5000
   resource-stickiness: 1000
 ```
-
 ### sap_ha_pacemaker_cluster_saphanasr_angi_detection
-
-- _Type:_ `string`
-- _Default:_ `True`
+- _Type:_ `string`<br>
+- _Default:_ `True`<br>
 
 Disabling this variable enables to use Classic SAPHanaSR agents even on server, with SAPHanaSR-angi is available.<br>
 
 ### sap_ha_pacemaker_cluster_sbd_devices
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 Required if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of block devices for Stonith SBD agent<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_sbd_devices:
-- /dev/disk/by-id/scsi-3600
+  - /dev/disk/by-id/scsi-3600
 ```
-
 ### sap_ha_pacemaker_cluster_sbd_enabled
-
-- _Type:_ `bool`
+- _Type:_ `bool`<br>
 
 Set this parameter to 'true' to enable workflow to add Stonith SBD resource.<br>
 Stonith SBD resource has to be provided as part of `sap_ha_pacemaker_cluster_stonith_custom`.<br>
-Default SBD agents are: `stonith:external/sbd` for SUSE and `stonith:fence_sbd` for Red Hat.<br>
+Default SBD agents are: stonith:external/sbd for SLES and stonith:fence_sbd for RHEL<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_sbd_devices:
-- /dev/disk/by-id/scsi-3600
+  - /dev/disk/by-id/scsi-3600
 sap_ha_pacemaker_cluster_sbd_enabled: true
 sap_ha_pacemaker_cluster_stonith_custom:
-- agent: stonith:external/sbd
-  id: stonith_sbd
-  instance_attrs:
-  - attrs:
-    - name: pcmk_delay_max
-      value: 15
+  - agent: stonith:external/sbd
+    id: stonith_sbd
+    instance_attrs:
+    - attrs:
+      - name: pcmk_delay_max
+        value: 15
 ```
-
 ### sap_ha_pacemaker_cluster_sbd_options
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of SBD specific options that are added into SBD configuration file.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_sbd_options:
-- name: startmode
-  value: clean
+  - name: startmode
+    value: clean
 ```
-
 ### sap_ha_pacemaker_cluster_sbd_watchdog
-
-- _Type:_ `str`
-- _Default:_ `/dev/watchdog`
+- _Type:_ `str`<br>
+- _Default:_ `/dev/watchdog`<br>
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide watchdog name to override default /dev/watchdog<br>
 
 ### sap_ha_pacemaker_cluster_sbd_watchdog_modules
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of watchdog kernel modules to be loaded (creates /dev/watchdog* devices).<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_sbd_watchdog_modules:
-- softdog
+  - softdog
 ```
-
 ### sap_ha_pacemaker_cluster_stonith_custom
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 Custom list of STONITH resource(s) to be configured in the cluster.<br>
 This definition override any defaults the role would apply otherwise.<br>
 Definition follows structure of ha_cluster_resource_primitives in linux-system-roles/ha_cluster<br>
 
 - **agent**<br>
-    Resource agent name, must contain the prefix "stonith:" to avoid mismatches or failures.
+**Required**<br>
+_Type:_ `str`<br>
+Resource agent name, must contain the prefix "stonith:" to avoid mismatches or failures.
 - **id**<br>
-    Parameter `id` is required.<br>Name that will be used as the resource ID (name).
+_Type:_ `str`<br>
+Parameter `id` is required.<br>Name that will be used as the resource ID (name).
 - **instance_attrs**<br>
-    Defines resource agent params as list of name/value pairs.<br>Requires the mandatory options for the particular stonith resource agent to be defined, otherwise the setup will fail.<br>Example: stonith:fence_sbd agent requires devices option with list of SBD disks.<br>Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`.
+_Type:_ `list`<br>
+Defines resource agent params as list of name/value pairs.<br>Requires the mandatory options for the particular stonith resource agent to be defined, otherwise the setup will fail.<br>Example: stonith:fence_sbd agent requires devices option with list of SBD disks.<br>Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`.
 - **meta_attrs**<br>
-    Defines meta attributes as list of name/value pairs.
+_Type:_ `list`<br>
+Defines meta attributes as list of name/value pairs.
 - **name**<br>
-    WARNING! This option will be removed in future release.
+_Type:_ `str`<br>
+WARNING! This option will be removed in future release.
 - **operations**<br>
-    Defines list of resource agent operations.
+_Type:_ `list`<br>
+Defines list of resource agent operations.
 - **options**<br>
-    WARNING! This option will be removed in future release.
+_Type:_ `dict`<br>
+WARNING! This option will be removed in future release.
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_stonith_custom:
-- agent: stonith:fence_rhevm
-  id: my-fence-resource
-  instance_attrs:
-  - attrs:
-    - name: ip
-      value: rhevm-server
-    - name: username
-      value: login-user
-    - name: password
-      value: login-user-password
-    - name: pcmk_host_list
-      value: node1,node2
-    - name: power_wait
-      value: 3
-  meta_attrs:
-  - attrs:
-    - name: target-role
-      value: Started
-  operations:
-  - action: start
-    attrs:
-    - name: interval
-      value: 0
-    - name: timeout
-      value: 180
+  - agent: stonith:fence_rhevm
+    id: my-fence-resource
+    instance_attrs:
+    - attrs:
+      - name: ip
+        value: rhevm-server
+      - name: username
+        value: login-user
+      - name: password
+        value: login-user-password
+      - name: pcmk_host_list
+        value: node1,node2
+      - name: power_wait
+        value: 3
+    meta_attrs:
+    - attrs:
+      - name: target-role
+        value: Started
+    operations:
+    - action: start
+      attrs:
+      - name: interval
+        value: 0
+      - name: timeout
+        value: 180
 ```
-
 ### sap_ha_pacemaker_cluster_storage_definition
-
-- _Type:_ `list`
+- _Type:_ `list`<br>
 
 List of filesystem definitions used for filesystem cluster resources.<br>
 Options relevant, see example.<br>
-Mandatory for SAP NetWeaver HA cluster configurations.<br>
+Mandatory for SAP NetWeaver cluster without Simple Mount.<br>
 Reuse `sap_storage_setup_definition` if defined.<br>
 Reuse `sap_storage_setup_definition` will extract values 'mountpoint', 'nfs_filesystem_type', 'nfs_mount_options', 'nfs_path', 'nfs_server'.<br>
 Reuse `sap_storage_setup_definition` all options are documented under Ansible Role `sap_storage_setup`.<br>
 Note! For this variable, the argument specification does not list options, to avoid errors during reuse of `sap_storage_setup_definition` if defined.<br>
 
 Example:
-
 ```yaml
 sap_ha_pacemaker_cluster_storage_definition:
-- mountpoint: /usr/sap
-  name: usr_sap
-  nfs_path: /usr/sap
-  nfs_server: nfs-server.example.com:/
-- mountpoint: /usr/sap/trans
-  name: usr_sap_trans
-  nfs_path: /usr/sap/trans
-  nfs_server: nfs-server.example.com:/
-- mountpoint: /sapmnt
-  name: sapmnt
-  nfs_filesystem_type: nfs
-  nfs_mount_options: defaults
-  nfs_path: /sapmnt
-  nfs_server: nfs-server.example.com:/
+  - mountpoint: /usr/sap
+    name: usr_sap
+    nfs_path: /usr/sap
+    nfs_server: nfs-server.example.com:/
+  - mountpoint: /usr/sap/trans
+    name: usr_sap_trans
+    nfs_path: /usr/sap/trans
+    nfs_server: nfs-server.example.com:/
+  - mountpoint: /sapmnt
+    name: sapmnt
+    nfs_filesystem_type: nfs
+    nfs_mount_options: defaults
+    nfs_path: /sapmnt
+    nfs_server: nfs-server.example.com:/
 ```
-
-### sap_ha_pacemaker_cluster_storage_nfs_filesytem_type
-
-- _Type:_ `string`
-- _Default:_ `nfs`
+### sap_ha_pacemaker_cluster_storage_nfs_filesystem_type
+- _Type:_ `string`<br>
+- _Default:_ `nfs`<br>
 
 Filesystem type of the NFS filesystems that are part of the cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_storage_nfs_mount_options
-
-- _Type:_ `string`
-- _Default:_ `defaults`
+- _Type:_ `string`<br>
+- _Default:_ `defaults`<br>
 
 Mount options of the NFS filesystems that are part of the cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_storage_nfs_server
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Default address of the NFS server, if not defined individually by filesystem.<br>
 
 ### sap_ha_pacemaker_cluster_system_roles_collection
+- _Type:_ `string`<br>
+- _Default:_ `fedora.linux_system_roles`<br>
 
-- _Type:_ `string`
-- _Default:_ `fedora.linux_system_roles`
-
-Set which Ansible Collection to use for the Linux System Roles.<br>
-Available values:
-- `fedora.linux_system_roles` - for community/upstream.<br>
-- `redhat.rhel_system_roles` - for the RHEL System Roles for SAP, or for Red Hat Automation Hub.<br>
+Reference to the Ansible Collection used for the Linux System Roles.<br>
+For community/upstream, use 'fedora.linux_system_roles'.<br>
+For RHEL System Roles for SAP, or Red Hat Automation Hub, use 'redhat.rhel_system_roles'.<br>
 
 ### sap_ha_pacemaker_cluster_vip_client_interface
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 OS device name of the network interface to use for the Virtual IP configuration.<br>
 When there is only one interface on the system, its name will be used by default.<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_primary_ip_address
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The virtual IP of the primary HANA instance.<br>
 Mandatory parameter for HANA clusters.<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_primary_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_primary`<br>
 
-- _Type:_ `string`
-- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_primary`
-
-Customize the name of the resource managing the Virtual IP of the primary HANA instance.<br>
+Name of the Virtual IP resource for primary HANA instance.<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 The virtual IP for read-only access to the secondary HANA instance.<br>
 Optional parameter in HANA clusters.<br>
 
-### sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address
+### sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_readonly`<br>
 
-- _Type:_ `string`
+Name of the Virtual IP resource for read-only HANA instance.<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address
+- _Type:_ `string`<br>
 
 Virtual IP of the NetWeaver AAS instance.<br>
 Mandatory for NetWeaver AAS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_AAS<AAS-instance-number>`<br>
 
-- _Type:_ `string`
-- _Default:_ `rsc_vip_<SID>_AAS<AAS-instance-number>`
-
-Name of the SAPInstance resource for NetWeaver AAS.<br>
-
-### sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address
-
-- _Type:_ `string`
-
-Virtual IP of the NetWeaver ASCS instance.<br>
-Mandatory for NetWeaver ASCS/ERS cluster setup.<br>
-
-### sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name
-
-- _Type:_ `string`
-- _Default:_ `grp_<SID>_ASCS<ASCS-instance-number>`
-
-Name of the NetWeaver ASCS resource group.<br>
-
-### sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_vip_<SID>_ASCS<ASCS-instance-number>`
-
-Name of the SAPInstance resource for NetWeaver ASCS.<br>
-
-### sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address
-
-- _Type:_ `string`
-
-Virtual IP of the NetWeaver ERS instance.<br>
-Mandatory for NetWeaver ASCS/ERS cluster setup.<br>
-
-### sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name
-
-- _Type:_ `string`
-- _Default:_ `grp_<SID>_ERS<ERS-instance-number>`
-
-Name of the NetWeaver ERS resource group.<br>
-
-### sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name
-
-- _Type:_ `string`
-- _Default:_ `rsc_vip_<SID>_ERS<ERS-instance-number>`
-
-Name of the SAPInstance resource for NetWeaver ERS.<br>
+Name of the Virtual IP resource for NetWeaver AAS.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address
-
-- _Type:_ `string`
+- _Type:_ `string`<br>
 
 Virtual IP of the NetWeaver PAS instance.<br>
 Mandatory for NetWeaver PAS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_PAS<PAS-instance-number>`<br>
 
-- _Type:_ `string`
-- _Default:_ `rsc_vip_<SID>_PAS<PAS-instance-number>`
+Name of the Virtual IP resource for NetWeaver PAS.<br>
 
-Name of the SAPInstance resource for NetWeaver PAS.<br>
+### sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address
+- _Type:_ `string`<br>
 
-### sap_ha_pacemaker_cluster_vip_secondary_resource_name
+Virtual IP of the NetWeaver ABAP Central Services (ASCS) instance.<br>
+Mandatory for NetWeaver ASCS/ERS cluster setup.<br>
 
-- _Type:_ `string`
-- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_readonly`
+### sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name
+- _Type:_ `string`<br>
+- _Default:_ `grp_<SID>_ASCS<ASCS-instance-number>`<br>
 
-Customize the name of the resource managing the Virtual IP of read-only access to the secondary HANA instance.<br>
+Name of the NetWeaver ASCS resource group.<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_ASCS<ASCS-instance-number>`<br>
+
+Name of the Virtual IP resource for NetWeaver ABAP Central Services (ASCS).<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address
+- _Type:_ `string`<br>
+
+Virtual IP of the NetWeaver Enqueue Replication Service (ERS) instance.<br>
+Mandatory for NetWeaver ASCS/ERS and SCS/ERS cluster setup.<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name
+- _Type:_ `string`<br>
+- _Default:_ `grp_<SID>_ERS<ERS-instance-number>`<br>
+
+Name of the NetWeaver ERS resource group.<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_ERS<ERS-instance-number>`<br>
+
+Name of the Virtual IP resource for NetWeaver Enqueue Replication Service (ERS).<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address
+- _Type:_ `string`<br>
+
+Virtual IP of the NetWeaver Central Services (SCS) instance.<br>
+Mandatory for NetWeaver SCS/ERS cluster setup.<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name
+- _Type:_ `string`<br>
+- _Default:_ `grp_<SID>_SCS<SCS-instance-number>`<br>
+
+Name of the NetWeaver SCS resource group.<br>
+
+### sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name
+- _Type:_ `string`<br>
+- _Default:_ `rsc_vip_<SID>_SCS<SCS-instance-number>`<br>
+
+Name of the Virtual IP resource for NetWeaver Central Services (SCS).<br>
+
 <!-- END Role Variables -->

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -613,20 +613,20 @@ Mandatory for the cluster setup on MS Azure instances.<br>
 Instance number of the NetWeaver ABAP AAS instance.<br>
 Mandatory for NetWeaver AAS cluster configuration.<br>
 
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
+### sap_ha_pacemaker_cluster_nwas_cs_ensa1
 
 - _Type:_ `bool`
 - _Default:_ `False`
 
-The standard NetWeaver ASCS/ERS cluster will be set up as ENSA2.<br>
+The standard NetWeaver Central Services (ASCS or SCS) cluster will be set up as ENSA2.<br>
 Set this parameter to 'true' to configure it as ENSA1.<br>
 
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+### sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 - _Type:_ `bool`
 - _Default:_ `True`
 
-Enables preferred method for ASCS ERS ENSA2 clusters - Simple Mount<br>
+Enables preferred method for Central Services (ASCS or SCS) ENSA2 clusters - Simple Mount.<br>
 Set this parameter to 'true' to configure ENSA2 Simple Mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name
@@ -643,11 +643,11 @@ Name of the filesystem resource for the ASCS instance.<br>
 
 NetWeaver ASCS resource group stickiness to prefer the ASCS group to stay on the node it was started on.<br>
 
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr
+### sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
 
 - _Type:_ `string`
 
-Instance number of the NetWeaver ABAP ASCS instance.<br>
+Instance number of the NetWeaver ABAP Central Services (ASCS) instance.<br>
 Mandatory for NetWeaver ASCS/ERS cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool
@@ -657,21 +657,21 @@ Mandatory for NetWeaver ASCS/ERS cluster configuration.<br>
 
 NetWeaver ASCS instance resource option "AUTOMATIC_RECOVER".<br>
 
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout
+### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout
 
 - _Type:_ `string`
 - _Default:_ `60`
 
-NetWeaver ASCS instance failure-timeout attribute.<br>
-Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1`). Default setup is ENSA2.<br>
+NetWeaver Central Services (ASCS or SCS) instance failure-timeout attribute.<br>
+Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
 
-### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold
+### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold
 
 - _Type:_ `string`
 - _Default:_ `1`
 
-NetWeaver ASCS instance migration-threshold setting attribute.<br>
-Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1`). Default setup is ENSA2.<br>
+NetWeaver Central Services (ASCS or SCS) instance migration-threshold setting attribute.<br>
+Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name
 
@@ -766,7 +766,7 @@ Name of the ERS SAPstartSrv resource for simple mount.<br>
 Instance number of the NetWeaver ABAP PAS instance.<br>
 Mandatory for NetWeaver PAS cluster configuration.<br>
 
-### sap_ha_pacemaker_cluster_nwas_abap_sid
+### sap_ha_pacemaker_cluster_nwas_sid
 
 - _Type:_ `string`
 
@@ -1116,7 +1116,7 @@ Mandatory for NetWeaver AAS cluster setup.<br>
 
 Name of the SAPInstance resource for NetWeaver AAS.<br>
 
-### sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address
+### sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address
 
 - _Type:_ `string`
 
@@ -1130,14 +1130,14 @@ Mandatory for NetWeaver ASCS/ERS cluster setup.<br>
 
 Name of the NetWeaver ASCS resource group.<br>
 
-### sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name
+### sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name
 
 - _Type:_ `string`
 - _Default:_ `rsc_vip_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the SAPInstance resource for NetWeaver ASCS.<br>
 
-### sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address
+### sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address
 
 - _Type:_ `string`
 
@@ -1151,7 +1151,7 @@ Mandatory for NetWeaver ASCS/ERS cluster setup.<br>
 
 Name of the NetWeaver ERS resource group.<br>
 
-### sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name
+### sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name
 
 - _Type:_ `string`
 - _Default:_ `rsc_vip_<SID>_ERS<ERS-instance-number>`

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -70,6 +70,10 @@ Managed nodes:
 | SAP HANA scale-up (performance-optimized) 2 nodes | SAPHanaSR-angi | :heavy_check_mark: |
 | SAP NetWeaver (ABAP) ASCS and ERS 2 nodes | Classic | :heavy_check_mark: |
 | SAP NetWeaver (ABAP) ASCS and ERS 2 nodes | Simple Mount | :heavy_check_mark: |
+| SAP NetWeaver (JAVA) SCS and ERS 2 nodes | Classic | :heavy_check_mark: |
+| SAP NetWeaver (JAVA) SCS and ERS 2 nodes | Simple Mount | :heavy_check_mark: |
+
+**NOTE: SAP Netweaver ASCS/ERS and SCS/ERS are ENSA2 by default, but ENSA1 is also supported.**
 <!-- END Execution -->
 
 <!-- BEGIN Execution Recommended -->

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -181,7 +181,7 @@ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr: ''  # Mandatory instance num
 
 # Definitions for filesystems resources. Currently limited to NFS filesystems.
 sap_ha_pacemaker_cluster_storage_definition: "{{ sap_storage_setup_definition | d([]) }}"
-sap_ha_pacemaker_cluster_storage_nfs_filesytem_type: nfs
+sap_ha_pacemaker_cluster_storage_nfs_filesystem_type: nfs
 sap_ha_pacemaker_cluster_storage_nfs_mount_options: 'defaults'
 sap_ha_pacemaker_cluster_storage_nfs_server: "{{ sap_storage_nfs_server | d('') }}"
 

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -111,7 +111,7 @@ sap_ha_pacemaker_cluster_hana_prefer_site_takeover: true
 # SAP HANA - Resource IDs (names) as convenience parameters.
 sap_ha_pacemaker_cluster_hana_resource_name: ''             # Default: rsc_SAPHana_<SID>_HDB<Instance Number>
 sap_ha_pacemaker_cluster_hana_resource_clone_name: ''       # Default: cln_SAPHana_<SID>_HDB<Instance Number>
-sap_ha_pacemaker_cluster_hana_resource_clone_msl_name: ''   # (SUSE Specific) Default: msl_SAPHana_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_resource_clone_msl_name: ''   # Default: msl_SAPHana_<SID>_HDB<Instance Number>
 sap_ha_pacemaker_cluster_hanacontroller_resource_name: ''   # Default: rsc_SAPHanaCon_<SID>_HDB<Instance Number>
 sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name: ''  # Default: cln_SAPHanaCon_<SID>_HDB<Instance Number>
 sap_ha_pacemaker_cluster_hana_topology_resource_name: ''  # Default: rsc_SAPHanaTop_<SID>_HDB<Instance Number>
@@ -160,8 +160,7 @@ sap_ha_pacemaker_cluster_saphanasr_angi_detection: true
 
 # Default will be ENSA2. To configure HA resources for ENSA1,
 # set this parameter to 'true'.
-# TODO: Remove backwards compatibility to nwas_abap_ascs
-sap_ha_pacemaker_cluster_nwas_cs_ensa1: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1 | d(false) }}"
+sap_ha_pacemaker_cluster_nwas_cs_ensa1: false
 
 # Enable ENSA2 simple mount configuration
 sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: true
@@ -214,11 +213,11 @@ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address: ''
 sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name: '' # Default: rsc_vip_<SID>_AAS<AAS-instance-number>
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name: ''  # Default: rsc_vip_health_check_<SID>_AAS<AAS-instance-number>
 
-# sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id: ''
-# sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id: ''
-# sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id: ''
-# sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id: ''
-# sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id: ''
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id: ''
+sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id: ''
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id: ''
+sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id: ''
+sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id: ''
 
 # SAP NetWeaver common - Resource IDs (names) as convenience parameters
 # for the following filesystems:
@@ -245,8 +244,10 @@ sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed: false
 ################################################################################
 
 # TODO: Remove backwards compatibility to nwas_abap_ascs
-sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool: false
-sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness: 5000
+sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool:
+  "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | d(false) }}"
+sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness:
+  "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness | d(5000) }}"
 sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold:
   "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold | d(1) }}"
 sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout:

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -29,7 +29,7 @@ sap_ha_pacemaker_cluster_create_config_dest: "review_resource_config.yml"
 # This variable is currently only required for HANA nodes to define
 # - hana_site: <DC-name>
 # Other options are needed in the separate HSR setup role.
-sap_ha_pacemaker_cluster_cluster_nodes: "{{ sap_hana_cluster_nodes | default([]) }}"
+sap_ha_pacemaker_cluster_cluster_nodes: "{{ sap_hana_cluster_nodes | d([]) }}"
 
 # Resource defaults are defined differently by cluster type in different tasks, if not custom defined.
 sap_ha_pacemaker_cluster_resource_defaults: {}
@@ -44,12 +44,11 @@ sap_ha_pacemaker_cluster_operation_defaults: {}
 # hana_scaleout         (not yet)
 # nwas_abap_ascs_ers    (available)
 # nwas_abap_pas_aas     (not yet)
-# nwas_java_scs_ers     (maybe)
+# nwas_java_scs_ers     (available)
 
 # 'sap_ha_pacemaker_cluster_host_type' is converted from string to list type in
 # 'tasks/ascertain_sap_landscape.yml'.
-# TODO: review with testers, updated arg specs now require it to be a list from the start
-sap_ha_pacemaker_cluster_host_type: "{{ sap_host_type | default(['hana_scaleup_perf']) }}"
+sap_ha_pacemaker_cluster_host_type: "{{ sap_host_type | d(['hana_scaleup_perf']) }}"
 
 ### VIP resource default patterns
 sap_ha_pacemaker_cluster_vip_client_interface: ''
@@ -98,11 +97,8 @@ sap_ha_pacemaker_cluster_hacluster_user_password: "{{ ha_cluster_hacluster_passw
 # HANA
 ################################################################################
 
-sap_ha_pacemaker_cluster_hana_sid: "{{ sap_hana_sid | default('') }}"
-# Keeping 'sap_ha_pacemaker_cluster_hana_instance_number' for the time being for backwards compatibility.
-sap_ha_pacemaker_cluster_hana_instance_nr: >-
-  {{ sap_ha_pacemaker_cluster_hana_instance_number
-  | default(sap_hana_instance_number) | default('') }}
+sap_ha_pacemaker_cluster_hana_sid: ''  # Mandatory System ID in capital letters
+sap_ha_pacemaker_cluster_hana_instance_nr: ''  # Mandatory instance number in string format
 
 # Optional parameters to customize SAPHana resources
 # AUTOMATED_REGISTER
@@ -113,65 +109,37 @@ sap_ha_pacemaker_cluster_hana_duplicate_primary_timeout: 7200
 sap_ha_pacemaker_cluster_hana_prefer_site_takeover: true
 
 # SAP HANA - Resource IDs (names) as convenience parameters.
-sap_ha_pacemaker_cluster_hana_resource_name: >-
-  rsc_SAPHana_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-sap_ha_pacemaker_cluster_hana_resource_clone_name: >-
-  cln_SAPHana_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-# Master slave clone for SAPHanaSR on SLES <15.6
-sap_ha_pacemaker_cluster_hana_resource_clone_msl_name: >-
-  msl_SAPHana_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-# SAPHanaController resource in SAPHanaSR-angi
-sap_ha_pacemaker_cluster_hanacontroller_resource_name: >-
-  rsc_SAPHanaCon_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name: >-
-  mst_SAPHanaCon_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-
-sap_ha_pacemaker_cluster_hana_topology_resource_name: >-
-  rsc_SAPHanaTop_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-sap_ha_pacemaker_cluster_hana_topology_resource_clone_name: >-
-  cln_SAPHanaTop_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-
-sap_ha_pacemaker_cluster_hana_filesystem_resource_name: >-
-  rsc_SAPHanaFil_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name: >-
-  cln_SAPHanaFil_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
+sap_ha_pacemaker_cluster_hana_resource_name: ''             # Default: rsc_SAPHana_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_resource_clone_name: ''       # Default: cln_SAPHana_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_resource_clone_msl_name: ''   # (SUSE Specific) Default: msl_SAPHana_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hanacontroller_resource_name: ''   # Default: rsc_SAPHanaCon_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name: ''  # Default: cln_SAPHanaCon_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_topology_resource_name: ''  # Default: rsc_SAPHanaTop_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_topology_resource_clone_name: ''  # Default: cln_SAPHanaTop_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_filesystem_resource_name: ''  # Default: rsc_SAPHanaFil_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name: ''  # Default: cln_SAPHanaFil_<SID>_HDB<Instance Number>
 
 # SAP HANA - Constraint names
-sap_ha_pacemaker_cluster_hana_order_topology_hana_name: >-
-  ord_saphana_saphanatop_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}
-
-sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name: >-
-  col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
-sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name: >-
-  col_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly
-
-sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name: >-
-  ord_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
-sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name: >-
-  ord_saphana_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly
+sap_ha_pacemaker_cluster_hana_order_topology_hana_name: ''  # Default: ord_saphana_saphanatop_<SID>_HDB<Instance Number>
+sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name: ''  # Default: col_saphana_vip_<SID>_HDB<Instance Number>_primary
+sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name: ''  # Default: col_saphana_vip_<SID>_HDB<Instance Number>_readonly
+sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name: ''  # Default: ord_saphana_vip_<SID>_HDB<Instance Number>_primary
+sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name: ''  # Default: ord_saphana_vip_<SID>_HDB<Instance Number>_readonly
 
 # Multiple VIP parameters can be defined and will be combined.
 # See tasks/include_construct_vip_resources.yml
 #
 # Mandatory: primary VIP address definition in HANA scale-up clusters
 sap_ha_pacemaker_cluster_vip_hana_primary_ip_address: ''
-sap_ha_pacemaker_cluster_vip_hana_primary_resource_name: >-
-  rsc_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
-sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name: >-
-  rsc_vip_health_check_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_primary
+sap_ha_pacemaker_cluster_vip_hana_primary_resource_name: ''  # Default: rsc_vip_<SID>_HDB<Instance Number>_primary
+sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name: ''  # Default: rsc_vip_health_check_<SID>_HDB<Instance Number>_primary
 
 sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address: ''
-sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name: >-
-  rsc_vip_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly
-sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name: >-
-  rsc_vip_health_check_{{ sap_ha_pacemaker_cluster_hana_sid }}_HDB{{ sap_ha_pacemaker_cluster_hana_instance_nr }}_readonly
+sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name: ''  # Default: rsc_vip_<SID>_HDB<Instance Number>_readonly
+sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name: ''  # Default: rsc_vip_health_check_<SID>_HDB<Instance Number>_readonly
 
-sap_ha_pacemaker_cluster_healthcheck_hana_primary_id: "{{ sap_ha_pacemaker_cluster_hana_sid + 'prim' }}"
-sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id: "{{ sap_ha_pacemaker_cluster_hana_sid + 'ro' }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid + 'ascs' }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid + 'ers' }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_id: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid + 'pas' }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_id: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid + 'aas' }}"
+sap_ha_pacemaker_cluster_healthcheck_hana_primary_id: ''  # Default: <SID>prim
+sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id: ''  # Default: <SID>ro
 
 # Optional dictionary with custom list of HANA Hooks for replication
 sap_ha_pacemaker_cluster_hana_hooks: []
@@ -181,8 +149,7 @@ sap_ha_pacemaker_cluster_hana_hook_tkover: false
 sap_ha_pacemaker_cluster_hana_hook_chksrv: false
 
 # SAP Hana global.ini path calculated from SID
-sap_ha_pacemaker_cluster_hana_global_ini_path: "/usr/sap/{{
- sap_ha_pacemaker_cluster_hana_sid | upper }}/SYS/global/hdb/custom/config/global.ini"
+sap_ha_pacemaker_cluster_hana_global_ini_path: ''  # Default: /usr/sap/<SID>/SYS/global/hdb/custom/config/global.ini
 
 # Disable auto-detection of SAPHanaSR-angi package and use Classic
 sap_ha_pacemaker_cluster_saphanasr_angi_detection: true
@@ -193,30 +160,31 @@ sap_ha_pacemaker_cluster_saphanasr_angi_detection: true
 
 # Default will be ENSA2. To configure HA resources for ENSA1,
 # set this parameter to 'true'.
-sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1: false
+# TODO: Remove backwards compatibility to nwas_abap_ascs
+sap_ha_pacemaker_cluster_nwas_cs_ensa1: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1 | d(false) }}"
 
 # Enable ENSA2 simple mount configuration
-sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount: true
+sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: true
 
 # Enable/Disable sap_cluster_connector.
 # Ref.: https://access.redhat.com/solutions/3606101
 sap_ha_pacemaker_cluster_enable_cluster_connector: true
 
-# Inherit common synonym NetWeaver parameters when defined.
-sap_ha_pacemaker_cluster_nwas_abap_sid: "{{ sap_swpm_sid | default('') }}"
-sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr: "{{ sap_swpm_ascs_instance_nr | default('') }}"
-sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr: "{{ sap_swpm_ers_instance_nr | default('') }}"
-sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr: "{{ sap_swpm_pas_instance_nr | default('') }}"
-sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr: "{{ sap_swpm_aas_instance_nr | default('') }}"
-# Prepare in case JAVA SCS/ERS will be included later.
-# sap_ha_pacemaker_cluster_nwas_java_scs_instance_nr: "{{ sap_swpm_java_scs_instance_nr | default('') }}"
-# sap_ha_pacemaker_cluster_nwas_java_ers_instance_nr: "{{ sap_swpm_java_ers_instance_nr | default('') }}"
+# SAP Netweaver instance details
+sap_ha_pacemaker_cluster_nwas_sid: ''  # Mandatory System ID in capital letters for Netweaver scenarios
+sap_ha_pacemaker_cluster_nwas_ascs_instance_nr: ''  # Mandatory instance number for ASCS/ERS
+sap_ha_pacemaker_cluster_nwas_scs_instance_nr: ''   # Mandatory instance number for SCS/ERS
+sap_ha_pacemaker_cluster_nwas_ers_instance_nr: ''   # Mandatory instance number for ASCS/ERS and SCS/ERS
+# TODO: Differentiate between ABAP and JAVA (Dxx vs Jxx) once supported
+sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr: ''  # Mandatory instance number for PAS/AAS
+sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr: ''  # Mandatory instance number for PAS/AAS
+
 
 # Definitions for filesystems resources. Currently limited to NFS filesystems.
-sap_ha_pacemaker_cluster_storage_definition: "{{ sap_storage_setup_definition | default([]) }}"
+sap_ha_pacemaker_cluster_storage_definition: "{{ sap_storage_setup_definition | d([]) }}"
 sap_ha_pacemaker_cluster_storage_nfs_filesytem_type: nfs
 sap_ha_pacemaker_cluster_storage_nfs_mount_options: 'defaults'
-sap_ha_pacemaker_cluster_storage_nfs_server: "{{ sap_storage_nfs_server | default('') }}"
+sap_ha_pacemaker_cluster_storage_nfs_server: "{{ sap_storage_nfs_server | d('') }}"
 
 # NFS filesystem resource requirement
 # Not adding to argument_specs because this should not be changed anyway.
@@ -226,148 +194,122 @@ sap_ha_pacemaker_cluster_resource_filesystem_force_unmount: safe
 
 # Multiple VIP parameters can be defined and will be combined.
 # See tasks/include_construct_vip_resources.yml
-sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address: ''
-sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name: >-
-  rsc_vip_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name: >-
-  rsc_vip_health_check_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
+sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address: ''
+sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name: ''  # Default rsc_vip_<SID>_ASCS<ASCS-instance-number>
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name: ''  # Default: rsc_vip_health_check_<SID>_ASCS<ASCS-instance-number>
 
-sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address: ''
-sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name: >-
-  rsc_vip_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name: >-
-  rsc_vip_health_check_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
+sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address: ''
+sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name: ''  # Default: rsc_vip_<SID>_SCS<SCS-instance-number>
+sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name: ''  # Default: rsc_vip_health_check_<SID>_SCS<SCS-instance-number>
+
+sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address: ''
+sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name: ''  # Default: rsc_vip_<SID>_ERS<ERS-instance-number>
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name: ''  # Default: rsc_vip_health_check_<SID>_ERS<ERS-instance-number>
 
 sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address: ''
-sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name: >-
-  rsc_vip_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_PAS{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name: >-
-  rsc_vip_health_check_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_PAS{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}
+sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name: '' # Default: rsc_vip_<SID>_PAS<PAS-instance-number>
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name: ''  # Default: rsc_vip_health_check_<SID>_PAS<PAS-instance-number>
 
 sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address: ''
-sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name: >-
-  rsc_vip_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_AAS{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name: >-
-  rsc_vip_health_check_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_AAS{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}
+sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name: '' # Default: rsc_vip_<SID>_AAS<AAS-instance-number>
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name: ''  # Default: rsc_vip_health_check_<SID>_AAS<AAS-instance-number>
 
+# sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id: ''
+# sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id: ''
+# sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id: ''
+# sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id: ''
+# sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id: ''
 
 # SAP NetWeaver common - Resource IDs (names) as convenience parameters
 # for the following filesystems:
 # - /sapmnt
 # - /usr/sap/trans
 # - /usr/sap/<<SID>>/SYS
-sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name: >-
-  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_sapmnt
-sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name: >-
-  cln_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_sapmnt
+sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name: ''  # Default: rsc_fs_<SID>_sapmnt
+sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name: ''  # Default: cln_fs_<SID>_sapmnt
 
-sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name: >-
-  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_trans
-sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name: >-
-  cln_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_trans
+sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name: ''  # Default: rsc_fs_<SID>_trans
+sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name: '' # Default: cln_fs_<SID>_trans
 
-sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name: >-
-  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_sys
-sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name: >-
-  cln_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_sys
+sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name: ''  # Default: rsc_fs_<SID>_sys
+sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name: ''  # Default: cln_fs_<SID>_sys
 
 # The shared filesystems are not required to be configured in the cluster.
 # By default it is assumed that they are mounted by the system and available on all cluster nodes.
 # Set this parameter to "true" to configure the 3 shared filesystems as part of the cluster.
 sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed: false
 
+
+################################################################################
+# ASCS and SCS shared resource defaults
+################################################################################
+
+# TODO: Remove backwards compatibility to nwas_abap_ascs
+sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool: false
+sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness: 5000
+sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold:
+  "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold | d(1) }}"
+sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout:
+  "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout | d(60) }}"
+sap_ha_pacemaker_cluster_nwas_cs_group_stickiness:
+  "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness | d(3000) }}"
+
+
 ################################################################################
 # ASCS resource defaults
 ################################################################################
 
-# Name of the instance profile - mandatory to be user-defined
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name: ''
-# Full path with instance profile name - mandatory to be user-defined
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string: ''
+sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name: ''  # Mandatory name of instance profile
+sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string: ''  # Full path of instance profile
 
-# SAP NetWeaver ABAP ASCS/ERS - Resource IDs (names) as convenience parameters.
-# - /usr/sap/<<SID>>/ASCS<<Instance>>
-# - /usr/sap/<<SID>>/ERS<<Instance>>
+sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name: ''  # Default: rsc_fs_<SID>_ASCS<ASCS-instance-number>
+sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name: ''  # Default: rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>
+sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name: ''  # Default: rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>
 
-sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name: >-
-  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name: >-
-  rsc_SAPInstance_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name: >-
-  rsc_SAPStartSrv_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
+sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name: ''  # Default: grp_<SID>_ASCS<ASCS-instance-number>
 
-sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name: >-
-  grp_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ASCS{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}
+sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name: ''  # Default: col_ascs_separate_<SID>
+sap_ha_pacemaker_cluster_nwas_order_ascs_first_name: ''  # Default: ord_ascs_first_<SID>
 
-sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name: >-
-  col_ascs_separate_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}
 
-sap_ha_pacemaker_cluster_nwas_order_ascs_first_name: >-
-  ord_ascs_first_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}
+################################################################################
+# SCS resource defaults
+################################################################################
 
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool: false
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness: 5000
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold: 1
-sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout: 60
+sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name: ''  # Mandatory name of instance profile
+sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string: ''  # Full path of instance profile
 
-# Stickiness of the ASCS group
-sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness: 3000
+sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name: ''  # Default: rsc_fs_<SID>_SCS<SCS-instance-number>
+sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name: ''  # Default: rsc_SAPInstance_<SID>_SCS<SCS-instance-number>
+sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name: ''  # Default: rsc_SAPStartSrv_<SID>_SCS<SCS-instance-number>
+
+sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name: ''  # Default: grp_<SID>_SCS<SCS-instance-number>
+
+sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name: ''  # Default: col_ascs_separate_<SID>
+sap_ha_pacemaker_cluster_nwas_order_scs_first_name: ''  # Default: ord_ascs_first_<SID>
+
 
 ################################################################################
 # ERS resource defaults
 ################################################################################
 
-# Name of the instance profile - mandatory to be user-defined
-sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name: ''
+sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name: ''  # Mandatory name of instance profile
+sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string: ''  # Full path of instance profile
 
-# Full path with instance profile name - mandatory to be user-defined
-sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string: ''
+sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name: ''  # Default: rsc_fs_<SID>_ERS<ERS-instance-number>
+sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name: ''  # Default: rsc_SAPInstance_<SID>_ERS<ERS-instance-number>
+sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name: ''  # Default: rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>
+sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name: ''  # Default: grp_<SID>_ERS<ERS-instance-number>
 
-# SAP NetWeaver ABAP ERS - Resource IDs (names) as convenience parameters.
-sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name: >-
-  rsc_fs_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
-sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name: >-
-  rsc_SAPInstance_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
-sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name: >-
-  rsc_SAPStartSrv_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
-sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool: false
-
-sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name: >-
-  grp_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_ERS{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}
-
+sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool: false
 
 ################################################################################
 # PAS/AAS resource defaults
 ################################################################################
-# SAP NetWeaver ABAP PAS/AAS - Resource IDs (names) as convenience parameters.
-# - /usr/sap/<<SID>>/D<<Instance>>
-# sap_ha_pacemaker_cluster_nwas_abap_pas_filesystem_resource_name: >
-#   "Filesystem_NWAS_ABAP_PAS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_abap_pas_sapinstance_resource_name: >
-#   "SAPInstance_NWAS_ABAP_PAS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_abap_aas_filesystem_resource_name: >
-#   "Filesystem_NWAS_ABAP_AAS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_abap_aas_sapinstance_resource_name: >
-#   "SAPInstance_NWAS_ABAP_AAS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
-
-################################################################################
-# JAVA SCS/ERS resource defaults
-################################################################################
-# SAP NetWeaver JAVA SCS/ERS - Resource IDs (names) as convenience parameters.
-# - /usr/sap/<<SID>>/SCS<<Instance>>
-# - /usr/sap/<<SID>>/ERS<<Instance>>
-# sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_resource_name: >
-#   "Filesytem_NWAS_JAVA_SCS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_java_scs_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_resource_name: >
-#   "SAPInstance_NWAS_JAVA_SCS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_java_scs_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_resource_clone_name: >
-#   "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}-clone"
-# sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_resource_name: >
-#   "Filesytem_NWAS_JAVA_ERS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_java_ers_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_resource_name: >
-#   "SAPInstance_NWAS_JAVA_ERS_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ sap_ha_pacemaker_cluster_nwas_java_ers_instance_nr }}"
-# sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_resource_clone_name: >
-#   "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}-clone"
+# sap_ha_pacemaker_cluster_nwas_abap_pas_filesystem_resource_name: ''
+# sap_ha_pacemaker_cluster_nwas_abap_pas_sapinstance_resource_name: ''
+# sap_ha_pacemaker_cluster_nwas_abap_aas_filesystem_resource_name: ''
+# sap_ha_pacemaker_cluster_nwas_abap_aas_sapinstance_resource_name: ''
 
 
 ################################################################################

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -135,7 +135,7 @@ argument_specs:
 #          - hana_scaleout
           - nwas_abap_ascs_ers
 #          - nwas_abap_pas_aas
-#          - nwas_java_scs_ers
+          - nwas_java_scs_ers
         default: hana_scaleup_perf
         description:
           - The SAP landscape to for which the cluster is to be configured.
@@ -368,16 +368,16 @@ argument_specs:
 
       sap_ha_pacemaker_cluster_hana_sid:
         description:
-          - The SAP HANA SID of the instance that will be configured in the cluster.
+          - The SAP HANA System ID (SID) of the instance that will be configured in the cluster.
           - The SID must follow SAP specifications - see SAP Note 1979280.
           - Inherits the value of `sap_hana_sid`, when defined.
-          - Mandatory for SAP HANA cluster setups.
+          - Mandatory for SAP HANA cluster scenarios.
 
       sap_ha_pacemaker_cluster_hana_instance_nr:
         description:
           - The instance number of the SAP HANA database which this role will configure in the cluster.
           - Inherits the value of `sap_hana_instance_number`, when defined.
-          - Mandatory for SAP HANA cluster setups.
+          - Mandatory for SAP HANA cluster scenarios.
 
       sap_ha_pacemaker_cluster_hana_automated_register:
         type: bool
@@ -467,18 +467,27 @@ argument_specs:
       sap_ha_pacemaker_cluster_vip_hana_primary_resource_name:
         default: "rsc_vip_<SID>_HDB<Instance Number>_primary"
         description:
-          - Customize the name of the resource managing the Virtual IP of the primary HANA instance.
+          - Name of the Virtual IP resource for primary HANA instance.
+
+      sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name:
+        default: "rsc_vip_health_check_<SID>_HDB<Instance Number>_primary"
+        description:
+          - Name of the Virtual IP Health Check resource for primary HANA instance.
 
       sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address:
         description:
           - The virtual IP for read-only access to the secondary HANA instance.
           - Optional parameter in HANA clusters.
 
-      sap_ha_pacemaker_cluster_vip_secondary_resource_name:
+      sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name:
         default: "rsc_vip_<SID>_HDB<Instance Number>_readonly"
         description:
-          - Customize the name of the resource managing the Virtual IP of read-only access to the
-            secondary HANA instance.
+          - Name of the Virtual IP resource for read-only HANA instance.
+
+      sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name:
+        default: "rsc_vip_health_check_<SID>_HDB<Instance Number>_readonly"
+        description:
+          - Name of the Virtual IP Health Check resource for read-only HANA instance.
 
       sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name:
         default: "ord_saphana_vip_<SID>_HDB<Instance Number>_primary"
@@ -558,18 +567,18 @@ argument_specs:
       # NetWeaver specific parameters
       ##########################################################################
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount:
+      sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount:
         type: bool
         default: true
         description:
-          - Enables preferred method for ASCS ERS ENSA2 clusters - Simple Mount
+          - Enables preferred method for Central Services (ASCS or SCS) ENSA2 clusters - Simple Mount.
           - Set this parameter to 'true' to configure ENSA2 Simple Mount.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1:
+      sap_ha_pacemaker_cluster_nwas_cs_ensa1:
         type: bool
         default: false
         description:
-          - The standard NetWeaver ASCS/ERS cluster will be set up as ENSA2.
+          - The standard NetWeaver Central Services cluster will be set up as ENSA2.
           - Set this parameter to 'true' to configure it as ENSA1.
 
       sap_ha_pacemaker_cluster_enable_cluster_connector:
@@ -580,22 +589,26 @@ argument_specs:
             known as `sap_cluster_connector`.
           - Set this parameter to 'false' if the SAP HA interface should not be installed and configured.
 
-      sap_ha_pacemaker_cluster_nwas_abap_sid:
+      sap_ha_pacemaker_cluster_nwas_sid:
         description:
-          - SID of the NetWeaver instances.
-          - Mandatory for NetWeaver cluster configuration.
-          - Uses `sap_swpm_sid` if defined.
-          - Mandatory for NetWeaver cluster setups.
+          - System ID (SID) of the NetWeaver instances in Capital letters.
+          - Defaults to `sap_swpm_sid` if defined.
+          - Mandatory for NetWeaver cluster scenarios.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr:
+      sap_ha_pacemaker_cluster_nwas_ascs_instance_nr:
         description:
-          - Instance number of the NetWeaver ABAP ASCS instance.
+          - Instance number of the NetWeaver ABAP Central Services (ASCS) instance.
           - Mandatory for NetWeaver ASCS/ERS cluster configuration.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr:
+      sap_ha_pacemaker_cluster_nwas_scs_instance_nr:
         description:
-          - Instance number of the NetWeaver ABAP ERS instance.
-          - Mandatory for NetWeaver ASCS/ERS cluster configuration.
+          - Instance number of the NetWeaver Central Services (SCS) instance.
+          - Mandatory for NetWeaver SCS/ERS cluster configuration.
+
+      sap_ha_pacemaker_cluster_nwas_ers_instance_nr:
+        description:
+          - Instance number of the NetWeaver Enqueue Replication Service (ERS) instance.
+          - Mandatory for NetWeaver ASCS/ERS and SCS/ERS cluster configuration.
 
       sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr:
         description:
@@ -612,7 +625,7 @@ argument_specs:
         description:
           - List of filesystem definitions used for filesystem cluster resources.
           - Options relevant, see example.
-          - Mandatory for SAP NetWeaver HA cluster configurations.
+          - Mandatory for SAP NetWeaver cluster without Simple Mount.
           - Reuse `sap_storage_setup_definition` if defined.
           - Reuse `sap_storage_setup_definition` will extract values 'mountpoint',
             'nfs_filesystem_type', 'nfs_mount_options', 'nfs_path', 'nfs_server'.
@@ -654,25 +667,50 @@ argument_specs:
         description:
           - Default address of the NFS server, if not defined individually by filesystem.
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address:
+      sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address:
         description:
-          - Virtual IP of the NetWeaver ASCS instance.
+          - Virtual IP of the NetWeaver ABAP Central Services (ASCS) instance.
           - Mandatory for NetWeaver ASCS/ERS cluster setup.
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name:
+      sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name:
         default: rsc_vip_<SID>_ASCS<ASCS-instance-number>
         description:
-          - Name of the SAPInstance resource for NetWeaver ASCS.
+          - Name of the Virtual IP resource for NetWeaver ABAP Central Services (ASCS).
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address:
+      sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name:
+        default: rsc_vip_health_check_<SID>_ASCS<ASCS-instance-number>
         description:
-          - Virtual IP of the NetWeaver ERS instance.
-          - Mandatory for NetWeaver ASCS/ERS cluster setup.
+          - Name of the Virtual IP Health Check resource for NetWeaver ABAP Central Services (ASCS).
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name:
+      sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address:
+        description:
+          - Virtual IP of the NetWeaver Central Services (SCS) instance.
+          - Mandatory for NetWeaver SCS/ERS cluster setup.
+
+      sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name:
+        default: rsc_vip_<SID>_SCS<SCS-instance-number>
+        description:
+          - Name of the Virtual IP resource for NetWeaver Central Services (SCS).
+
+      sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name:
+        default: rsc_vip_health_check_<SID>_SCS<SCS-instance-number>
+        description:
+          - Name of the Virtual IP Health Check resource for NetWeaver Central Services (SCS).
+
+      sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address:
+        description:
+          - Virtual IP of the NetWeaver Enqueue Replication Service (ERS) instance.
+          - Mandatory for NetWeaver ASCS/ERS and SCS/ERS cluster setup.
+
+      sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
         default: rsc_vip_<SID>_ERS<ERS-instance-number>
         description:
-          - Name of the SAPInstance resource for NetWeaver ERS.
+          - Name of the Virtual IP resource for NetWeaver Enqueue Replication Service (ERS).
+
+      sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
+        default: rsc_vip_health_check_<SID>_ERS<ERS-instance-number>
+        description:
+          - Name of the Virtual IP Health Check resource for NetWeaver Enqueue Replication Service (ERS).
 
       sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address:
         description:
@@ -682,7 +720,12 @@ argument_specs:
       sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
         default: rsc_vip_<SID>_PAS<PAS-instance-number>
         description:
-          - Name of the SAPInstance resource for NetWeaver PAS.
+          - Name of the Virtual IP resource for NetWeaver PAS.
+
+      sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name:
+        default: rsc_vip_health_check_<SID>_PAS<PAS-instance-number>
+        description:
+          - Name of the Virtual IP Health Check resource for NetWeaver PAS.
 
       sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address:
         description:
@@ -692,7 +735,12 @@ argument_specs:
       sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name:
         default: rsc_vip_<SID>_AAS<AAS-instance-number>
         description:
-          - Name of the SAPInstance resource for NetWeaver AAS.
+          - Name of the Virtual IP resource for NetWeaver AAS.
+
+      sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name:
+        default: rsc_vip_health_check_<SID>_AAS<AAS-instance-number>
+        description:
+          - Name of the Virtual IP Health Check resource for NetWeaver AAS.
 
       sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name:
         default: rsc_fs_<SID>_sapmnt
@@ -744,36 +792,36 @@ argument_specs:
             `/usr/sap/<SID>/SYS` and '/sapmnt' shall be configured as cloned cluster resources.
 
       ##########################################################################
-      # NetWeaver ASCS specific parameters
+      # NetWeaver ABAP Central Services (ASCS) specific parameters
       ##########################################################################
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name:
+      sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name:
         description:
           - The name of the ASCS instance, typically the profile name.
           - Mandatory for the NetWeaver ASCS/ERS cluster setup
-          - Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname>.
+          - Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname>
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string:
+      sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string:
         description:
           - The full path and name of the ASCS instance profile.
           - Mandatory for the NetWeaver ASCS/ERS cluster setup.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name:
+      sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name:
         default: rsc_fs_<SID>_ASCS<ASCS-instance-number>
         description:
           - Name of the filesystem resource for the ASCS instance.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name:
+      sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name:
         default: rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>
         description:
           - Name of the ASCS instance resource.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name:
+      sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name:
         default: rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>
         description:
           - Name of the ASCS SAPStartSrv resource for simple mount.
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name:
+      sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name:
         default: grp_<SID>_ASCS<ASCS-instance-number>
         description:
           - Name of the NetWeaver ASCS resource group.
@@ -788,75 +836,124 @@ argument_specs:
         description:
           - Customize the cluster constraint name for ASCS starting before ERS order.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool:
+      ##########################################################################
+      # NetWeaver Central Services (SCS) specific parameters
+      ##########################################################################
+
+      sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name:
+        description:
+          - The name of the SCS instance, typically the profile name.
+          - Mandatory for the NetWeaver SCS/ERS cluster setup
+          - Recommended format <SID>_SCS<SCS-instance-number>_<SCS-hostname>
+
+      sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string:
+        description:
+          - The full path and name of the SCS instance profile.
+          - Mandatory for the NetWeaver SCS/ERS cluster setup.
+
+      sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name:
+        default: rsc_fs_<SID>_SCS<SCS-instance-number>
+        description:
+          - Name of the filesystem resource for the SCS instance.
+
+      sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name:
+        default: rsc_SAPInstance_<SID>_SCS<SCS-instance-number>
+        description:
+          - Name of the SCS instance resource.
+
+      sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name:
+        default: rsc_SAPStartSrv_<SID>_SCS<SCS-instance-number>
+        description:
+          - Name of the SCS SAPStartSrv resource for simple mount.
+
+      sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name:
+        default: grp_<SID>_SCS<SCS-instance-number>
+        description:
+          - Name of the NetWeaver SCS resource group.
+
+      sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name:
+        default: "col_ascs_separate_<SID>"
+        description:
+          - Customize the cluster constraint name for SCS and ERS separation colocation.
+
+      sap_ha_pacemaker_cluster_nwas_order_scs_first_name:
+        default: "ord_ascs_first_<SID>"
+        description:
+          - Customize the cluster constraint name for SCS starting before ERS order.
+
+      ##########################################################################
+      # NetWeaver Central Services (ASCS and SCS) shared parameters
+      ##########################################################################
+
+      sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool:
         type: bool
         default: false
         description:
-          - NetWeaver ASCS instance resource option "AUTOMATIC_RECOVER".
+          - NetWeaver Central Services (ASCS and SCS) instance resource option "AUTOMATIC_RECOVER".
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness:
+      sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness:
         default: 5000
         description:
-          - NetWeaver ASCS instance resource stickiness attribute.
+          - NetWeaver Central Services (ASCS and SCS) instance resource stickiness attribute.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold:
+      sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold:
         default: 1
         description:
-          - NetWeaver ASCS instance migration-threshold setting attribute.
-          - Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1`).
+          - NetWeaver Central Services (ASCS and SCS) instance migration-threshold setting attribute.
+          - Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`).
             Default setup is ENSA2.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout:
+      sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout:
         default: 60
         description:
-          - NetWeaver ASCS instance failure-timeout attribute.
-          - Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1`).
+          - NetWeaver Central Services (ASCS and SCS) instance failure-timeout attribute.
+          - Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`).
             Default setup is ENSA2.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness:
+      sap_ha_pacemaker_cluster_nwas_cs_group_stickiness:
         default: 3000
         description:
-          - NetWeaver ASCS resource group stickiness to prefer the ASCS group to stay on the node
-            it was started on.
+          - NetWeaver Central Services (ASCS and SCS) resource group stickiness.
+          - Defines how sticky is Central Services group to the node it was started on.
 
 
       ##########################################################################
       # NetWeaver ERS specific parameters
       ##########################################################################
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name:
+      sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name:
         description:
           - The name of the ERS instance, typically the profile name.
-          - Mandatory for the NetWeaver ASCS/ERS cluster setup.
+          - Mandatory for the NetWeaver ASCS/ERS and SCS/ERS clusters.
           - Recommended format <SID>_ERS<ERS-instance-number>_<ERS-hostname>.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string:
+      sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string:
         description:
           - The full path and name of the ERS instance profile.
-          - Mandatory for the NetWeaver ASCS/ERS cluster.
+          - Mandatory for the NetWeaver ASCS/ERS and SCS/ERS clusters.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool:
+      sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool:
         type: bool
         default: false
         description:
           - NetWeaver ERS instance resource option "AUTOMATIC_RECOVER".
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name:
+      sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name:
         default: rsc_fs_<SID>_ERS<ERS-instance-number>
         description:
           - Name of the filesystem resource for the ERS instance.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name:
+      sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name:
         default: rsc_SAPInstance_<SID>_ERS<ERS-instance-number>
         description:
           - Name of the ERS instance resource.
 
-      sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name:
+      sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name:
         default: rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>
         description:
           - Name of the ERS SAPstartSrv resource for simple mount.
 
-      sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name:
+      sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name:
         default: grp_<SID>_ERS<ERS-instance-number>
         description:
           - Name of the NetWeaver ERS resource group.

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -79,7 +79,7 @@ argument_specs:
               - _Optional. Currently not needed/used in cluster configuration._
           node_name:
             description:
-              - Name of the cluster node, should match the remote systems' hostnames.
+              - Hostname of the cluster node.
               - _Optional. Currently not needed/used in cluster configuration._
           node_role:
             choices:
@@ -399,9 +399,6 @@ argument_specs:
 
       sap_ha_pacemaker_cluster_hana_prefer_site_takeover:
         type: bool
-        choices:
-          - true
-          - false
         default: true
         description:
           - Parameter for the 'SAPHana' cluster resource.
@@ -653,7 +650,7 @@ argument_specs:
               nfs_server: "nfs-server.example.com:/"
 
 
-      sap_ha_pacemaker_cluster_storage_nfs_filesytem_type:
+      sap_ha_pacemaker_cluster_storage_nfs_filesystem_type:
         default: nfs
         description:
           - Filesystem type of the NFS filesystems that are part of the cluster configuration.

--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/post_steps_hana_scaleup.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/post_steps_hana_scaleup.yml
@@ -9,16 +9,16 @@
 
 - name: "SAP HA Install Pacemaker - SAPHana pcs resource cleanup"
   ansible.builtin.command:
-    cmd: pcs resource cleanup {{ sap_ha_pacemaker_cluster_hana_resource_name
+    cmd: pcs resource cleanup {{ __sap_ha_pacemaker_cluster_hana_resource_name
      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else sap_ha_pacemaker_cluster_hanacontroller_resource_name }}
+     else __sap_ha_pacemaker_cluster_hanacontroller_resource_name }}
   changed_when: true
 
 - name: "SAP HA Install Pacemaker - SAPHana clone pcs resource refresh"
   ansible.builtin.command:
-    cmd: pcs resource refresh {{ sap_ha_pacemaker_cluster_hana_resource_clone_name
+    cmd: pcs resource refresh {{ __sap_ha_pacemaker_cluster_hana_resource_clone_name
      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}
+     else __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}
   changed_when: true
 
 # Sleep 30 is added to leave enough time for agents to load data from HANA.
@@ -30,7 +30,7 @@
 
 - name: "SAP HA Install Pacemaker - SAPHana clone pcs resource meta maintenance=false"
   ansible.builtin.command:
-    cmd: pcs resource meta {{ sap_ha_pacemaker_cluster_hana_resource_clone_name
+    cmd: pcs resource meta {{ __sap_ha_pacemaker_cluster_hana_resource_clone_name
      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }} maintenance=false
+     else __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }} maintenance=false
   changed_when: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_hana_scaleup.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_hana_scaleup.yml
@@ -8,16 +8,16 @@
 
 - name: "SAP HA Install Pacemaker - SAPHana crm resource cleanup"
   ansible.builtin.command:
-    cmd: crm resource cleanup {{ sap_ha_pacemaker_cluster_hana_resource_name
+    cmd: crm resource cleanup {{ __sap_ha_pacemaker_cluster_hana_resource_name
      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else sap_ha_pacemaker_cluster_hanacontroller_resource_name }}
+     else __sap_ha_pacemaker_cluster_hanacontroller_resource_name }}
   changed_when: true
 
 - name: "SAP HA Install Pacemaker - SAPHana clone crm resource refresh"
   ansible.builtin.command:
-    cmd: crm resource refresh {{ sap_ha_pacemaker_cluster_hana_resource_clone_name
+    cmd: crm resource refresh {{ __sap_ha_pacemaker_cluster_hana_resource_clone_name
      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}
+     else __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}
   changed_when: true
 
 - name: "SAP HA Install Pacemaker - Wait for SAP HANA to become idle"
@@ -27,7 +27,7 @@
 
 - name: "SAP HA Install Pacemaker - SAPHana crm resource maintenance off"
   ansible.builtin.command:
-    cmd: crm resource maintenance {{ sap_ha_pacemaker_cluster_hana_resource_clone_name
+    cmd: crm resource maintenance {{ __sap_ha_pacemaker_cluster_hana_resource_clone_name
      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }} off
+     else __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }} off
   changed_when: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -73,7 +73,7 @@
     - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
       ansible.builtin.command:
         cmd: cibadmin -d --force --xpath "//primitive[@type='SAPStartSrv']//operations"
-      when: sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+      when: __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
       changed_when: true
 
     # SAPInstance - Remove default operations: promote, demote, start, stop

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -73,7 +73,7 @@
     - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
       ansible.builtin.command:
         cmd: cibadmin -d --force --xpath "//primitive[@type='SAPStartSrv']//operations"
-      when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+      when: sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
       changed_when: true
 
     # SAPInstance - Remove default operations: promote, demote, start, stop

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Recent crmsh changes have added default behavior, where all default metadata
+# op parameters are added and it cannot be controlled. Not adding them during
+# creation, will forcefully add them regardless.
+
+# Following steps are similar to crmsh code in ha_cluster role, but they are
+# too SAP specific, so they are added here instead of there.
+
+# Python3-pip and pexpect are required for ansible.builtin.expect
+# Python installation was removed from sap_swpm role in PR#720
+- name: "SAP HA Install Pacemaker - Install required python3-pip"
+  ansible.builtin.package:
+    name:
+      - python3-pip
+    state: present
+
+- name: "SAP HA Install Pacemaker - Install required pip pexpect"
+  ansible.builtin.pip:
+    name:
+      - pexpect
+
+- name: Block to ensure that changes are executed only once
+  run_once: true  # noqa: run_once[task]
+  block:
+
+    - name: "SAP HA Install Pacemaker - Create file for CIB backup"
+      ansible.builtin.tempfile:
+        state: file
+        suffix: _sap_ha_pacemaker_cluster_cib_xml_backup
+      register: __sap_ha_pacemaker_cluster_cib_xml_backup
+
+    - name: "SAP HA Install Pacemaker - Put cluster in maintenance mode"
+      ansible.builtin.expect:
+        command: crm configure property maintenance-mode=true
+        responses:
+          ".*is-managed.*": "n"
+          ".*already.*": "n"
+      check_mode: false
+      changed_when: true
+
+    - name: "SAP HA Install Pacemaker - Verify that maintenance-mode is true"
+      ansible.builtin.command:
+        cmd: crm status
+      register: __sap_ha_pacemaker_cluster_crm_status_maint
+      retries: 10
+      delay: 5
+      until:
+        '"Resource management is DISABLED" in __sap_ha_pacemaker_cluster_crm_status_maint.stdout'
+      check_mode: false
+      changed_when: false
+      run_once: true  # noqa: run_once[task]
+
+    - name: "SAP HA Install Pacemaker - Fetch CIB configuration"
+      ansible.builtin.command:
+        cmd: cibadmin --query
+      register: __sap_ha_pacemaker_cluster_cib_query
+      check_mode: false
+      changed_when: false
+
+    - name: "SAP HA Install Pacemaker - Save CIB configuration"
+      ansible.builtin.copy:
+        content: "{{ __sap_ha_pacemaker_cluster_cib_query.stdout }}"
+        dest: "{{ __sap_ha_pacemaker_cluster_cib_xml_backup.path }}"
+        owner: root
+        group: root
+        mode: '0600'
+      check_mode: false
+
+    # SAPStartSrv - Remove monitor, start, stop operations from SAPStartSrv
+    # These operations are not supported and not recommended.
+    # TODO: Limit deletion in future, when more supported is added in Resource Agent
+    - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
+      ansible.builtin.command:
+        cmd: cibadmin -d --force --xpath "//primitive[@type='SAPStartSrv']//operations"
+      when: sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+      changed_when: true
+
+    # SAPInstance - Remove default operations: promote, demote, start, stop
+    - name: "SAP HA Install Pacemaker - Remove operations for SAPInstance"
+      ansible.builtin.command:
+        cmd: cibadmin -d --force --xpath "//primitive[@type='SAPInstance']//op[{{ item }}]"
+      loop:
+        - "@name='promote' and @interval='0s'"
+        - "@name='demote' and @interval='0s'"
+        - "@name='start' and @interval='0s'"
+        - "@name='stop' and @interval='0s'"
+      changed_when: true
+
+    - name: "SAP HA Install Pacemaker - Disable maintenance mode"
+      ansible.builtin.expect:
+        command: crm configure property maintenance-mode=false
+        responses:
+          ".*is-managed.*": "n"
+          ".*already.*": "n"
+      check_mode: false
+      changed_when: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
@@ -73,7 +73,7 @@
     - name: "SAP HA Install Pacemaker - Remove operations for SAPStartSrv"
       ansible.builtin.command:
         cmd: cibadmin -d --force --xpath "//primitive[@type='SAPStartSrv']//operations"
-      when: sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+      when: __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
       changed_when: true
 
     # SAPInstance - Remove default operations: promote, demote, start, stop

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
@@ -7,7 +7,7 @@
 # without proper migration from SAPHanaSR to SAPHanaSR-angi!
 
 - name: "SAP HA Prepare Pacemaker - Block for detection of SAPHanaSR-angi"
-  when: sap_ha_pacemaker_cluster_saphanasr_angi_detection
+  when: (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
   block:
     # Requirement for package_facts Ansible Module
     # SLES: Ensure OS Package for Python Lib of rpm bindings is enabled for System Python
@@ -15,7 +15,6 @@
       ansible.builtin.package:
         name: python3-rpm
         state: present
-      when: ansible_os_family == "Suse"
 
     - name: "SAP HA Prepare Pacemaker - Gather installed packages facts"
       ansible.builtin.package_facts:

--- a/roles/sap_ha_pacemaker_cluster/tasks/ascertain_sap_landscape.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/ascertain_sap_landscape.yml
@@ -36,7 +36,7 @@
   ansible.builtin.include_tasks:
     file: include_vars_hana.yml
   when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - Include NETWEAVER specific variables"
   ansible.builtin.include_tasks:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# After NetWeaver ASCS/ERS instances were configured in the cluster,
+# they must be disabled from automatically (re)starting outside of
+# cluster control.
+
+- name: "SAP HA Pacemaker - (ASCS profile) Prevent automatic restart of enqueue server"
+  ansible.builtin.replace:
+    path: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+    backup: true
+    regexp: 'Restart_Program_01'
+    replace: 'Start_Program_01'
+  # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
+  throttle: 1
+  retries: 30
+  delay: 10
+
+- name: "SAP HA Pacemaker - (ERS profile) Prevent automatic restart"
+  ansible.builtin.replace:
+    path: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+    backup: true
+    regexp: 'Restart_Program_00'
+    replace: 'Start_Program_00'
+  # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
+  throttle: 1
+  retries: 30
+  delay: 10
+
+# Comment out lines in /usr/sap/sapservices, which
+# - contain the target instance profile names
+# - are not commented out yet
+- name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
+  ansible.builtin.replace:
+    path: /usr/sap/sapservices
+    backup: true
+    regexp: '^([^#\n].+{{ sapserv_item }}.+)$'
+    replace: '# \1'
+  loop:
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+  loop_control:
+    loop_var: sapserv_item
+
+- name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+  loop:
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+  loop_control:
+    loop_var: systemd_item
+    label: "SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+  register: __sap_ha_pacemaker_cluster_register_instance_service
+
+- name: "SAP HA Pacemaker - (systemd) Save found ASCS/ERS services"
+  ansible.builtin.set_fact:
+    sap_ha_pacemaker_cluster_instance_services_fact: "{{
+      __sap_ha_pacemaker_cluster_register_instance_service.results
+      | selectattr('stat.exists')
+      | map(attribute='stat.path')
+      | regex_replace('/etc/systemd/system/', '')
+      }}"
+
+# BLOCK:
+# When the systemd based SAP startup framework is used, make sure that the
+# instance services do not auto-start.
+- name: "SAP HA Pacemaker - Block to disable systemd auto-start of instances"
+  when:
+    - sap_ha_pacemaker_cluster_instance_services_fact is defined
+    - sap_ha_pacemaker_cluster_instance_services_fact | length > 0
+  block:
+
+    - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance service"
+      ansible.builtin.service:
+        name: "{{ instance_srv_item }}"
+        enabled: false
+      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop_control:
+        loop_var: instance_srv_item
+
+    # Creates a config file for the services.
+    # Parent directories will be created when missing.
+    - name: "SAP HA Pacemaker - (systemd) Create ASCS/ERS instance unit config file"
+      ansible.builtin.lineinfile:
+        create: true
+        path: "/etc/systemd/system/{{ dropfile_item }}.d/HA.conf"
+        line: "[Service]"
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop_control:
+        loop_var: dropfile_item
+
+    - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance unit auto-restart"
+      ansible.builtin.lineinfile:
+        path: "/etc/systemd/system/{{ dropfile_item }}.d/HA.conf"
+        regex: '^Restart\s*=\s*no'
+        insertafter: '^[Service]$'
+        line: "Restart=no"
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop_control:
+        loop_var: dropfile_item
+
+### END of BLOCK for systemd setup.
+
+
+# Block for configuring the SAP HA Interface (sap_cluster_connector).
+#
+# The 'sap-cluster-connector' package is already optionally added to
+# '__sap_ha_pacemaker_cluster_sap_extra_packages'.
+- name: "SAP HA Pacemaker - (SAP HA Interface) Configure SAP HA Interface"
+  when:
+    - sap_ha_pacemaker_cluster_enable_cluster_connector
+  block:
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm
+       user to 'haclient' group"  # noqa name[template]
+      ansible.builtin.user:
+        name: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+        groups: haclient
+        append: true
+        state: present
+
+    # Using 'lineinfile' with a nested loop to avoid duplicate entries for existing configuration.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Add connector to start profiles"
+      ansible.builtin.lineinfile:
+        backup: true
+        path: "{{ nwas_profile_item.0 }}"
+        line: "{{ nwas_profile_item.1 }}"
+      loop: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_ers_profile_paths
+              | product(__sap_ha_pacemaker_cluster_connector_config_lines)
+             }}"
+      loop_control:
+        loop_var: nwas_profile_item
+        label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
+    # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
+      throttle: 1
+      retries: 30
+      delay: 10
+
+    # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_where_ascs
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
+      changed_when: false
+      failed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_where_ers
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
+      changed_when: false
+      failed_when: false
+
+    # NOTE: RestartService can cause fencing lockup and hang forever,
+    # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_restart_ascs
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function RestartService
+      changed_when: __sap_ha_pacemaker_cluster_register_restart_ascs.rc == 0
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_restart_ers
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function RestartService
+      changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
+      ansible.builtin.shell: |
+        sleep 10
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
+      changed_when: false
+      failed_when: false
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
+
+
+    # Block to restart cluster resources if RestartService is not enough.
+    # This is required for SUSE, where SAP needs full restart to load HAlib.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
+      when:
+        - "(__sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout)
+          or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout)
+          or (__sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout is defined
+           and 'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout)"
+      vars:
+        __rsc_ascs: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
+          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          else __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+        __rsc_ers: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
+          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          else __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
+      block:
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
+          ansible.builtin.shell: |
+            {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ restart_item }}
+          loop:
+            - "{{ __rsc_ascs }}"
+            - "{{ __rsc_ers }}"
+          loop_control:
+            loop_var: restart_item
+          when:
+            - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+          changed_when: true
+
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
+          become: true
+          become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+          register: __sap_ha_pacemaker_cluster_register_where_ascs_restart
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
+          changed_when: false
+          failed_when: false
+
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
+          become: true
+          become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+          register: __sap_ha_pacemaker_cluster_register_where_ers_restart
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
+          changed_when: false
+          failed_when: false
+
+        # Ensure there are no errors after resources were restarted
+        - name: "SAP HA Install Pacemaker - Cluster resource cleanup after restart"
+          ansible.builtin.shell: |
+            {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
+          changed_when: true
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
+      ansible.builtin.shell: |
+        sleep 30
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
+      changed_when: false
+      failed_when:
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout"
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
+      changed_when: false
+      failed_when:
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+      # failed_when:
+      #   - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
+      ansible.builtin.shell: |
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
+      changed_when: false
+      # failed_when:
+      #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout
+
+
+    # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ASCS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+
+    # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
+
+    # HACheckConfig shows same statues on both nodes, therefore only ASCS is shown
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
+      when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
+      ansible.builtin.debug:
+        msg: |
+          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
+
+
+    # TODO: verification checks that the instances are running and HA Interface is enabled
+
+### END of BLOCK for sap_cluster_connector.

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -43,13 +43,13 @@
 
 - name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
   ansible.builtin.stat:
-    path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+    path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ systemd_item }}.service"
   loop:
     - "{{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
     - "{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
   loop_control:
     loop_var: systemd_item
-    label: "SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+    label: "SAP{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ systemd_item }}.service"
   register: __sap_ha_pacemaker_cluster_register_instance_service
 
 - name: "SAP HA Pacemaker - (systemd) Save found ASCS/ERS services"
@@ -246,10 +246,10 @@
            and 'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout)"
       vars:
         __rsc_ascs: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
-          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          if __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
           else __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
         __rsc_ers: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
-          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          if __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
           else __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       block:
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_ascs_ers_postinstallation.yml
@@ -6,7 +6,7 @@
 
 - name: "SAP HA Pacemaker - (ASCS profile) Prevent automatic restart of enqueue server"
   ansible.builtin.replace:
-    path: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string }}"
+    path: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
     backup: true
     regexp: 'Restart_Program_01'
     replace: 'Start_Program_01'
@@ -17,7 +17,7 @@
 
 - name: "SAP HA Pacemaker - (ERS profile) Prevent automatic restart"
   ansible.builtin.replace:
-    path: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string }}"
+    path: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
     backup: true
     regexp: 'Restart_Program_00'
     replace: 'Start_Program_00'
@@ -36,20 +36,20 @@
     regexp: '^([^#\n].+{{ sapserv_item }}.+)$'
     replace: '# \1'
   loop:
-    - "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name }}"
-    - "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name }}"
+    - "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+    - "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
   loop_control:
     loop_var: sapserv_item
 
 - name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
   ansible.builtin.stat:
-    path: "/etc/systemd/system/SAP{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ systemd_item }}.service"
+    path: "/etc/systemd/system/SAP{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
   loop:
-    - "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}"
-    - "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}"
+    - "{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+    - "{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
   loop_control:
     loop_var: systemd_item
-    label: "SAP{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}_{{ systemd_item }}.service"
+    label: "SAP{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
   register: __sap_ha_pacemaker_cluster_register_instance_service
 
 - name: "SAP HA Pacemaker - (systemd) Save found ASCS/ERS services"
@@ -117,10 +117,10 @@
     - sap_ha_pacemaker_cluster_enable_cluster_connector
   block:
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm
        user to 'haclient' group"  # noqa name[template]
       ansible.builtin.user:
-        name: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+        name: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
         groups: haclient
         append: true
         state: present
@@ -131,7 +131,7 @@
         backup: true
         path: "{{ nwas_profile_item.0 }}"
         line: "{{ nwas_profile_item.1 }}"
-      loop: "{{ __sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_profile_paths
+      loop: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_ers_profile_paths
               | product(__sap_ha_pacemaker_cluster_connector_config_lines)
              }}"
       loop_control:
@@ -145,19 +145,19 @@
     # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ascs
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 30
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 30
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
 
@@ -167,20 +167,20 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ascs
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function RestartService
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function RestartService
       changed_when: __sap_ha_pacemaker_cluster_register_restart_ascs.rc == 0
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function RestartService
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function RestartService
       changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
 
 
@@ -188,21 +188,21 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
       ansible.builtin.shell: |
         sleep 10
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
@@ -218,10 +218,10 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HACheckConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when: false
 
@@ -245,12 +245,12 @@
           or (__sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout is defined
            and 'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout)"
       vars:
-        __rsc_ascs: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
-          if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
-          else sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}"
-        __rsc_ers: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name
-          if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
-          else sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}"
+        __rsc_ascs: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
+          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+        __rsc_ers: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
+          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       block:
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
           ansible.builtin.shell: |
@@ -266,19 +266,19 @@
 
         - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
           become: true
-          become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+          become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
           register: __sap_ha_pacemaker_cluster_register_where_ascs_restart
           ansible.builtin.shell: |
-            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function WaitforStarted 600 30
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
 
         - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
           become: true
-          become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+          become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
           register: __sap_ha_pacemaker_cluster_register_where_ers_restart
           ansible.builtin.shell: |
-            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function WaitforStarted 600 30
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
 
@@ -293,11 +293,11 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
       ansible.builtin.shell: |
         sleep 30
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HACheckConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout"
@@ -306,10 +306,10 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HACheckConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
@@ -319,10 +319,10 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
@@ -332,10 +332,10 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | lower }}adm"
+      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -43,13 +43,13 @@
 
 - name: "SAP HA Pacemaker - (systemd) Check for SCS/ERS services"
   ansible.builtin.stat:
-    path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+    path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ systemd_item }}.service"
   loop:
     - "{{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }}"
     - "{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
   loop_control:
     loop_var: systemd_item
-    label: "SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+    label: "SAP{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ systemd_item }}.service"
   register: __sap_ha_pacemaker_cluster_register_instance_service
 
 - name: "SAP HA Pacemaker - (systemd) Save found SCS/ERS services"
@@ -246,10 +246,10 @@
            and 'ERROR' in __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout)"
       vars:
         __rsc_scs: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name
-          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          if __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
           else __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
         __rsc_ers: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
-          if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+          if __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
           else __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       block:
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart SCS ERS resources"

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# After NetWeaver ASCS/ERS instances were configured in the cluster,
+# After NetWeaver SCS/ERS instances were configured in the cluster,
 # they must be disabled from automatically (re)starting outside of
 # cluster control.
 
-- name: "SAP HA Pacemaker - (ASCS profile) Prevent automatic restart of enqueue server"
+- name: "SAP HA Pacemaker - (SCS profile) Prevent automatic restart of enqueue server"
   ansible.builtin.replace:
-    path: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+    path: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
     backup: true
     regexp: 'Restart_Program_01'
     replace: 'Start_Program_01'
@@ -17,7 +17,7 @@
 
 - name: "SAP HA Pacemaker - (ERS profile) Prevent automatic restart"
   ansible.builtin.replace:
-    path: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+    path: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
     backup: true
     regexp: 'Restart_Program_00'
     replace: 'Start_Program_00'
@@ -36,23 +36,23 @@
     regexp: '^([^#\n].+{{ sapserv_item }}.+)$'
     replace: '# \1'
   loop:
-    - "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
-    - "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
   loop_control:
     loop_var: sapserv_item
 
-- name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
+- name: "SAP HA Pacemaker - (systemd) Check for SCS/ERS services"
   ansible.builtin.stat:
-    path: "/etc/systemd/system/SAP{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+    path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
   loop:
-    - "{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
-    - "{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
   loop_control:
     loop_var: systemd_item
-    label: "SAP{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
+    label: "SAP{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ systemd_item }}.service"
   register: __sap_ha_pacemaker_cluster_register_instance_service
 
-- name: "SAP HA Pacemaker - (systemd) Save found ASCS/ERS services"
+- name: "SAP HA Pacemaker - (systemd) Save found SCS/ERS services"
   ansible.builtin.set_fact:
     sap_ha_pacemaker_cluster_instance_services_fact: "{{
       __sap_ha_pacemaker_cluster_register_instance_service.results
@@ -70,7 +70,7 @@
     - sap_ha_pacemaker_cluster_instance_services_fact | length > 0
   block:
 
-    - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance service"
+    - name: "SAP HA Pacemaker - (systemd) Disable SCS/ERS instance service"
       ansible.builtin.service:
         name: "{{ instance_srv_item }}"
         enabled: false
@@ -80,7 +80,7 @@
 
     # Creates a config file for the services.
     # Parent directories will be created when missing.
-    - name: "SAP HA Pacemaker - (systemd) Create ASCS/ERS instance unit config file"
+    - name: "SAP HA Pacemaker - (systemd) Create SCS/ERS instance unit config file"
       ansible.builtin.lineinfile:
         create: true
         path: "/etc/systemd/system/{{ dropfile_item }}.d/HA.conf"
@@ -92,7 +92,7 @@
       loop_control:
         loop_var: dropfile_item
 
-    - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance unit auto-restart"
+    - name: "SAP HA Pacemaker - (systemd) Disable SCS/ERS instance unit auto-restart"
       ansible.builtin.lineinfile:
         path: "/etc/systemd/system/{{ dropfile_item }}.d/HA.conf"
         regex: '^Restart\s*=\s*no'
@@ -117,10 +117,10 @@
     - sap_ha_pacemaker_cluster_enable_cluster_connector
   block:
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Add {{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm
        user to 'haclient' group"  # noqa name[template]
       ansible.builtin.user:
-        name: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+        name: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
         groups: haclient
         append: true
         state: present
@@ -131,7 +131,7 @@
         backup: true
         path: "{{ nwas_profile_item.0 }}"
         line: "{{ nwas_profile_item.1 }}"
-      loop: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_ers_profile_paths
+      loop: "{{ __sap_ha_pacemaker_cluster_nwas_scs_ers_profile_paths
               | product(__sap_ha_pacemaker_cluster_connector_config_lines)
              }}"
       loop_control:
@@ -143,142 +143,142 @@
       delay: 10
 
     # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for SCS to be up and running"
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_where_ascs
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_where_scs
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
-    # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
+    # it might be good to remove them in future and leave reload to "SCS ERS restart" block.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the SCS service"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_restart_ascs
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_restart_scs
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function RestartService
-      changed_when: __sap_ha_pacemaker_cluster_register_restart_ascs.rc == 0
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function RestartService
+      changed_when: __sap_ha_pacemaker_cluster_register_restart_scs.rc == 0
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function RestartService
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function RestartService
       changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for SCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_scs_ha_failover_config
       ansible.builtin.shell: |
         sleep 10
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines }}
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for SCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_scs_ha_check_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines }}
 
 
     # Block to restart cluster resources if RestartService is not enough.
     # This is required for SUSE, where SAP needs full restart to load HAlib.
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Block for SCS ERS restart"
       when:
-        - "(__sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
-           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout)
+        - "(__sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout is defined
+           and 'FALSE' in __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout)
           or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
            and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout)
-          or (__sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout is defined
-           and 'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout)"
+          or (__sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout is defined
+           and 'ERROR' in __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout)"
       vars:
-        __rsc_ascs: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
+        __rsc_scs: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name
           if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
-          else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
-        __rsc_ers: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
+          else __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
+        __rsc_ers: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
           if sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
-          else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
+          else __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       block:
-        - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Restart SCS ERS resources"
           ansible.builtin.shell: |
             {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ restart_item }}
           loop:
-            - "{{ __rsc_ascs }}"
+            - "{{ __rsc_scs }}"
             - "{{ __rsc_ers }}"
           loop_control:
             loop_var: restart_item
           when:
-            - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+            - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
           changed_when: true
 
-        - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for SCS to be up and running"
           become: true
-          become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-          register: __sap_ha_pacemaker_cluster_register_where_ascs_restart
+          become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+          register: __sap_ha_pacemaker_cluster_register_where_scs_restart
           ansible.builtin.shell: |
-            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
 
         - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
           become: true
-          become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+          become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
           register: __sap_ha_pacemaker_cluster_register_where_ers_restart
           ansible.builtin.shell: |
-            /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
 
@@ -289,53 +289,53 @@
           changed_when: true
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for SCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_scs_ha_check_config
       ansible.builtin.shell: |
         sleep 30
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
-        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout"
+        - "'ERROR' in __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for SCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      register: __sap_ha_pacemaker_cluster_register_scs_ha_failover_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       # failed_when:
-      #   - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
-      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout
+      #   - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout is defined
+      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
-      become_user: "{{ sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
@@ -343,13 +343,13 @@
 
 
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ASCS"
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on SCS"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines }}
 
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
@@ -360,14 +360,14 @@
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
 
-    # HACheckConfig shows same statues on both nodes, therefore only ASCS is shown
+    # HACheckConfig shows same statues on both nodes, therefore only SCS is shown
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:
         msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
+          {{ __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines }}
 
 
     # TODO: verification checks that the instances are running and HA Interface is enabled

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
@@ -2,13 +2,13 @@
 ---
 - name: "SAP HA Pacemaker srHook - Check presence of global.ini"
   ansible.builtin.stat:
-    path: "{{ sap_ha_pacemaker_cluster_hana_global_ini_path }}"
+    path: "{{ __sap_ha_pacemaker_cluster_hana_global_ini_path }}"
   register: __sap_ha_pacemaker_cluster_global_ini
   failed_when: not __sap_ha_pacemaker_cluster_global_ini.stat.exists
 
 - name: "SAP HA Pacemaker srHook - Get contents of global.ini"
   ansible.builtin.command:
-    cmd: cat "{{ sap_ha_pacemaker_cluster_hana_global_ini_path }}"
+    cmd: cat "{{ __sap_ha_pacemaker_cluster_hana_global_ini_path }}"
   register: __sap_ha_pacemaker_cluster_global_ini_contents
   changed_when: false
 
@@ -42,7 +42,7 @@
 
 - name: "SAP HA Pacemaker srHook - Update srHook providers in global.ini"
   ansible.builtin.blockinfile:
-    path: "{{ sap_ha_pacemaker_cluster_hana_global_ini_path }}"
+    path: "{{ __sap_ha_pacemaker_cluster_hana_global_ini_path }}"
     marker: ""
     block: |
       [ha_dr_provider_{{ srhook_item.provider }}]
@@ -61,7 +61,7 @@
 # Separate task to create [trace] block so hooks can be appended to it
 - name: "SAP HA Pacemaker srHook - Add [trace] block in global.ini"
   ansible.builtin.blockinfile:
-    path: "{{ sap_ha_pacemaker_cluster_hana_global_ini_path }}"
+    path: "{{ __sap_ha_pacemaker_cluster_hana_global_ini_path }}"
     marker: ""
     block: |
       [trace]
@@ -71,7 +71,7 @@
 # Append hooks to [trace] block if they are not present already
 - name: "SAP HA Pacemaker srHook - Update srHooks trace in global.ini"
   ansible.builtin.lineinfile:
-    path: "{{ sap_ha_pacemaker_cluster_hana_global_ini_path }}"
+    path: "{{ __sap_ha_pacemaker_cluster_hana_global_ini_path }}"
     insertafter: "^\\[trace\\]"
     line: "ha_dr_{{ srhook_item.provider }} = info"
   loop: "{{ __sap_ha_pacemaker_cluster_hana_hooks }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -88,7 +88,7 @@
 - name: "SAP HA Prepare Pacemaker - Prepare corosync totem settings"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_corosync_totem:
-      options: "{{ __sap_ha_pacemaker_cluster_corosync_totem.options | default([]) + __totem_settings }}"
+      options: "{{ __sap_ha_pacemaker_cluster_corosync_totem.options | d([]) + __totem_settings }}"
   vars:
     # Identify if provided sap_ha_pacemaker_cluster_corosync_totem is defined
     __user_totem_is_present:

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup.yml
@@ -5,14 +5,14 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_hana_topology] }}"
   vars:
     __resource_hana_topology:
-      id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.saphanatopology }}"
       instance_attrs:
         - attrs:
             - name: SID
-              value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
       operations:
         - action: start
           attrs:
@@ -37,14 +37,14 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_hana] }}"
   vars:
     __resource_hana:
-      id: "{{ sap_ha_pacemaker_cluster_hana_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.saphana }}"
       instance_attrs:
         - attrs:
             - name: SID
-              value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
             - name: AUTOMATED_REGISTER
               value: "{{ sap_ha_pacemaker_cluster_hana_automated_register | string }}"
             - name: DUPLICATE_PRIMARY_TIMEOUT
@@ -98,8 +98,8 @@
     __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_hana_topology] }}"
   vars:
     __clone_hana_topology:
-      id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
-      resource_id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
+      resource_id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
       meta_attrs:
         - attrs:
             - name: clone-max
@@ -111,6 +111,13 @@
   when:
     - __clone_hana_topology.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
 
+# (SUSE Specific) Change SAP HANA Clone name to MSL
+- name: "SAP HA Prepare Pacemaker - Define SAP HANA MSL Clone name"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_hana_resource_clone_name: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
+  when:
+    - ansible_os_family == 'Suse'
+
 
 - name: "SAP HA Prepare Pacemaker - Add resource clone: SAP HANA DB"
   ansible.builtin.set_fact:
@@ -118,8 +125,8 @@
       "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_hana] }}"
   vars:
     __clone_hana:
-      id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
-      resource_id: "{{ sap_ha_pacemaker_cluster_hana_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+      resource_id: "{{ __sap_ha_pacemaker_cluster_hana_resource_name }}"
       meta_attrs:
         - attrs:
             - name: clone-max
@@ -143,8 +150,8 @@
       "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_hana] }}"
   vars:
     __clone_hana:
-      id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
-      resource_id: "{{ sap_ha_pacemaker_cluster_hana_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+      resource_id: "{{ __sap_ha_pacemaker_cluster_hana_resource_name }}"
       meta_attrs:
         - attrs:
             - name: clone-max
@@ -169,14 +176,13 @@
       "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_hana_topology] }}"
   vars:
     __constraint_order_hana_topology:
-      id: "{{ sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
         action: start
       resource_then:
         # SUSE SAPHanaSR is using Master Slave clone using Master/Slave roles
-        id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name
-          if ansible_os_family != 'Suse' else sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: start
       options:
         - name: symmetrical

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup_angi.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_hana_scaleup_angi.yml
@@ -5,14 +5,14 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_hana_topology] }}"
   vars:
     __resource_hana_topology:
-      id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.saphanatopology }}"
       instance_attrs:
         - attrs:
             - name: SID
-              value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
       operations:
         - action: start
           attrs:
@@ -37,14 +37,14 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_hana] }}"
   vars:
     __resource_hana:
-      id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.saphanacontroller }}"
       instance_attrs:
         - attrs:
             - name: SID
-              value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
             - name: AUTOMATED_REGISTER
               value: "{{ sap_ha_pacemaker_cluster_hana_automated_register | string }}"
             - name: DUPLICATE_PRIMARY_TIMEOUT
@@ -97,14 +97,14 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_hana_filesystem] }}"
   vars:
     __resource_hana_filesystem:
-      id: "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_filesystem_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.saphanafilesystem }}"
       instance_attrs:
         - attrs:
             - name: SID
-              value: "{{ sap_ha_pacemaker_cluster_hana_sid }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_sid }}"
             - name: InstanceNumber
-              value: "{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+              value: "{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
             - name: ON_FAIL_ACTION
               value: fence
       operations:
@@ -135,8 +135,8 @@
     __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_hana_topology] }}"
   vars:
     __clone_hana_topology:
-      id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
-      resource_id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
+      resource_id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
       meta_attrs:
         - attrs:
             - name: clone-max
@@ -155,8 +155,8 @@
       "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_hana] }}"
   vars:
     __clone_hana:
-      id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
-      resource_id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
+      resource_id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
       meta_attrs:
         - attrs:
             - name: clone-max
@@ -177,8 +177,8 @@
     __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_hana_filesystem] }}"
   vars:
     __clone_hana_filesystem:
-      id: "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name }}"
-      resource_id: "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name }}"
+      resource_id: "{{ __sap_ha_pacemaker_cluster_hana_filesystem_resource_name }}"
       meta_attrs:
         - attrs:
             - name: clone-node-max
@@ -195,12 +195,12 @@
       "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_hana_topology] }}"
   vars:
     __constraint_order_hana_topology:
-      id: "{{ sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
         action: start
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
         action: start
       options:
         - name: symmetrical

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_haproxy_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_haproxy_constraints_hana.yml
@@ -9,7 +9,7 @@
   vars:
     __constraint_order_haproxy:
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: promote
       resource_then:
         id: "{{ vip_list_item.key }}"
@@ -24,10 +24,10 @@
   vars:
     __constraint_colo_haproxy:
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         role: promoted
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
       options:
         - name: score
           value: "{{ sap_ha_pacemaker_cluster_constraint_colo_base_score }}"
@@ -41,14 +41,14 @@
   vars:
     __constraint_colo_haproxy:
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         role: unpromoted
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
       options:
         - name: score
           value: "{{ sap_ha_pacemaker_cluster_constraint_colo_base_score }}"
   when:
     - __constraint_colo_haproxy.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
-    - sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address is defined
-    - sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address != ''
+    - __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address is defined
+    - __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address != ''

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
@@ -100,7 +100,7 @@
         {% if def.nfs_filesystem_type is defined -%}
           {{ def.nfs_filesystem_type }}
         {%- else -%}
-          {{ sap_ha_pacemaker_cluster_storage_nfs_filesytem_type }}
+          {{ __sap_ha_pacemaker_cluster_storage_nfs_filesystem_type }}
         {%- endif %}
       {%- endif %}
       {%- endfor %}

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
@@ -2,28 +2,28 @@
 ---
 ### Different SAPInstance resource attributes for ENSA1 and ENSA2
 - name: "SAP HA Prepare Pacemaker - Define default ASCS/ERS instance attributes (ENSA2)"
-  when: not sap_ha_pacemaker_cluster_nwas_cs_ensa1
+  when: not __sap_ha_pacemaker_cluster_nwas_cs_ensa1
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_meta_attrs:
       - name: resource-stickiness
-        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
       - name: InstanceName
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
       - name: START_PROFILE
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
       - name: IS_ERS
         value: true
 
 - name: "SAP HA Prepare Pacemaker - Define ASCS/ERS instance attributes (ENSA1)"
-  when: sap_ha_pacemaker_cluster_nwas_cs_ensa1
+  when: __sap_ha_pacemaker_cluster_nwas_cs_ensa1
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_meta_attrs:
       - name: resource-stickiness
-        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
       - name: migration-threshold
         value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold }}"
       - name: failure-timeout
@@ -31,11 +31,11 @@
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
       - name: InstanceName
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
       - name: START_PROFILE
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
       - name: IS_ERS
         value: true
 
@@ -49,9 +49,9 @@
     __resource_filesystem:
       id: |-
         {%- if '/ASCS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name %}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name %}
         {%- elif '/ERS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name %}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name %}
         {%- endif -%}
         {{ idname }}
       agent: "ocf:heartbeat:Filesystem"
@@ -146,16 +146,16 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
       meta_attrs:
         - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_meta_attrs }}"
       operations:
@@ -189,7 +189,7 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
   vars:
     __resource_sapinstance_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs }}"
@@ -228,14 +228,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ascs_group] }}"
   vars:
     __ascs_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -260,14 +260,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
   vars:
     __ers_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -292,12 +292,12 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
     __constraint_colo_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
         role: started
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: score
           value: -5000
@@ -310,12 +310,12 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
   vars:
     __constraint_order_ascs_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: symmetrical
           value: "false"
@@ -331,13 +331,13 @@
   vars:
     __constraint_location_ascs_ers:
       resource:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
-      rule: "runs_ers_{{ sap_ha_pacemaker_cluster_nwas_sid }} eq 1"
+        id: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+      rule: "runs_ers_{{ __sap_ha_pacemaker_cluster_nwas_sid }} eq 1"
       options:
         - name: score
           value: 2000
   when:
-    - sap_ha_pacemaker_cluster_nwas_cs_ensa1
+    - __sap_ha_pacemaker_cluster_nwas_cs_ensa1
 
 
 # When /sapmnt is managed by the cluster,
@@ -348,10 +348,10 @@
   vars:
     __constraint_order_sapmnt:
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
   when:
     - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
 
@@ -361,9 +361,9 @@
   vars:
     __constraint_order_sapmnt:
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
   when:
     - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
@@ -1,79 +1,57 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Variables containing variables must be constructed with values
-# to be fed into the included ha_cluster role
-
-# TODO: add conditionals to verify that the same resource agent is not already
-#       defined in user input variables. Conflicting user input should take precedence.
-
-# Several parameters are pre-defined from potentially inherited ha_cluster LSR definitions.
-# They are necessary to be used for combining all cluster setup definitions.
-#
-# See tasks/ascertain_ha_cluster_in_inventory.yml:
-#
-# __sap_ha_pacemaker_cluster_cluster_properties: "{{ ha_cluster_cluster_properties }}"
-# __sap_ha_pacemaker_cluster_constraints_colocation: "{{ ha_cluster_constraints_colocation }}"
-# __sap_ha_pacemaker_cluster_constraints_location: "{{ ha_cluster_constraints_location }}"
-# __sap_ha_pacemaker_cluster_constraints_order: "{{ ha_cluster_constraints_order }}"
-# __sap_ha_pacemaker_cluster_fence_agent_packages: "{{ ha_cluster_fence_agent_packages }}"
-# __sap_ha_pacemaker_cluster_repos: "{{ ha_cluster_repos }}"
-# __sap_ha_pacemaker_cluster_resource_clones: "{{ ha_cluster_resource_clones }}"
-# __sap_ha_pacemaker_cluster_resource_groups: "{{ ha_cluster_resource_groups }}"
-# __sap_ha_pacemaker_cluster_resource_primitives: "{{ ha_cluster_resource_primitives }}"
-
-
 ### Different SAPInstance resource attributes for ENSA1 and ENSA2
 - name: "SAP HA Prepare Pacemaker - Define default ASCS/ERS instance attributes (ENSA2)"
-  when: not sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
+  when: not sap_ha_pacemaker_cluster_nwas_cs_ensa1
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_meta_attrs:
       - name: resource-stickiness
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
       - name: InstanceName
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
       - name: START_PROFILE
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool | string }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
       - name: IS_ERS
         value: true
 
 - name: "SAP HA Prepare Pacemaker - Define ASCS/ERS instance attributes (ENSA1)"
-  when: sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
+  when: sap_ha_pacemaker_cluster_nwas_cs_ensa1
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_meta_attrs:
       - name: resource-stickiness
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
       - name: migration-threshold
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_migration_threshold }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold }}"
       - name: failure-timeout
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_ensa1_failure_timeout }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
       - name: InstanceName
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
       - name: START_PROFILE
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
-        value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool | string }}"
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
       - name: IS_ERS
         value: true
 
 
 ### Resources
-# ASCS/ERS instance filesystems
-- name: "SAP HA Prepare Pacemaker - Add filesystem resources for ASCS/ERS to resource definition"
+# ASCS/ERS Filesystems
+- name: "SAP HA Prepare Pacemaker - Add filesystem resources to resource definition (ASCS/ERS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_filesystem] }}"
   vars:
     __resource_filesystem:
       id: |-
         {%- if '/ASCS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name %}
+          {% set idname = sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name %}
         {%- elif '/ERS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name %}
+          {% set idname = sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name %}
         {%- endif -%}
         {{ idname }}
       agent: "ocf:heartbeat:Filesystem"
@@ -154,32 +132,30 @@
       {%- endfor %}
     __mountpoint: "{{ fsres_item }}"
 
-  loop: "{{ __sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_filesystems }}"
+  loop: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_ers_filesystems }}"
   loop_control:
     loop_var: fsres_item
     label: "{{ fsres_item }}"
   when:
     - __resource_filesystem.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
-# End of filesystem resource task
-
 
 # ASCS instance resource definition
-- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Central Service (ABAP ASCS)"
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for ABAP SAP Central Service (ASCS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
       meta_attrs:
         - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_meta_attrs }}"
       operations:
@@ -208,12 +184,12 @@
 
 
 # ERS instance resource definition
-- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Enqueue Replication Service (ABAP ERS)"
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Enqueue Replication Service (ERS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
   vars:
     __resource_sapinstance_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs }}"
@@ -252,14 +228,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ascs_group] }}"
   vars:
     __ascs_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name,
-          sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name,
-          sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name %}
+          sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name,
+          sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name,
+          sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -269,7 +245,7 @@
       meta_attrs:
         - attrs:
             - name: resource-stickiness
-              value: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_group_stickiness }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_group_stickiness }}"
   when:
     - __ascs_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
 
@@ -284,14 +260,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
   vars:
     __ers_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name,
-          sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name,
-          sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name %}
+          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
+          sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name,
+          sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -318,10 +294,10 @@
     __constraint_colo_ers:
       id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
         role: started
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: score
           value: -5000
@@ -336,10 +312,10 @@
     __constraint_order_ascs_ers:
       id: "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: symmetrical
           value: "false"
@@ -355,13 +331,13 @@
   vars:
     __constraint_location_ascs_ers:
       resource:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name }}"
-      rule: "runs_ers_{{ sap_ha_pacemaker_cluster_nwas_abap_sid }} eq 1"
+        id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+      rule: "runs_ers_{{ sap_ha_pacemaker_cluster_nwas_sid }} eq 1"
       options:
         - name: score
           value: 2000
   when:
-    - sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
+    - sap_ha_pacemaker_cluster_nwas_cs_ensa1
 
 
 # When /sapmnt is managed by the cluster,
@@ -375,7 +351,7 @@
         id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
   when:
     - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
 
@@ -388,6 +364,6 @@
         id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
   when:
     - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
@@ -9,12 +9,12 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
   vars:
     __resource_sapstartsrv:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
   when:
     - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
@@ -24,12 +24,12 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
   vars:
     __resource_sapstartsrv:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
   when:
     - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
@@ -40,22 +40,22 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
             - name: MINIMAL_PROBE
               value: true
       meta_attrs:
         - attrs:
             - name: resource-stickiness
-              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
       operations:
         # TODO: Add values for start and stop when they are published.
         - action: monitor
@@ -76,16 +76,16 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
   vars:
     __resource_sapinstance_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
             - name: IS_ERS
               value: true
             - name: MINIMAL_PROBE
@@ -114,14 +114,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ascs_group] }}"
   vars:
     __ascs_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -145,14 +145,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
   vars:
     __ers_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -177,12 +177,12 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
     __constraint_colo_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
         role: started
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: score
           value: -5000
@@ -195,12 +195,12 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
   vars:
     __constraint_order_ascs_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: symmetrical
           value: "false"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
@@ -120,7 +120,7 @@
               value: 40
 
     # Format input variables to make above construction code more readable.
-    __fstype: "{{ commonfs_item.nfs_filesystem_type | d(sap_ha_pacemaker_cluster_storage_nfs_filesytem_type) }}"
+    __fstype: "{{ commonfs_item.nfs_filesystem_type | d(__sap_ha_pacemaker_cluster_storage_nfs_filesystem_type) }}"
     __mount_opts: "{{ commonfs_item.nfs_mount_options | d(sap_ha_pacemaker_cluster_storage_nfs_mount_options) }}"
     __nfs_server: "{{ commonfs_item.nfs_server | d(sap_ha_pacemaker_cluster_storage_nfs_server) | regex_replace('/$', '') }}"
     __nfs_path: |-

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
@@ -78,11 +78,11 @@
     __resource_filesystem:
       id: |-
         {%- if '/sapmnt' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name %}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name %}
         {% elif '/usr/sap/trans' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name %}
-        {% elif '/usr/sap/' + (sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name %}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name %}
+        {% elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name %}
         {% endif %}
         {{ idname }}
 
@@ -125,13 +125,13 @@
     __nfs_server: "{{ commonfs_item.nfs_server | d(sap_ha_pacemaker_cluster_storage_nfs_server) | regex_replace('/$', '') }}"
     __nfs_path: |-
       {%- if '/usr/sap' in commonfs_item.nfs_path and '/usr/sap/trans' not in commonfs_item.nfs_path -%}
-        {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
+        {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
       {%- else -%}
         {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}
       {%- endif %}
     __mountpoint: |-
       {%- if commonfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
-        {{ commonfs_item.mountpoint | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
+        {{ commonfs_item.mountpoint | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
       {%- else -%}
         {{ commonfs_item.mountpoint | regex_replace('/$', '') }}
       {%- endif %}
@@ -159,19 +159,19 @@
     __clone_common_filesystem:
       id: |-
         {%- if '/sapmnt' in __mountpoint -%}
-          {{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}
+          {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
-          {{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}
-        {%- elif '/usr/sap/' + (sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
-          {{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}
+          {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}
+        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
+          {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}
         {%- endif %}
       resource_id: |-
         {%- if '/sapmnt' in __mountpoint -%}
-          {{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}
+          {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
-          {{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}
-        {%- elif '/usr/sap/' + (sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
-          {{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}
+          {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}
+        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
+          {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}
         {%- endif %}
       meta_attrs:
         - attrs:
@@ -180,7 +180,7 @@
 
     __mountpoint: |-
       {%- if commonfsclone_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
-        {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
+        {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
       {%- else -%}
         {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}
       {%- endif %}

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
@@ -81,7 +81,7 @@
           {% set idname = __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name %}
         {% elif '/usr/sap/trans' in __mountpoint -%}
           {% set idname = __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name %}
-        {% elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
+        {% elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid ) + '/SYS' in __mountpoint -%}
           {% set idname = __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name %}
         {% endif %}
         {{ idname }}
@@ -125,13 +125,13 @@
     __nfs_server: "{{ commonfs_item.nfs_server | d(sap_ha_pacemaker_cluster_storage_nfs_server) | regex_replace('/$', '') }}"
     __nfs_path: |-
       {%- if '/usr/sap' in commonfs_item.nfs_path and '/usr/sap/trans' not in commonfs_item.nfs_path -%}
-        {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
+        {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid }}/SYS
       {%- else -%}
         {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}
       {%- endif %}
     __mountpoint: |-
       {%- if commonfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
-        {{ commonfs_item.mountpoint | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
+        {{ commonfs_item.mountpoint | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid }}/SYS
       {%- else -%}
         {{ commonfs_item.mountpoint | regex_replace('/$', '') }}
       {%- endif %}
@@ -162,7 +162,7 @@
           {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}
-        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid ) + '/SYS' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}
         {%- endif %}
       resource_id: |-
@@ -170,7 +170,7 @@
           {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}
-        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid ) + '/SYS' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}
         {%- endif %}
       meta_attrs:
@@ -180,7 +180,7 @@
 
     __mountpoint: |-
       {%- if commonfsclone_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
-        {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
+        {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}/{{ __sap_ha_pacemaker_cluster_nwas_sid }}/SYS
       {%- else -%}
         {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}
       {%- endif %}

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
@@ -81,7 +81,7 @@
           {% set idname = sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name %}
         {% elif '/usr/sap/trans' in __mountpoint -%}
           {% set idname = sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name %}
-        {% elif '/usr/sap/' + sap_ha_pacemaker_cluster_nwas_abap_sid + '/SYS' in __mountpoint -%}
+        {% elif '/usr/sap/' + (sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
           {% set idname = sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name %}
         {% endif %}
         {{ idname }}
@@ -120,18 +120,18 @@
               value: 40
 
     # Format input variables to make above construction code more readable.
-    __fstype: "{{ commonfs_item.nfs_filesystem_type | default(sap_ha_pacemaker_cluster_storage_nfs_filesytem_type) }}"
-    __mount_opts: "{{ commonfs_item.nfs_mount_options | default(sap_ha_pacemaker_cluster_storage_nfs_mount_options) }}"
-    __nfs_server: "{{ commonfs_item.nfs_server | default(sap_ha_pacemaker_cluster_storage_nfs_server) | regex_replace('/$', '') }}"
+    __fstype: "{{ commonfs_item.nfs_filesystem_type | d(sap_ha_pacemaker_cluster_storage_nfs_filesytem_type) }}"
+    __mount_opts: "{{ commonfs_item.nfs_mount_options | d(sap_ha_pacemaker_cluster_storage_nfs_mount_options) }}"
+    __nfs_server: "{{ commonfs_item.nfs_server | d(sap_ha_pacemaker_cluster_storage_nfs_server) | regex_replace('/$', '') }}"
     __nfs_path: |-
       {%- if '/usr/sap' in commonfs_item.nfs_path and '/usr/sap/trans' not in commonfs_item.nfs_path -%}
-        {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}/SYS
+        {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
       {%- else -%}
         {{ commonfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}
       {%- endif %}
     __mountpoint: |-
       {%- if commonfs_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
-        {{ commonfs_item.mountpoint | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}/SYS
+        {{ commonfs_item.mountpoint | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
       {%- else -%}
         {{ commonfs_item.mountpoint | regex_replace('/$', '') }}
       {%- endif %}
@@ -162,7 +162,7 @@
           {{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}
-        {%- elif '/usr/sap/' + sap_ha_pacemaker_cluster_nwas_abap_sid + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + (sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
           {{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}
         {%- endif %}
       resource_id: |-
@@ -170,7 +170,7 @@
           {{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}
-        {%- elif '/usr/sap/' + sap_ha_pacemaker_cluster_nwas_abap_sid + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + (sap_ha_pacemaker_cluster_nwas_sid | upper) + '/SYS' in __mountpoint -%}
           {{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}
         {%- endif %}
       meta_attrs:
@@ -180,7 +180,7 @@
 
     __mountpoint: |-
       {%- if commonfsclone_item.mountpoint | regex_replace('/$', '') == '/usr/sap' -%}
-        {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_abap_sid }}/SYS
+        {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}/{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SYS
       {%- else -%}
         {{ commonfsclone_item.mountpoint | regex_replace('/$', '') }}
       {%- endif %}

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers.yml
@@ -101,7 +101,7 @@
         {% if def.nfs_filesystem_type is defined -%}
           {{ def.nfs_filesystem_type }}
         {%- else -%}
-          {{ sap_ha_pacemaker_cluster_storage_nfs_filesytem_type }}
+          {{ __sap_ha_pacemaker_cluster_storage_nfs_filesystem_type }}
         {%- endif %}
       {%- endif %}
       {%- endfor %}

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers.yml
@@ -2,28 +2,28 @@
 ---
 ### Different SAPInstance resource attributes for ENSA1 and ENSA2
 - name: "SAP HA Prepare Pacemaker - Define default SCS/ERS instance attributes (ENSA2)"
-  when: not sap_ha_pacemaker_cluster_nwas_cs_ensa1
+  when: not __sap_ha_pacemaker_cluster_nwas_cs_ensa1
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_meta_attrs:
       - name: resource-stickiness
-        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
       - name: InstanceName
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
       - name: START_PROFILE
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
       - name: IS_ERS
         value: true
 
 - name: "SAP HA Prepare Pacemaker - Define SCS/ERS instance attributes (ENSA1)"
-  when: sap_ha_pacemaker_cluster_nwas_cs_ensa1
+  when: __sap_ha_pacemaker_cluster_nwas_cs_ensa1
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_meta_attrs:
       - name: resource-stickiness
-        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
       - name: migration-threshold
         value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold }}"
       - name: failure-timeout
@@ -31,11 +31,11 @@
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
       - name: InstanceName
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
       - name: START_PROFILE
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
       - name: AUTOMATIC_RECOVER
-        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+        value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
       - name: IS_ERS
         value: true
 
@@ -50,9 +50,9 @@
     __resource_filesystem:
       id: |-
         {%- if '/SCS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name %}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name %}
         {%- elif '/ERS' in __mountpoint -%}
-          {% set idname = sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name %}
+          {% set idname = __sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name %}
         {%- endif -%}
         {{ idname }}
       agent: "ocf:heartbeat:Filesystem"
@@ -147,16 +147,16 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
       meta_attrs:
         - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_meta_attrs }}"
       operations:
@@ -190,7 +190,7 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
   vars:
     __resource_sapinstance_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs }}"
@@ -229,15 +229,15 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__scs_group] }}"
   vars:
-    __acs_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+    __scs_group:
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name,
-          sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name,
-          sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -262,14 +262,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
   vars:
     __ers_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -294,12 +294,12 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
     __constraint_colo_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
         role: started
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: score
           value: -5000
@@ -312,12 +312,12 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_scs_ers] }}"
   vars:
     __constraint_order_scs_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: symmetrical
           value: "false"
@@ -333,13 +333,13 @@
   vars:
     __constraint_location_scs_ers:
       resource:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
-      rule: "runs_ers_{{ sap_ha_pacemaker_cluster_nwas_sid }} eq 1"
+        id: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
+      rule: "runs_ers_{{ __sap_ha_pacemaker_cluster_nwas_sid }} eq 1"
       options:
         - name: score
           value: 2000
   when:
-    - sap_ha_pacemaker_cluster_nwas_cs_ensa1
+    - __sap_ha_pacemaker_cluster_nwas_cs_ensa1
 
 
 # When /sapmnt is managed by the cluster,
@@ -350,10 +350,10 @@
   vars:
     __constraint_order_sapmnt:
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
   when:
     - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
 
@@ -363,9 +363,9 @@
   vars:
     __constraint_order_sapmnt:
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
   when:
     - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers.yml
@@ -1,35 +1,73 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Variables containing variables must be constructed with values
-# to be fed into the included ha_cluster role
+### Different SAPInstance resource attributes for ENSA1 and ENSA2
+- name: "SAP HA Prepare Pacemaker - Define default SCS/ERS instance attributes (ENSA2)"
+  when: not sap_ha_pacemaker_cluster_nwas_cs_ensa1
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_meta_attrs:
+      - name: resource-stickiness
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
 
-# - put here all scale-up and scale-out common resources
-# - certain differences like ra agent names are provided through
-#   type specific variables
+    __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
+      - name: InstanceName
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+      - name: START_PROFILE
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+      - name: AUTOMATIC_RECOVER
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+      - name: IS_ERS
+        value: true
 
-# TODO: add conditionals to verify that the same resource agent is not already
-#       defined in user input variables. Conflicting user input should take precedence.
+- name: "SAP HA Prepare Pacemaker - Define SCS/ERS instance attributes (ENSA1)"
+  when: sap_ha_pacemaker_cluster_nwas_cs_ensa1
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_meta_attrs:
+      - name: resource-stickiness
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+      - name: migration-threshold
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold }}"
+      - name: failure-timeout
+        value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs:
+      - name: InstanceName
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+      - name: START_PROFILE
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+      - name: AUTOMATIC_RECOVER
+        value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+      - name: IS_ERS
+        value: true
 
 
-- name: "SAP HA Prepare Pacemaker - Add resource: Filesystem /usr/sap/<<SID>>/SCS<<Instance>>"
+### Resources
+# SCS/ERS Filesystems
+
+- name: "SAP HA Prepare Pacemaker - Add filesystem resources to resource definition (SCS/ERS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_filesystem] }}"
   vars:
     __resource_filesystem:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_resource_name }}"
+      id: |-
+        {%- if '/SCS' in __mountpoint -%}
+          {% set idname = sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name %}
+        {%- elif '/ERS' in __mountpoint -%}
+          {% set idname = sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name %}
+        {%- endif -%}
+        {{ idname }}
       agent: "ocf:heartbeat:Filesystem"
       instance_attrs:
         - attrs:
             - name: device
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_host_mount_path }}"
+              value: "{{ __nfs_server }}/{{ __nfs_path }}/{{ __mountpoint }}"
             - name: directory
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_local_mount_path }}"
+              value: "/usr/sap/{{ __mountpoint }}"
             - name: fstype
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_fstype }}"
+              value: "{{ __fstype }}"
             - name: options
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_options_string }}"
+              value: "{{ __mount_opts }}"
             - name: force_unmount
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_force_unmount }}"
+              value: "{{ sap_ha_pacemaker_cluster_resource_filesystem_force_unmount }}"
       operations:
         - action: start
           attrs:
@@ -49,74 +87,78 @@
               value: 200
             - name: timeout
               value: 40
+
+    # Format input variables to make above construction code more readable.
+    # Method:
+    # - parse sap_ha_pacemaker_cluster_storage_definition
+    # - check if a mounpoint is defined (filters out swap)
+    # - if the needed parameter is defined, take it
+    # - otherwise, take the value from a default parameter
+
+    __fstype: |-
+      {% for def in sap_ha_pacemaker_cluster_storage_definition -%}
+      {% if def.mountpoint is defined and '/usr/sap' == def.mountpoint | regex_replace('/$', '') -%}
+        {% if def.nfs_filesystem_type is defined -%}
+          {{ def.nfs_filesystem_type }}
+        {%- else -%}
+          {{ sap_ha_pacemaker_cluster_storage_nfs_filesytem_type }}
+        {%- endif %}
+      {%- endif %}
+      {%- endfor %}
+    __mount_opts: |-
+      {% for def in sap_ha_pacemaker_cluster_storage_definition -%}
+      {% if def.mountpoint is defined and '/usr/sap' == def.mountpoint | regex_replace('/$', '') -%}
+        {% if def.nfs_mount_options is defined -%}
+          {{ def.nfs_mount_options }}
+        {%- else -%}
+          {{ sap_ha_pacemaker_cluster_storage_nfs_mount_options }}
+        {%- endif %}
+      {%- endif %}
+      {%- endfor %}
+    __nfs_path: |-
+      {% for def in sap_ha_pacemaker_cluster_storage_definition -%}
+      {% if def.mountpoint is defined and '/usr/sap' == def.mountpoint | regex_replace('/$', '') -%}
+        {{ def.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}
+      {%- endif %}
+      {%- endfor %}
+    __nfs_server: |-
+      {% for def in sap_ha_pacemaker_cluster_storage_definition -%}
+      {% if def.mountpoint is defined and '/usr/sap' == def.mountpoint | regex_replace('/$', '') -%}
+        {% if def.nfs_server is defined -%}
+          {{ def.nfs_server | regex_replace('/$', '') }}
+        {%- else -%}
+          {{ sap_ha_pacemaker_cluster_storage_nfs_server | regex_replace('/$', '') }}
+        {%- endif %}
+      {%- endif %}
+      {%- endfor %}
+    __mountpoint: "{{ fsres_item }}"
+
+  loop: "{{ __sap_ha_pacemaker_cluster_nwas_scs_ers_filesystems }}"
+  loop_control:
+    loop_var: fsres_item
+    label: "{{ fsres_item }}"
   when:
     - __resource_filesystem.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
-- name: "SAP HA Prepare Pacemaker - Add resource: Filesystem /usr/sap/<<SID>>/ERS<<Instance>>"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_filesystem] }}"
-  vars:
-    __resource_filesystem:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_resource_name }}"
-      agent: "ocf:heartbeat:Filesystem"
-      instance_attrs:
-        - attrs:
-            - name: device
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_host_mount_path }}"
-            - name: directory
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_local_mount_path }}"
-            - name: fstype
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_fstype }}"
-            - name: options
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_options_string }}"
-            - name: force_unmount
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_force_unmount }}"
-      operations:
-        - action: start
-          attrs:
-            - name: interval
-              value: 0
-            - name: timeout
-              value: 60
-        - action: stop
-          attrs:
-            - name: interval
-              value: 0
-            - name: timeout
-              value: 120
-        - action: monitor
-          attrs:
-            - name: interval
-              value: 200
-            - name: timeout
-              value: 40
-  when:
-    - __resource_filesystem.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
-
-- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Central Service (JAVA SCS)"
+# SCS instance resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for SAP Central Service (SCS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_resource_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_instance_name }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_start_profile_string }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
       meta_attrs:
-        - attrs:
-            - name: resource-stickiness
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_resource_stickiness }}"
-            - name: migration-threshold
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_migration_threshold }}"
-            - name: failure-timeout
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_failure_timeout }}"
+        - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_meta_attrs }}"
       operations:
         - action: start
           attrs:
@@ -141,29 +183,17 @@
   when:
     - __resource_sapinstance.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
-- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Enqueue Replication Service (JAVA ERS)"
+
+# ERS instance resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for Enqueue Replication Service (ERS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
   vars:
     __resource_sapinstance_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_resource_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
-        - attrs:
-            - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_instance_name }}"
-            - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_start_profile_string }}"
-            - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_automatic_recover_bool | string }}"
-      meta_attrs:
-        - attrs:
-            - name: resource-stickiness
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_resource_stickiness }}"
-            - name: migration-threshold
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_migration_threshold }}"
-            - name: failure-timeout
-              value: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_failure_timeout }}"
+        - attrs: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_attrs }}"
       operations:
         - action: start
           attrs:
@@ -189,95 +219,153 @@
     - __resource_sapinstance_ers.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
 
-- name: "SAP HA Prepare Pacemaker - Add resource clone: Filesystem /usr/sap/<<SID>>/SCS<<Instance>>"
+### Groups
+# SCS group consists of resources in this order:
+# - SCS filesystem
+# - SCS instance
+# - SCS VIP
+
+- name: "SAP HA Prepare Pacemaker - Add resource group for SCS resources"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_filesystem] }}"
+    __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__scs_group] }}"
   vars:
-    __clone_filesystem:
-      resource_id: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_filesystem_resource_name }}"
-      promotable: "no"
+    __acs_group:
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+      resource_ids: |
+        {% set resource_ids_list = [] %}
+        {%- for resource in
+          sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name,
+          sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name,
+          sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name %}
+          {%- if resource | length > 0
+            and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
+            {%- set ids = resource_ids_list.append(resource) %}
+          {%- endif %}
+        {%- endfor %}
+        {{ resource_ids_list }}
       meta_attrs:
         - attrs:
-            - name: clone-max
-              value: 2
-            - name: clone-node-max
-              value: 1
-        - name: interleave
-          value: "true"
+            - name: resource-stickiness
+              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_group_stickiness }}"
   when:
-    - __clone_filesystem.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
+    - __scs_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
 
-- name: "SAP HA Prepare Pacemaker - Add resource clone: Filesystem /usr/sap/<<SID>>/ERS<<Instance>>"
+
+# ERS group consists of resources in this order:
+# - ERS filesystem
+# - ERS instance
+# - ERS VIP
+
+- name: "SAP HA Prepare Pacemaker - Add resource group for ERS resources"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_filesystem] }}"
+    __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
   vars:
-    __clone_filesystem:
-      resource_id: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_filesystem_resource_name }}"
-      promotable: "no"
-      meta_attrs:
-        - attrs:
-            - name: clone-max
-              value: 2
-            - name: clone-node-max
-              value: 1
-        - name: interleave
-          value: "true"
+    __ers_group:
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+      resource_ids: |
+        {% set resource_ids_list = [] %}
+        {%- for resource in
+          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
+          sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name,
+          sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
+          {%- if resource | length > 0
+            and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
+            {%- set ids = resource_ids_list.append(resource) %}
+          {%- endif %}
+        {%- endfor %}
+        {{ resource_ids_list }}
   when:
-    - __clone_filesystem.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
+    - __ers_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
 
-
-- name: "SAP HA Prepare Pacemaker - Add resource clone: SAPInstance for Central Service (JAVA SCS)"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_sapinstance] }}"
-  vars:
-    __clone_sapinstance:
-      resource_id: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_resource_name }}"
-      promotable: "yes"
-      meta_attrs:
-        - attrs:
-            - name: clone-max
-              value: 2
-            - name: clone-node-max
-              value: 1
-            - name: interleave
-              value: "true"
+- name: "SAP HA Prepare Pacemaker - Display VIP resource group definition if any were built"
+  ansible.builtin.debug:
+    var: __sap_ha_pacemaker_cluster_resource_groups
   when:
-    - __clone_sapinstance.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
+    - __sap_ha_pacemaker_cluster_resource_groups is defined
+    - __sap_ha_pacemaker_cluster_resource_groups | length > 0
 
-- name: "SAP HA Prepare Pacemaker - Add resource clone: SAPInstance for Enqueue Replication Service (JAVA ERS)"
+
+### Constraints
+# ERS and SCS resource groups should try to avoid running on the same node
+- name: "SAP HA Prepare Pacemaker - Add colocation constraint: ERS avoids to run on the SCS node"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones + [__clone_sapinstance_ers] }}"
+    __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
-    __clone_sapinstance_ers:
-      resource_id: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_resource_name }}"
-      promotable: "yes"
-      meta_attrs:
-        - attrs:
-            - name: clone-max
-              value: 2
-            - name: clone-node-max
-              value: 1
-            - name: interleave
-              value: "true"
+    __constraint_colo_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
+      resource_leader:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        role: started
+      resource_follower:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+      options:
+        - name: score
+          value: -5000
   when:
-    - __clone_sapinstance_ers.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
+    - __constraint_colo_ers.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
 
-# First start SAPInstance for Central Service, then SAPInstance for Enqueue Replication Service (automatically stops in reverse order)
-- name: "SAP HA Prepare Pacemaker - Add order constraint: Central Service starts before Enqueue Replication Service"
+# Optional: SCS should be started before ERS
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start SCS group, then ERS group"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_sapinstance] }}"
+    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_scs_ers] }}"
   vars:
-    __constraint_order_sapinstance:
+    __constraint_order_scs_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_java_scs_sapinstance_resource_clone_name }}"
-        action: start
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_nwas_java_ers_sapinstance_resource_clone_name }}"
-        action: start
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: symmetrical
           value: "false"
         - name: kind
-          value: "Optional"
+          value: Optional
+#  when:
+#    - __constraint_order_scs_ers.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))
+
+# ENSA1 only: location rule for SCS to follow ERS
+- name: "SAP HA Prepare Pacemaker - Add location constraint: SCS follows ERS in ENSA1 setup"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_constraints_location: "{{ __sap_ha_pacemaker_cluster_constraints_location + [__constraint_location_scs_ers] }}"
+  vars:
+    __constraint_location_scs_ers:
+      resource:
+        id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
+      rule: "runs_ers_{{ sap_ha_pacemaker_cluster_nwas_sid }} eq 1"
+      options:
+        - name: score
+          value: 2000
   when:
-    - __constraint_order_sapinstance.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))
+    - sap_ha_pacemaker_cluster_nwas_cs_ensa1
+
+
+# When /sapmnt is managed by the cluster,
+# start instance groups only after the SAPMNT resource is running.
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start /sapmnt, then start SCS group"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_sapmnt] }}"
+  vars:
+    __constraint_order_sapmnt:
+      resource_first:
+        id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
+        role: started
+      resource_then:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+  when:
+    - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
+
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start /sapmnt, then start ERS group"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_sapmnt] }}"
+  vars:
+    __constraint_order_sapmnt:
+      resource_first:
+        id: "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
+        role: started
+      resource_then:
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+  when:
+    - sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers_simple_mount.yml
@@ -9,12 +9,12 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
   vars:
     __resource_sapstartsrv:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
   when:
     - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
@@ -24,12 +24,12 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
   vars:
     __resource_sapstartsrv:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
   when:
     - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
@@ -40,22 +40,22 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
             - name: MINIMAL_PROBE
               value: true
       meta_attrs:
         - attrs:
             - name: resource-stickiness
-              value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
       operations:
         # TODO: Add values for start and stop when they are published.
         - action: monitor
@@ -76,16 +76,16 @@
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance_ers] }}"
   vars:
     __resource_sapinstance_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
+              value: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | string }}"
             - name: IS_ERS
               value: true
             - name: MINIMAL_PROBE
@@ -114,14 +114,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__scs_group] }}"
   vars:
     __scs_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name,
-          sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name,
-          sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -145,14 +145,14 @@
     __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ers_group] }}"
   vars:
     __ers_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
+          __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name,
+          __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name,
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -177,12 +177,12 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
     __constraint_colo_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
         role: started
       resource_follower:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: score
           value: -5000
@@ -195,12 +195,12 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_scs_ers] }}"
   vars:
     __constraint_order_scs_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
         role: started
       resource_then:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       options:
         - name: symmetrical
           value: "false"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_java_scs_ers_simple_mount.yml
@@ -1,20 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# ASCS ERS simple mount cluster is ENSA2.
+# SCS ERS simple mount cluster is ENSA2.
 
 ### Resources
-# ASCS SAPStartSrv resource definition
-- name: "SAP HA Prepare Pacemaker - Add resource: SAPStartSrv for ABAP SAP Central Service (ASCS)"
+# SCS SAPStartSrv resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPStartSrv for ABAP SAP Central Service (SCS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapstartsrv] }}"
   vars:
     __resource_sapstartsrv:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name }}"
       agent: "{{ __sap_ha_pacemaker_cluster_resource_agents.sapstartsrv }}"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
   when:
     - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
@@ -34,20 +34,20 @@
     - __resource_sapstartsrv.id not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
 
 
-# ASCS instance resource definition
-- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for ABAP SAP Central Service (ASCS)"
+# SCS instance resource definition
+- name: "SAP HA Prepare Pacemaker - Add resource: SAPInstance for ABAP SAP Central Service (SCS)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_sapinstance] }}"
   vars:
     __resource_sapinstance:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
       agent: "ocf:heartbeat:SAPInstance"
       instance_attrs:
         - attrs:
             - name: InstanceName
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
             - name: START_PROFILE
-              value: "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+              value: "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
             - name: AUTOMATIC_RECOVER
               value: "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | string }}"
             - name: MINIMAL_PROBE
@@ -105,23 +105,23 @@
 
 
 ### Groups
-# ASCS group consists of resources in this order:
-# - ASCS VIP
-# - ASCS SAPStartSrv
-# - ASCS SAPInstance
-- name: "SAP HA Prepare Pacemaker - Add resource group for ASCS resources"
+# SCS group consists of resources in this order:
+# - SCS VIP
+# - SCS SAPStartSrv
+# - SCS SAPInstance
+- name: "SAP HA Prepare Pacemaker - Add resource group for SCS resources"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__ascs_group] }}"
+    __sap_ha_pacemaker_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups + [__scs_group] }}"
   vars:
-    __ascs_group:
-      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+    __scs_group:
+      id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
       resource_ids: |
         {% set resource_ids_list = [] %}
         {%- for resource in
-          sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name,
-          sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name %}
+          sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name,
+          sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name,
+          sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name %}
           {%- if resource | length > 0
             and resource in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')) %}
             {%- set ids = resource_ids_list.append(resource) %}
@@ -133,7 +133,7 @@
             - name: resource-stickiness
               value: "{{ sap_ha_pacemaker_cluster_nwas_cs_group_stickiness }}"
   when:
-    - __ascs_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
+    - __scs_group.id is not in (__sap_ha_pacemaker_cluster_resource_groups | map(attribute='id'))
 
 
 # ERS group consists of resources in this order:
@@ -171,15 +171,15 @@
 
 
 ### Constraints
-# ERS and ASCS resource groups should try to avoid running on the same node
-- name: "SAP HA Prepare Pacemaker - Add colocation constraint: ERS avoids to run on the ASCS node"
+# ERS and SCS resource groups should try to avoid running on the same node
+- name: "SAP HA Prepare Pacemaker - Add colocation constraint: ERS avoids to run on the SCS node"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_ers] }}"
   vars:
     __constraint_colo_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
+      id: "{{ sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
       resource_leader:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
         role: started
       resource_follower:
         id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
@@ -189,15 +189,15 @@
   when:
     - __constraint_colo_ers.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
 
-# Optional: ASCS should be started before ERS
-- name: "SAP HA Prepare Pacemaker - Add order constraint: first start ASCS group, then ERS group"
+# Optional: SCS should be started before ERS
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start SCS group, then ERS group"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
+    __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_scs_ers] }}"
   vars:
-    __constraint_order_ascs_ers:
-      id: "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
+    __constraint_order_scs_ers:
+      id: "{{ sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        id: "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
         role: started
       resource_then:
         id: "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
@@ -207,4 +207,4 @@
         - name: kind
           value: Optional
   when:
-    - __constraint_order_ascs_ers.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))
+    - __constraint_order_scs_ers.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -70,7 +70,7 @@
     - sap_ha_pacemaker_cluster_cluster_properties is iterable
     - sap_ha_pacemaker_cluster_cluster_properties | length > 0
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_cluster_properties: "{{ __sap_ha_pacemaker_cluster_cluster_properties | default([]) + __stonith_properties }}"
+    __sap_ha_pacemaker_cluster_cluster_properties: "{{ __sap_ha_pacemaker_cluster_cluster_properties | d([]) + __stonith_properties }}"
   vars:
     __stonith_properties:
       - attrs: |-
@@ -99,10 +99,10 @@
     - sap_ha_pacemaker_cluster_stonith_custom is not defined
       or sap_ha_pacemaker_cluster_stonith_custom | length == 0
     - (hostvars[stonith_host_item].__sap_ha_pacemaker_cluster_stonith_default).id
-     not in (__sap_ha_pacemaker_cluster_stonith_resource | default([])| map(attribute='id'))
+     not in (__sap_ha_pacemaker_cluster_stonith_resource | d([])| map(attribute='id'))
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_stonith_resource:
-      "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([])
+      "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([])
        + [hostvars[stonith_host_item].__sap_ha_pacemaker_cluster_stonith_default] }}"
   loop: "{{ ansible_play_hosts_all }}"
   loop_control:
@@ -218,9 +218,9 @@
     - stonith_item.name is defined and stonith_item.name | length > 0
       and stonith_item.options is defined and stonith_item.options | length > 0
     # Keep following conditional after removing Tech Debt
-    - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([]) | map(attribute='id'))
+    - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [__stonith_resource_element] }}"
+    __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [__stonith_resource_element] }}"
   vars:
     __stonith_resource_element:
       # Ensure that resource name conforms with naming convention rsc_
@@ -251,10 +251,10 @@
      and sap_ha_pacemaker_cluster_stonith_custom is iterable
      and sap_ha_pacemaker_cluster_stonith_custom is not string
     - stonith_item.id is defined and stonith_item.id | length > 0
-    - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | default([]) | map(attribute='id'))
+    - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_stonith_resource:
-      "{{ __sap_ha_pacemaker_cluster_stonith_resource | default([]) + [stonith_item] }}"
+      "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [stonith_item] }}"
   loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
   loop_control:
     label: "{{ stonith_item.name if stonith_item.name is defined else stonith_item.id }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
@@ -7,9 +7,9 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_vip] }}"
   vars:
     __constraint_order_vip:
-      id: "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: promote
       resource_then:
         id: "{{ __res_or_grp }}"
@@ -23,14 +23,14 @@
     __res_or_grp: |-
       {% if sap_ha_pacemaker_cluster_vip_group_prefix | length > 0 and
         __sap_ha_pacemaker_cluster_resource_groups | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
+        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
+        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}
       {%- else -%}
         none_found
       {%- endif -%}
@@ -46,9 +46,9 @@
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_vip] }}"
   vars:
     __constraint_order_vip:
-      id: "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name }}"
       resource_first:
-        id: "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: start
       resource_then:
         id: "{{ __res_or_grp }}"
@@ -62,14 +62,14 @@
     __res_or_grp: |-
       {% if sap_ha_pacemaker_cluster_vip_group_prefix | length > 0 and
         __sap_ha_pacemaker_cluster_resource_groups | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
+        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
+        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}
       {%- else -%}
         none_found
       {%- endif -%}
@@ -86,11 +86,12 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_vip] }}"
   vars:
     __constraint_colo_vip:
-      id: "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name }}"
       resource_leader:
         # SAPHana is replaced by SAP HANA Controller for SAPHanaSR-angi
-        id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name if __sap_ha_pacemaker_cluster_saphanasr_angi_available
-           else sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
+          if __sap_ha_pacemaker_cluster_saphanasr_angi_available
+           else __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         # SUSE SAPHanaSR is using Master Slave clone using Master/Slave roles
         role: "{{ 'master' if ansible_os_family == 'Suse' and not __sap_ha_pacemaker_cluster_saphanasr_angi_available
          else 'promoted' }}"
@@ -110,14 +111,14 @@
     __res_or_grp: |-
       {% if sap_ha_pacemaker_cluster_vip_group_prefix | length > 0 and
         __sap_ha_pacemaker_cluster_resource_groups | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
+        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
+        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}
       {%- else -%}
         none_found
       {%- endif -%}
@@ -127,7 +128,7 @@
       {% if __sap_ha_pacemaker_cluster_resource_groups | length > 0 -%}
         {% for group in __sap_ha_pacemaker_cluster_resource_groups -%}
           {% if group.id == (sap_ha_pacemaker_cluster_vip_group_prefix
-            + sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
+            + __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
             {{ (group.resource_ids | length * 1000) + sap_ha_pacemaker_cluster_constraint_colo_base_score }}
           {%- endif %}
         {%- endfor %}
@@ -146,11 +147,12 @@
     __sap_ha_pacemaker_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation + [__constraint_colo_vip] }}"
   vars:
     __constraint_colo_vip:
-      id: "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name }}"
+      id: "{{ __sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name }}"
       resource_leader:
         # SAPHana is replaced by SAP HANA Controller for SAPHanaSR-angi
-        id: "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name if __sap_ha_pacemaker_cluster_saphanasr_angi_available
-          else sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
+          if __sap_ha_pacemaker_cluster_saphanasr_angi_available
+          else __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         # SUSE SAPHanaSR is using Master Slave clone using Master/Slave roles
         role: "{{ 'slave' if ansible_os_family == 'Suse' and not __sap_ha_pacemaker_cluster_saphanasr_angi_available
          else 'unpromoted' }}"
@@ -169,14 +171,14 @@
     __res_or_grp: |-
       {% if sap_ha_pacemaker_cluster_vip_group_prefix | length > 0 and
         __sap_ha_pacemaker_cluster_resource_groups | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
+        | select('match', sap_ha_pacemaker_cluster_vip_group_prefix + __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
+        {{ sap_ha_pacemaker_cluster_vip_group_prefix }}{{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}
       {%- elif __sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id')
-        | select('match', sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name) -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}
+        | select('match', __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name) -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}
       {%- else -%}
         none_found
       {%- endif -%}
@@ -186,7 +188,7 @@
       {% if __sap_ha_pacemaker_cluster_resource_groups | length > 0 -%}
         {% for group in __sap_ha_pacemaker_cluster_resource_groups -%}
           {% if group.id == (sap_ha_pacemaker_cluster_vip_group_prefix
-            + sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
+            + __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
             {{ (group.resource_ids | length * 1000) + sap_ha_pacemaker_cluster_constraint_colo_base_score }}
           {%- endif %}
         {%- endfor %}
@@ -196,6 +198,6 @@
 
   when:
     - __constraint_colo_vip.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
-    - sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address is defined
-    - sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address != ''
+    - __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address is defined
+    - __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address != ''
     - __res_or_grp != 'none_found'  # fallback skip if there was neither a group nor any VIP/HC resources found

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_groups.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_groups.yml
@@ -10,30 +10,30 @@
       resource_ids: "{{ group_item.vip_hc_resources }}"
 
     __instance:
-      - name: "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
+      - name: "{{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
         vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
+          - "{{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
+          - "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}"
+      - name: "{{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
         vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
-        vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
-        vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
-        vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
-        vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name }}"
+          - "{{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
+          - "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}"
+      # - name: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
+      #   vip_hc_resources:
+      #     - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
+      #     - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name }}"
+      # - name: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
+      #   vip_hc_resources:
+      #     - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
+      #     - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name }}"
+      # - name: "{{ __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
+      #   vip_hc_resources:
+      #     - "{{ __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
+      #     - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name }}"
+      # - name: "{{ __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
+      #   vip_hc_resources:
+      #     - "{{ __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
+      #     - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name }}"
   loop: "{{ __instance }}"
   loop_control:
     loop_var: group_item

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_groups.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_groups.yml
@@ -18,14 +18,14 @@
         vip_hc_resources:
           - "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
           - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name }}"
+      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
         vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name }}"
-      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name }}"
+          - "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
+          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name }}"
+      - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
         vip_hc_resources:
-          - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name }}"
-          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name }}"
+          - "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
+          - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name }}"
       - name: "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
         vip_hc_resources:
           - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_construct_vip_resources.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_construct_vip_resources.yml
@@ -6,51 +6,51 @@
     __sap_ha_pacemaker_cluster_all_vip_fact: # noqa jinja[spacing]
       hana_scaleup_perf: "{{
         {
-          sap_ha_pacemaker_cluster_vip_hana_primary_resource_name:
-            sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name:
-            sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name:
+          __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name:
+            __sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name:
+            __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_hana_primary_port,
-          sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name:
+          __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port
-        } }}"
+        } if sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup_perf') | length > 0 else omit }}"
 
       nwas_abap_ascs_ers: "{{
         {
-          sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name:
+          __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name:
+            __sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
+            __sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port
-        } }}"
+        } if sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0 else omit }}"
 
       nwas_java_scs_ers: "{{
         {
-          sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name:
+          __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name:
+            __sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
+            __sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_nwas_scs_port,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port
-        } }}"
+        } if sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0 else omit }}"
 
       nwas_abap_pas_aas: "{{
         {
-          sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name:
+          __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
+            __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name:
+            __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | regex_replace('/.*', ''),
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name:
+          __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port
-        } }}"
+        } if sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas_aas') | length > 0 else omit }}"
 
 ### Maintenance note
 #
@@ -100,6 +100,27 @@
 
 # The VIP resource construction files are included in a loop to allow
 # for multiple IPs to be configured in cluster resources
+
+# Create list of VIP resource names to distinguish between VIP and HC resources
+- name: "SAP HA Prepare Pacemaker - Prepare list of VIP resource names"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_vip_resource_list:
+      - "{{ __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name | d('') }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_resource_list:
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name | d('') }}"
+      - "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name | d('') }}"
 
 # Repeat the VIP resource definition in a loop over the above combined possible parameters.
 # Applies to systems with no particular platform detected.

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_construct_vip_resources.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_construct_vip_resources.yml
@@ -15,17 +15,31 @@
           sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name:
             sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port
         } }}"
+
       nwas_abap_ascs_ers: "{{
         {
-          sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name:
-            sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | regex_replace('/.*', ''),
-          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name:
-            sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port,
-          sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name:
-            sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port
+          sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name:
+            sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | regex_replace('/.*', ''),
+          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
+            sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | regex_replace('/.*', ''),
+          sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name:
+            sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
+            sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port
         } }}"
+
+      nwas_java_scs_ers: "{{
+        {
+          sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name:
+            sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | regex_replace('/.*', ''),
+          sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
+            sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | regex_replace('/.*', ''),
+          sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name:
+            sap_ha_pacemaker_cluster_healthcheck_nwas_scs_port,
+          sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
+            sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port
+        } }}"
+
       nwas_abap_pas_aas: "{{
         {
           sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
@@ -63,7 +77,7 @@
 - name: "SAP HA Prepare Pacemaker - Combine VIP parameters"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_vip_resource_definition:
-      "{{ __sap_ha_pacemaker_cluster_vip_resource_definition | default({})
+      "{{ __sap_ha_pacemaker_cluster_vip_resource_definition | d({})
         | combine(__sap_ha_pacemaker_cluster_all_vip_fact[vip_item])
         | dict2items | rejectattr('value', 'equalto', '') | list | items2dict }}"
   loop: "{{ sap_ha_pacemaker_cluster_host_type }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
@@ -35,82 +35,105 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
 
 
+# Private variables are assigned following logic:
+# 1. Use backwards compatible var if new var is empty
+# 2. Use user input if new var is not empty
+# 3. Use default (results in failed assert in validation tasks if default is empty string)
+
+
 # Calculate private variables
 - name: "SAP HA Prepare Pacemaker - Set primary variables (HANA)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_hana_sid:
-      "{{ sap_ha_pacemaker_cluster_hana_sid | d(sap_hana_sid) | d('') | upper }}"
+      "{{ sap_hana_sid | d('') | upper
+        if sap_ha_pacemaker_cluster_hana_sid | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_sid | upper }}"
 
     # TODO: Remove backwards compatibility sap_ha_pacemaker_cluster_hana_instance_number
     __sap_ha_pacemaker_cluster_hana_instance_nr:
-      "{{ sap_ha_pacemaker_cluster_hana_instance_nr | d(sap_ha_pacemaker_cluster_hana_instance_number)
-      | d(sap_hana_instance_number) | d('') }}"
+      "{{ sap_ha_pacemaker_cluster_hana_instance_number | d(sap_hana_instance_number) | d('')
+        if sap_ha_pacemaker_cluster_hana_instance_nr | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_instance_nr }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set cluster resource variables: Primitives (HANA)"
   ansible.builtin.set_fact:
     # SAP Hana
     __sap_ha_pacemaker_cluster_hana_resource_name:
-      "{{ sap_ha_pacemaker_cluster_hana_resource_name
-      | d('rsc_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'rsc_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_resource_name }}"
 
     __sap_ha_pacemaker_cluster_hana_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name
-      | d('cln_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'cln_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_resource_clone_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
 
     __sap_ha_pacemaker_cluster_hana_resource_clone_msl_name:
-      "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name
-      | d('msl_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'msl_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_resource_clone_msl_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
 
     # SAP Hana Controller
     __sap_ha_pacemaker_cluster_hanacontroller_resource_name:
-      "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_name
-      | d('rsc_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'rsc_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hanacontroller_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
 
     __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
-      | d('mst_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'mst_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
 
     # SAP Hana Topology
     __sap_ha_pacemaker_cluster_hana_topology_resource_name:
-      "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name
-      | d('rsc_SAPHanaTop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'rsc_SAPHanaTop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_topology_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_topology_resource_name }}"
 
     __sap_ha_pacemaker_cluster_hana_topology_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name
-      | d('cln_SAPHanaTop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'cln_SAPHanaTop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_topology_resource_clone_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_topology_resource_clone_name }}"
 
     # SAP Hana Filesystem
     __sap_ha_pacemaker_cluster_hana_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_name
-      | d('rsc_SAPHanaFil_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'rsc_SAPHanaFil_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_filesystem_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name
-      | d('cln_SAPHanaFil_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'cln_SAPHanaFil_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set cluster resource variables: Constraints (HANA)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_hana_order_topology_hana_name:
-      "{{ sap_ha_pacemaker_cluster_hana_order_topology_hana_name
-      | d('ord_saphana_saphanatop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+      "{{ 'ord_saphana_saphanatop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+        if sap_ha_pacemaker_cluster_hana_order_topology_hana_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_order_topology_hana_name }}"
 
     __sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name:
-      "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name
-      | d('col_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+      "{{ 'col_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_primary'
+        if sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name }}"
 
     __sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name:
-      "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name
-      | d('col_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+      "{{ 'col_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_readonly'
+        if sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name }}"
 
     __sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name:
-      "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name
-      | d('ord_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+      "{{ 'ord_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_primary'
+        if sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name }}"
 
     __sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name:
-      "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name
-      | d('ord_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+      "{{ 'ord_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_readonly'
+        if sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set cluster resource variables: VIP (HANA)"
@@ -119,33 +142,42 @@
       "{{ sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | d('') }}"
 
     __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name:
-      "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name
-      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+      "{{ 'rsc_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_primary'
+        if sap_ha_pacemaker_cluster_vip_hana_primary_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name
-      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+      "{{ 'rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_primary'
+        if sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}"
 
     __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address:
       "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | d('') }}"
 
     __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name:
-      "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name
-      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+      "{{ 'rsc_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_readonly'
+        if sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
-      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+      "{{ 'rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr ~ '_readonly'
+        if sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name | string | length == 0
+        else sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_hana_primary_id:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id | d(__sap_ha_pacemaker_cluster_hana_sid ~ 'prim') }}"
+      "{{ __sap_ha_pacemaker_cluster_hana_sid ~ 'prim'
+        if sap_ha_pacemaker_cluster_healthcheck_hana_primary_id | string | length == 0
+        else sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id | d(__sap_ha_pacemaker_cluster_hana_sid ~ 'ro') }}"
+      "{{ __sap_ha_pacemaker_cluster_hana_sid ~ 'ro'
+        if sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id | string | length == 0
+        else sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variables: Other (HANA)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_hana_global_ini_path:
-      "{{ sap_ha_pacemaker_cluster_hana_global_ini_path
-      | d('/usr/sap/' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '/SYS/global/hdb/custom/config/global.ini') }}"
+      "{{ '/usr/sap/' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '/SYS/global/hdb/custom/config/global.ini'
+        if sap_ha_pacemaker_cluster_hana_global_ini_path | string | length == 0
+        else sap_ha_pacemaker_cluster_hana_global_ini_path }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
@@ -33,3 +33,119 @@
       else sap_ha_pacemaker_cluster_cluster_properties }}"
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
+
+
+# Calculate private variables
+- name: "SAP HA Prepare Pacemaker - Set primary variables (HANA)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_hana_sid:
+      "{{ sap_ha_pacemaker_cluster_hana_sid | d(sap_hana_sid) | d('') | upper }}"
+
+    # TODO: Remove backwards compatibility sap_ha_pacemaker_cluster_hana_instance_number
+    __sap_ha_pacemaker_cluster_hana_instance_nr:
+      "{{ sap_ha_pacemaker_cluster_hana_instance_nr | d(sap_ha_pacemaker_cluster_hana_instance_number)
+      | d(sap_hana_instance_number) | d('') }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set cluster resource variables: Primitives (HANA)"
+  ansible.builtin.set_fact:
+    # SAP Hana
+    __sap_ha_pacemaker_cluster_hana_resource_name:
+      "{{ sap_ha_pacemaker_cluster_hana_resource_name
+      | d('rsc_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_hana_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_hana_resource_clone_name
+      | d('cln_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_hana_resource_clone_msl_name:
+      "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name
+      | d('msl_SAPHana_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    # SAP Hana Controller
+    __sap_ha_pacemaker_cluster_hanacontroller_resource_name:
+      "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_name
+      | d('rsc_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
+      | d('mst_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    # SAP Hana Topology
+    __sap_ha_pacemaker_cluster_hana_topology_resource_name:
+      "{{ sap_ha_pacemaker_cluster_hana_topology_resource_name
+      | d('rsc_SAPHanaTop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_hana_topology_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_hana_topology_resource_clone_name
+      | d('cln_SAPHanaTop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    # SAP Hana Filesystem
+    __sap_ha_pacemaker_cluster_hana_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_name
+      | d('rsc_SAPHanaFil_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name
+      | d('cln_SAPHanaFil_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set cluster resource variables: Constraints (HANA)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_hana_order_topology_hana_name:
+      "{{ sap_ha_pacemaker_cluster_hana_order_topology_hana_name
+      | d('ord_saphana_saphanatop_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name:
+      "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name
+      | d('col_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+
+    __sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name:
+      "{{ sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name
+      | d('col_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+
+    __sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name:
+      "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name
+      | d('ord_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+
+    __sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name:
+      "{{ sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name
+      | d('ord_saphana_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set cluster resource variables: VIP (HANA)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_vip_hana_primary_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | d('') }}"
+
+    __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name:
+      "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_primary' }}"
+
+    __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | d('') }}"
+
+    __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name:
+      "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr) ~ '_readonly' }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_hana_primary_id:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id | d(__sap_ha_pacemaker_cluster_hana_sid ~ 'prim') }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id | d(__sap_ha_pacemaker_cluster_hana_sid ~ 'ro') }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variables: Other (HANA)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_hana_global_ini_path:
+      "{{ sap_ha_pacemaker_cluster_hana_global_ini_path
+      | d('/usr/sap/' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '/SYS/global/hdb/custom/config/global.ini') }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
@@ -372,6 +372,9 @@
       if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1 is defined and sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
       else sap_ha_pacemaker_cluster_nwas_cs_ensa1 | d(false) }}"
 
+    __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount:
+      "{{ sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool | d(true) }}"
+
 # TODO: Add PAS and AAS variables
 # sap_ha_pacemaker_cluster_nwas_abap_pas_filesystem_resource_name: >
 #   "Filesystem_NWAS_ABAP_PAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
@@ -381,3 +381,10 @@
 #   "Filesystem_NWAS_ABAP_AAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 # sap_ha_pacemaker_cluster_nwas_abap_aas_sapinstance_resource_name: >
 #   "SAPInstance_NWAS_ABAP_AAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variables for NFS Filesystems (Netweaver)"
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to typo
+    __sap_ha_pacemaker_cluster_storage_nfs_filesystem_type:
+      "{{ sap_ha_pacemaker_cluster_storage_nfs_filesytem_type | d(sap_ha_pacemaker_cluster_storage_nfs_filesystem_type) }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
@@ -14,34 +14,50 @@
     - "(role_path + '/vars/' + include_item + '.yml') is file"
 
 
+# Private variables are assigned following logic:
+# 1. Use backwards compatible var if new var is empty
+# 2. Use user input if new var is not empty
+# 3. Use default (results in failed assert in validation tasks if default is empty string)
+
+
 # Calculate private variables
 - name: "SAP HA Prepare Pacemaker - Set primary variables (Netweaver)"
   ansible.builtin.set_fact:
     # TODO: Remove backwards compatibility to nwas_abap_ascs
     __sap_ha_pacemaker_cluster_nwas_sid:
       "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | d(sap_swpm_sid) | d('') | upper
-        if sap_ha_pacemaker_cluster_nwas_sid | length == 0 else sap_ha_pacemaker_cluster_nwas_sid | upper }}"
+        if sap_ha_pacemaker_cluster_nwas_sid | string | length == 0
+        else sap_ha_pacemaker_cluster_nwas_sid | upper }}"
 
     __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr:
       "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | d(sap_swpm_ascs_instance_nr) | d('')
-        if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0 else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+        if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | string | length == 0
+        else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
 
     __sap_ha_pacemaker_cluster_nwas_scs_instance_nr:
-      "{{ sap_ha_pacemaker_cluster_nwas_scs_instance_nr | d(sap_swpm_java_scs_instance_nr) | d('') }}"
+      "{{ sap_swpm_ascs_instance_nr | d('')
+        if sap_ha_pacemaker_cluster_nwas_scs_instance_nr | string | length == 0
+        else sap_ha_pacemaker_cluster_nwas_scs_instance_nr }}"
 
     # Assign from sap_swpm variables based on host type
     __sap_ha_pacemaker_cluster_nwas_ers_instance_nr:
       "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | d(sap_swpm_ers_instance_nr) | d('')
-        if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0 and sap_ha_pacemaker_cluster_host_type == 'nwas_abap_ascs_ers'
+        if sap_ha_pacemaker_cluster_nwas_ers_instance_nr | string | length == 0
+        and sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
         else (sap_swpm_ers_instance_nr | d('')
-          if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0 and sap_ha_pacemaker_cluster_host_type == 'nwas_java_scs_ers'
-          else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+          if sap_ha_pacemaker_cluster_nwas_ers_instance_nr | string | length == 0
+          and sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+          else sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
 
-    # __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr:
-    #   "{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr | d(sap_swpm_pas_instance_nr) | d('') }}"
+    __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr:
+      "{{ sap_swpm_pas_instance_nr | d('')
+        if sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr | string | length == 0
+        else sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 
-    # __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr:
-    #   "{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr | d(sap_swpm_aas_instance_nr) | d('') }}"
+    __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr:
+      "{{ sap_swpm_aas_instance_nr | d('')
+        if sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr | string | length == 0
+        else sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set cluster resource variable: VIP (Netweaver)"
@@ -50,122 +66,146 @@
     # ASCS
     __sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address:
       "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | d('')
-      if sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | length == 0
-      else  sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address }}"
+      if sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address }}"
 
     __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name:
-      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name | d('')
-      if sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name
-      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr)
+      if sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name | d('')
-      if sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name
-      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr)
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name }}"
 
     # SCS
     __sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address:
       "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | d('') }}"
 
     __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name:
-      "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name
-      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+      "{{ 'rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      if sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name
-      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+      "{{ 'rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name }}"
 
     # ERS
     __sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address:
       "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | d('')
-      if sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | length == 0
-      else  sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | d('') }}"
+      if sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address }}"
 
     __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
-      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name | d('')
-      if sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name
-      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr)
+      if sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
 
     __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
-      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name | d('')
-      if sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name
-      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr)
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name }}"
 
-    # # PAS
-    # __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address:
-    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | d('') }}"
+    # PAS
+    __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | d('') }}"
 
-    # __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
-    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name
-    #   | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_PAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr) }}"
+    __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
+      "{{ 'rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_PAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
+      if sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
 
-    # __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name:
-    #   "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name
-    #   | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_PAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr) }}"
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name:
+      "{{ 'rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_PAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name }}"
 
-    # # AAS
-    # __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address:
-    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | d('') }}"
+    # AAS
+    __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | d('') }}"
 
-    # __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name:
-    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name
-    #   | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_AAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr) }}"
+    __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name:
+      "{{ 'rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_AAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
+      if sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
 
-    # __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name:
-    #   "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name
-    #   | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_AAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr) }}"
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name:
+      "{{ 'rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_AAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name }}"
 
-# Currently not implemented
-# - name: "SAP HA Prepare Pacemaker - Set cluster resource variable: VIP Health Checks (Netweaver)"
-#   ansible.builtin.set_fact:
-#     # TODO: Remove backwards compatibility to nwas_abap_ascs
-#     __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id:
-#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | d(sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id)
-#       | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'ascs')  }}"
 
-#     __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id:
-#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'scs')  }}"
+- name: "SAP HA Prepare Pacemaker - Set cluster resource variable: VIP Health Checks (Netweaver)"
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'ascs')
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id }}"
 
-#     __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id:
-#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | d(sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id)
-#       | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'ers')  }}"
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id:
+      "{{ __sap_ha_pacemaker_cluster_nwas_sid ~ 'scs'
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id }}"
 
-#     __sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id:
-#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'pas')  }}"
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'ers')
+        if sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | string | length == 0
+        and sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+        else (__sap_ha_pacemaker_cluster_nwas_sid ~ 'ers'
+          if sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | string | length == 0
+          and sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+          else sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id) }}"
 
-#     __sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id:
-#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'aas')  }}"
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id:
+      "{{ __sap_ha_pacemaker_cluster_nwas_sid ~ 'pas'
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id:
+      "{{ __sap_ha_pacemaker_cluster_nwas_sid ~ 'aas'
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id | string | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set cluster resource variable: Filesystem (Netweaver)"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name
-      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sapmnt') }}"
+      "{{ 'rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sapmnt'
+      if sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name
-      | d('cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sapmnt') }}"
+      "{{ 'cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sapmnt'
+      if sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name
-      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_trans') }}"
+      "{{ 'rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_trans'
+      if sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name
-      | d('cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_trans') }}"
+      "{{ 'cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_trans'
+      if sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name
-      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sys') }}"
+      "{{ 'rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sys'
+      if sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name
-      | d('cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sys') }}"
+      "{{ 'cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sys'
+      if sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variable: Instance names (Netweaver)"
@@ -173,41 +213,37 @@
     # TODO: Remove backwards compatibility to nwas_abap_ascs
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name:
       "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
-        | d(sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name) | d('') }}"
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | d('') }}"
 
     __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name:
       "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name | d('') }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name:
       "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name
-        | d(sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name) | d('') }}"
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | d('') }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variable: Instance profile paths (Netweaver)"
   ansible.builtin.set_fact:
     # TODO: Remove backwards compatibility to nwas_abap_ascs
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string
-      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/')
-        ~ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name}}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string
+      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/' ~ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name)
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
 
     __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string:
-      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string
-      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/')
-        ~ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name}}"
+      "{{ '/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/' ~ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name
+      if sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string
-      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/')
-        ~ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name}}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string
+      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/' ~ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name)
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variables for ASCS resources (Netweaver)"
@@ -216,36 +252,38 @@
   ansible.builtin.set_fact:
     # TODO: Remove backwards compatibility to nwas_abap_ascs
     __sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name
-      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr)
+      if sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name
-      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name
+      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr)
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
-      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name
+      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr)
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name }}"
 
     __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name:
-      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name | d('')
-      if sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name | length == 0
-      else sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name
-      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name
+      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr)
+      if sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name
-      | d('col_ascs_separate_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+      "{{ 'col_ascs_separate_' ~ __sap_ha_pacemaker_cluster_nwas_sid
+      if sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_order_ascs_first_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name
-      | d('ord_ascs_first_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+      "{{ 'ord_ascs_first_' ~ __sap_ha_pacemaker_cluster_nwas_sid
+      if sap_ha_pacemaker_cluster_nwas_order_ascs_first_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variables for SCS resources (Netweaver)"
@@ -253,28 +291,34 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name
-      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+      "{{ 'rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      if sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name
-      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+      "{{ 'rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      if sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name
-      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+      "{{ 'rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      if sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name }}"
 
     __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name:
-      "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name
-      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+      "{{ 'grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      if sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name
-      | d('col_scs_separate_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+      "{{ 'col_scs_separate_' ~ __sap_ha_pacemaker_cluster_nwas_sid
+      if sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_order_scs_first_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_order_scs_first_name
-      | d('ord_scs_first_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+      "{{ 'ord_scs_first_' ~ __sap_ha_pacemaker_cluster_nwas_sid
+      if sap_ha_pacemaker_cluster_nwas_order_scs_first_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_order_scs_first_name }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variables for ERS resources (Netweaver)"
@@ -284,33 +328,31 @@
   ansible.builtin.set_fact:
     # TODO: Remove backwards compatibility to nwas_abap_ascs
     __sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name
-      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr)
+      if sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name
-      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name
+      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr)
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name | length == 0
-      else sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
-      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name
+      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr)
+      if sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name | string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name }}"
 
     __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name:
-      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name | d('')
-      if sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name | length == 0
-      else sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name
-      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name
+      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr)
+      if sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name | string | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
 
     __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool | d(false)
-      if not sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool
-      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool | d(false) }}"
 
 
 - name: "SAP HA Prepare Pacemaker - Set variables for Central Services parameters (Netweaver)"
@@ -320,25 +362,22 @@
   ansible.builtin.set_fact:
     # TODO: Remove backwards compatibility to nwas_abap_ascs
     __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | d(false)
-      if not sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool
-      else sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool | d(false) }}"
 
     __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness | d(5000)
-      if sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness != 5000
-      else sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+      "{{ sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness | d(5000) }}"
 
-- name: Pause
-  ansible.builtin.pause:
-    minutes: 1200
+    __sap_ha_pacemaker_cluster_nwas_cs_ensa1:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
+      if sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1 is defined and sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_ensa1
+      else sap_ha_pacemaker_cluster_nwas_cs_ensa1 | d(false) }}"
 
 # TODO: Add PAS and AAS variables
 # sap_ha_pacemaker_cluster_nwas_abap_pas_filesystem_resource_name: >
-#   "Filesystem_NWAS_ABAP_PAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+#   "Filesystem_NWAS_ABAP_PAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 # sap_ha_pacemaker_cluster_nwas_abap_pas_sapinstance_resource_name: >
-#   "SAPInstance_NWAS_ABAP_PAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+#   "SAPInstance_NWAS_ABAP_PAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 # sap_ha_pacemaker_cluster_nwas_abap_aas_filesystem_resource_name: >
-#   "Filesystem_NWAS_ABAP_AAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+#   "Filesystem_NWAS_ABAP_AAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 # sap_ha_pacemaker_cluster_nwas_abap_aas_sapinstance_resource_name: >
-#   "SAPInstance_NWAS_ABAP_AAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+#   "SAPInstance_NWAS_ABAP_AAS_{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
@@ -12,3 +12,333 @@
       - "{{ sap_ha_pacemaker_cluster_host_type }}"
   when:
     - "(role_path + '/vars/' + include_item + '.yml') is file"
+
+
+# Calculate private variables
+- name: "SAP HA Prepare Pacemaker - Set primary variables (Netweaver)"
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_nwas_sid:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | d(sap_swpm_sid) | d('') | upper
+        if sap_ha_pacemaker_cluster_nwas_sid | length == 0 else sap_ha_pacemaker_cluster_nwas_sid | upper }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | d(sap_swpm_ascs_instance_nr) | d('')
+        if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0 else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+
+    __sap_ha_pacemaker_cluster_nwas_scs_instance_nr:
+      "{{ sap_ha_pacemaker_cluster_nwas_scs_instance_nr | d(sap_swpm_java_scs_instance_nr) | d('') }}"
+
+    # Assign from sap_swpm variables based on host type
+    __sap_ha_pacemaker_cluster_nwas_ers_instance_nr:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | d(sap_swpm_ers_instance_nr) | d('')
+        if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0 and sap_ha_pacemaker_cluster_host_type == 'nwas_abap_ascs_ers'
+        else (sap_swpm_ers_instance_nr | d('')
+          if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0 and sap_ha_pacemaker_cluster_host_type == 'nwas_java_scs_ers'
+          else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    # __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr:
+    #   "{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr | d(sap_swpm_pas_instance_nr) | d('') }}"
+
+    # __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr:
+    #   "{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr | d(sap_swpm_aas_instance_nr) | d('') }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set cluster resource variable: VIP (Netweaver)"
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    # ASCS
+    __sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | d('')
+      if sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | length == 0
+      else  sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address }}"
+
+    __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name | d('')
+      if sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name | d('')
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    # SCS
+    __sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | d('') }}"
+
+    __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+
+    # ERS
+    __sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | d('')
+      if sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | length == 0
+      else  sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | d('') }}"
+
+    __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name | d('')
+      if sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name
+      | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name:
+      "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name | d('')
+      if sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name
+      | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+
+    # # PAS
+    # __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address:
+    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | d('') }}"
+
+    # __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name:
+    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name
+    #   | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_PAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr) }}"
+
+    # __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name:
+    #   "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name
+    #   | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_PAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr) }}"
+
+    # # AAS
+    # __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address:
+    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | d('') }}"
+
+    # __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name:
+    #   "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name
+    #   | d('rsc_vip_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_AAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr) }}"
+
+    # __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name:
+    #   "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name
+    #   | d('rsc_vip_health_check_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_AAS' ~ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr) }}"
+
+# Currently not implemented
+# - name: "SAP HA Prepare Pacemaker - Set cluster resource variable: VIP Health Checks (Netweaver)"
+#   ansible.builtin.set_fact:
+#     # TODO: Remove backwards compatibility to nwas_abap_ascs
+#     __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id:
+#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | d(sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id)
+#       | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'ascs')  }}"
+
+#     __sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id:
+#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_scs_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'scs')  }}"
+
+#     __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id:
+#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | d(sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id)
+#       | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'ers')  }}"
+
+#     __sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id:
+#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'pas')  }}"
+
+#     __sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id:
+#       "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id | d(__sap_ha_pacemaker_cluster_nwas_sid ~ 'aas')  }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set cluster resource variable: Filesystem (Netweaver)"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sapmnt') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name
+      | d('cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sapmnt') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_trans') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name
+      | d('cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_trans') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sys') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name
+      | d('cln_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_sys') }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variable: Instance names (Netweaver)"
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
+        | d(sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name) | d('') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name | d('') }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name
+        | d(sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name) | d('') }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variable: Instance profile paths (Netweaver)"
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_start_profile_string | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string
+      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/')
+        ~ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name}}"
+
+    __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string:
+      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string
+      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/')
+        ~ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name}}"
+
+    __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_start_profile_string | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string
+      | d('/sapmnt/' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '/profile/')
+        ~ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name}}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variables for ASCS resources (Netweaver)"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_filesystem_resource_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name
+      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapstartsrv_resource_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
+      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_group_name | d('')
+      if sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name
+      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ASCS' ~ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name
+      | d('col_ascs_separate_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_order_ascs_first_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_order_ascs_first_name
+      | d('ord_ascs_first_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variables for SCS resources (Netweaver)"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name
+      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name
+      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name
+      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_SCS' ~ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name
+      | d('col_scs_separate_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_order_scs_first_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_order_scs_first_name
+      | d('ord_scs_first_' ~ __sap_ha_pacemaker_cluster_nwas_sid) }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variables for ERS resources (Netweaver)"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_filesystem_resource_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name
+      | d('rsc_fs_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_resource_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name
+      | d('rsc_SAPInstance_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapstartsrv_resource_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name | length == 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
+      | d('rsc_SAPStartSrv_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name:
+      "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_group_name | d('')
+      if sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name | length == 0
+      else sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name
+      | d('grp_' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_ERS' ~ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr) }}"
+
+    __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_automatic_recover_bool | d(false)
+      if not sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool }}"
+
+
+- name: "SAP HA Prepare Pacemaker - Set variables for Central Services parameters (Netweaver)"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+  ansible.builtin.set_fact:
+    # TODO: Remove backwards compatibility to nwas_abap_ascs
+    __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_automatic_recover_bool | d(false)
+      if not sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool
+      else sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool }}"
+
+    __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_resource_stickiness | d(5000)
+      if sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness != 5000
+      else sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+
+- name: Pause
+  ansible.builtin.pause:
+    minutes: 1200
+
+# TODO: Add PAS and AAS variables
+# sap_ha_pacemaker_cluster_nwas_abap_pas_filesystem_resource_name: >
+#   "Filesystem_NWAS_ABAP_PAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+# sap_ha_pacemaker_cluster_nwas_abap_pas_sapinstance_resource_name: >
+#   "SAPInstance_NWAS_ABAP_PAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+# sap_ha_pacemaker_cluster_nwas_abap_aas_filesystem_resource_name: >
+#   "Filesystem_NWAS_ABAP_AAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+# sap_ha_pacemaker_cluster_nwas_abap_aas_sapinstance_resource_name: >
+#   "SAPInstance_NWAS_ABAP_AAS_{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}_{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -48,8 +48,8 @@
 - name: "SAP HA Prepare Pacemaker - Include variable construction for VIP resources"
   ansible.builtin.import_tasks: include_construct_vip_resources.yml
 
-# Include construction task files for different scenarios.
 
+# SAP HANA Scenarios
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP HANA common"
   ansible.builtin.include_tasks:
     file: construct_vars_hana_common.yml
@@ -70,23 +70,31 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
     - __sap_ha_pacemaker_cluster_saphanasr_angi_available
 
+
+# Common variables for Netweaver scenarios
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver common"
   ansible.builtin.include_tasks:
-    file: construct_vars_nwas_common.yml
+    file: "{{ item }}"
+  loop:
+    - construct_vars_nwas_common.yml
+    - gather_vars_nwas.yml
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
 
-- name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ABAP ASCS/ERS"
+
+# SAP ASCS/ERS Scenarios
+- name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ASCS/ERS"
   ansible.builtin.include_tasks:
     file: construct_vars_nwas_abap_ascs_ers.yml
   loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
   loop_control:
     loop_var: nwas_build_item
   when:
-    - "'nwas_abap_ascs' in nwas_build_item"
-    - not sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
+    - "'nwas_abap_ascs_ers' in nwas_build_item"
+    - not sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
-- name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ABAP ASCS/ERS
+- name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ASCS/ERS Simple Mount
     Simple Mount # noqa name[template]
   ansible.builtin.include_tasks:
     file: construct_vars_nwas_abap_ascs_ers_simple_mount.yml
@@ -94,11 +102,34 @@
   loop_control:
     loop_var: nwas_build_item
   when:
-    - "'nwas_abap_ascs' in nwas_build_item"
-    - sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount
-    # TODO: Remove rule when SAPStartSrv resource agents are available on Red Hat
-    - ansible_os_family == 'Suse'
+    - "'nwas_abap_ascs_ers' in nwas_build_item"
+    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
+
+# SAP SCS/ERS Scenarios
+- name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver SCS/ERS"
+  ansible.builtin.include_tasks:
+    file: construct_vars_nwas_java_scs_ers.yml
+  loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
+  loop_control:
+    loop_var: nwas_build_item
+  when:
+    - "'nwas_java_scs_ers' in nwas_build_item"
+    - not sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+
+- name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver SCS/ERS Simple Mount
+    Simple Mount # noqa name[template]
+  ansible.builtin.include_tasks:
+    file: construct_vars_nwas_java_scs_ers_simple_mount.yml
+  loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
+  loop_control:
+    loop_var: nwas_build_item
+  when:
+    - "'nwas_java_scs_ers' in nwas_build_item"
+    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+
+
+# SAP PAS/AAS Scenarios
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ABAP PAS/AAS"
   ansible.builtin.include_tasks:
     file: construct_vars_nwas_abap_pas_aas.yml
@@ -108,14 +139,6 @@
   when:
     - "'nwas_abap_pas' in nwas_build_item"
 
-- name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver Java SCS/ERS"
-  ansible.builtin.include_tasks:
-    file: construct_vars_nwas_java_scs_ers.yml
-  loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
-  loop_control:
-    loop_var: nwas_build_item
-  when:
-    - "'nwas_java' in nwas_build_item"
 
 # Include constraints construction after the related resources were constructed.
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP Hana VIP constraints"
@@ -182,6 +205,16 @@
         group: root
         owner: root
         mode: "0600"
+
+
+    # TODO REMOVE
+    - name: Debug __sap_ha_pacemaker_cluster_resource_primitives
+      ansible.builtin.debug:
+        var: __sap_ha_pacemaker_cluster_resource_primitives
+    - name: Pause
+      ansible.builtin.pause:
+        minutes: 1200
+
 
     # Cluster installation and configuration through the dedicated
     # linux system role 'ha_cluster'

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -16,9 +16,6 @@
 # TODO: Build all resource/constraint configuration variables based on
 # simpler user input (think: drop-down options in a UI)
 
-- name: "SAP HA Prepare Pacemaker - Include parameter validation tasks"
-  ansible.builtin.import_tasks: validate_input_parameters.yml
-
 # Make sure that all parameters already set for 'ha_cluster' are also inherited.
 # Add to this file a task for EACH parameter which this SAP cluster role
 # supports.
@@ -31,6 +28,10 @@
 # Determine which SAP landscape we are going to configure in the cluster.
 - name: "SAP HA Prepare Pacemaker - Include tasks for SAP landscape calculation"
   ansible.builtin.import_tasks: ascertain_sap_landscape.yml
+
+# Validate input variables after processing in include_vars_ tasks.
+- name: "SAP HA Prepare Pacemaker - Include parameter validation tasks"
+  ansible.builtin.import_tasks: validate_input_parameters.yml
 
 # Determine if we are on a cloud platform.
 - name: "SAP HA Prepare Pacemaker - Include tasks for platform detection"
@@ -74,10 +75,7 @@
 # Common variables for Netweaver scenarios
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver common"
   ansible.builtin.include_tasks:
-    file: "{{ item }}"
-  loop:
-    - construct_vars_nwas_common.yml
-    - gather_vars_nwas.yml
+    file: construct_vars_nwas_common.yml
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
       or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
@@ -92,7 +90,7 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_abap_ascs_ers' in nwas_build_item"
-    - not sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+    - not (sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool)
 
 - name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ASCS/ERS Simple Mount
     Simple Mount # noqa name[template]
@@ -103,7 +101,7 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_abap_ascs_ers' in nwas_build_item"
-    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
 
 
 # SAP SCS/ERS Scenarios
@@ -115,7 +113,7 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_java_scs_ers' in nwas_build_item"
-    - not sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+    - not (sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool)
 
 - name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver SCS/ERS Simple Mount
     Simple Mount # noqa name[template]
@@ -126,7 +124,7 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_java_scs_ers' in nwas_build_item"
-    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
 
 
 # SAP PAS/AAS Scenarios
@@ -144,6 +142,8 @@
 - name: "SAP HA Prepare Pacemaker - Include variable construction for SAP Hana VIP constraints"
   ansible.builtin.include_tasks:
     file: construct_vars_vip_constraints_hana.yml
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 # All of the SAP HA role constructed parameters must be translated to
 # 'ha_cluster' Linux System Role parameters.
@@ -207,15 +207,6 @@
         mode: "0600"
 
 
-    # TODO REMOVE
-    - name: Debug __sap_ha_pacemaker_cluster_resource_primitives
-      ansible.builtin.debug:
-        var: __sap_ha_pacemaker_cluster_resource_primitives
-    - name: Pause
-      ansible.builtin.pause:
-        minutes: 1200
-
-
     # Cluster installation and configuration through the dedicated
     # linux system role 'ha_cluster'
     - name: "SAP HA Install Pacemaker - Include System Role 'ha_cluster'"
@@ -223,32 +214,6 @@
         name: "{{ sap_ha_pacemaker_cluster_system_roles_collection }}.ha_cluster"
       no_log: "{{ __sap_ha_pacemaker_cluster_no_log }}"  # some parameters contain secrets
 
-    # # Resource defaults settings were added to "ha_cluster" in Apr 2023 (GH version 1.9.0)
-    # # https://github.com/linux-system-roles/ha_cluster#ha_cluster_resource_defaults
-    # # Keeping separate for compatibility with older versions of the ha_cluster role.
-    # # TODO: Change resource defaults update to "ha_cluster" native syntax.
-    # - name: "SAP HA Install Pacemaker - Check resource defaults"
-    #   ansible.builtin.command:
-    #     cmd: |
-    #       {{ __sap_ha_pacemaker_cluster_command.resource_defaults_show }}
-    #   register: __sap_ha_pacemaker_cluster_check_resource_defaults
-    #   run_once: true
-    #   changed_when: false
-    #   check_mode: false
-
-    # - name: "SAP HA Install Pacemaker - Update resource default attributes"
-    #   when:
-    #     - item.key ~ '=' ~ item.value not in __sap_ha_pacemaker_cluster_check_resource_defaults.stdout
-    #     - __sap_ha_pacemaker_cluster_resource_defaults is defined
-    #     - __sap_ha_pacemaker_cluster_resource_defaults | length > 0
-    #   ansible.builtin.command:
-    #     cmd: |
-    #       {{ __sap_ha_pacemaker_cluster_command.resource_defaults_update }} {{ item.key }}={{ item.value }}
-    #   loop: "{{ __sap_ha_pacemaker_cluster_resource_defaults | dict2items }}"
-    #   loop_control:
-    #     label: "{{ item.key }}={{ item.value }}"
-    #   run_once: true
-    #   changed_when: true
 
     # Corosync post-inst
     - name: "SAP HA Install Pacemaker - Make sure corosync systemd directory exists"
@@ -291,23 +256,43 @@
         - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
       run_once: true
 
-    # Post steps for ACS ERS crmsh cluster to remove unsupported operations
+
+    # Post steps for ASCS/ERS crmsh cluster to remove unsupported operations
     - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS post steps OS specific"
       ansible.builtin.include_tasks:
         file: "{{ ansible_facts['os_family'] }}/post_steps_nwas_abap_ascs_ers.yml"
       when:
-        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
         - ansible_os_family == 'Suse'
       run_once: true
 
+    # Post steps for SCS/ERS crmsh cluster to remove unsupported operations
+    - name: "SAP HA Install Pacemaker - Include NetWeaver SCS/ERS post steps OS specific"
+      ansible.builtin.include_tasks:
+        file: "{{ ansible_facts['os_family'] }}/post_steps_nwas_java_scs_ers.yml"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+        - ansible_os_family == 'Suse'
+      run_once: true
+
+
     - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS post steps"
       ansible.builtin.include_tasks:
-        file: configure_nwas_ascs_ers_postinstallation.yml
+        file: configure_nwas_abap_ascs_ers_post_install.yml
         apply:
           tags: nwas_postinst
       tags: nwas_postinst
       when:
-        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+
+    - name: "SAP HA Install Pacemaker - Include NetWeaver SCS/ERS post steps"
+      ansible.builtin.include_tasks:
+        file: configure_nwas_java_scs_ers_post_install.yml
+        apply:
+          tags: nwas_postinst
+      tags: nwas_postinst
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
 
 
 ### END OF BLOCK: prerequisite changes and cluster setup

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -90,10 +90,9 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_abap_ascs_ers' in nwas_build_item"
-    - not (sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool)
+    - not __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 - name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver ASCS/ERS Simple Mount
-    Simple Mount # noqa name[template]
   ansible.builtin.include_tasks:
     file: construct_vars_nwas_abap_ascs_ers_simple_mount.yml
   loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
@@ -101,7 +100,7 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_abap_ascs_ers' in nwas_build_item"
-    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
+    - __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 
 # SAP SCS/ERS Scenarios
@@ -113,10 +112,9 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_java_scs_ers' in nwas_build_item"
-    - not (sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool)
+    - not __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 - name: SAP HA Prepare Pacemaker - Include variable construction for SAP NetWeaver SCS/ERS Simple Mount
-    Simple Mount # noqa name[template]
   ansible.builtin.include_tasks:
     file: construct_vars_nwas_java_scs_ers_simple_mount.yml
   loop: "{{ sap_ha_pacemaker_cluster_host_type }}"
@@ -124,7 +122,7 @@
     loop_var: nwas_build_item
   when:
     - "'nwas_java_scs_ers' in nwas_build_item"
-    - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
+    - __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 
 # SAP PAS/AAS Scenarios

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
@@ -58,9 +58,9 @@
       {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
         and sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port | length > 4 -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name -%}
+      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name -%}
+      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}
       {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_id }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
@@ -53,19 +53,19 @@
               value: 20
 
     __haproxy_id: >-
-      {% if vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
+      {% if vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
         and sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port | length > 4 -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_id }}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id }}
       {%- else -%}
       {%- endif %}
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_ibmcloud_vs.yml
@@ -30,19 +30,19 @@
               value: 20
 
     __haproxy_id: >-
-      {% if vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
+      {% if vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
         and sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port | length > 4 -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name -%}
-        {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_id }}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_pas_id }}
+      {%- elif vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name -%}
+        {{ __sap_ha_pacemaker_cluster_healthcheck_nwas_aas_id }}
       {%- else -%}
       {%- endif %}
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_ibmcloud_vs.yml
@@ -35,9 +35,9 @@
       {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
         and sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port | length > 4 -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name -%}
+      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}
-      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name -%}
+      {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}
       {%- elif vip_list_item.key == sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name -%}
         {{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_id }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
@@ -46,13 +46,13 @@
     - name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for HANA"
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_healthcheck_list_hana:
-          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
+          - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
             port: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_port }}"
         # If no custom port is defined, calculate the port for the secondary
         # by adding 10, to avoid a conflict with the port for the primary hc port.
-          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
+          - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
             port: >-
-              {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
+              {% if __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
                 {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port }}
               {%- else %}0{%- endif %}
       when:
@@ -61,9 +61,9 @@
     - name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for NW ASCS/ERS"
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_healthcheck_list_ascs:
-          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}"
+          - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id }}"
             port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port }}"
-          - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}"
+          - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id }}"
             port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port }}"
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
@@ -62,11 +62,11 @@
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_healthcheck_list_ascs:
           - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}"
-            port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port }}"
+            port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port }}"
           - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}"
-            port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port }}"
+            port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port }}"
       when:
-        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for HANA instances"
@@ -148,7 +148,7 @@
         loop_var: haproxy_item
         label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
       when:
-        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Ensure that haproxy service is running"

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
@@ -78,13 +78,13 @@
 - name: "SAP HA Install Pacemaker - IBM Cloud VS - Define healthcheck details for HANA"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_healthcheck_list_hana:
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
+      - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_primary_id }}"
         port: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_port }}"
     # If no custom port is defined, calculate the port for the secondary
     # by adding 10, to avoid a conflict with the port for the primary hc port.
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
+      - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_id }}"
         port: >-
-          {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
+          {% if __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
             {{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port }}
           {%- else %}0{%- endif %}
   when:
@@ -93,9 +93,9 @@
 - name: "SAP HA Install Pacemaker - IBM Cloud VS - Define healthcheck details for NW ASCS/ERS"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_healthcheck_list_ascs:
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}"
+      - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id }}"
         port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port }}"
-      - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}"
+      - name: "{{ __sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id }}"
         port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port }}"
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
@@ -94,11 +94,11 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_healthcheck_list_ascs:
       - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id }}"
-        port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port }}"
+        port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port }}"
       - name: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id }}"
-        port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port }}"
+        port: "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port }}"
   when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
 - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for HANA instances"
   ansible.builtin.blockinfile:
@@ -178,7 +178,7 @@
     loop_var: haproxy_item
     label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
   when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
 
 # - name: "SAP HA Prepare Pacemaker - IBM Cloud VS - haproxy listener configuration"

--- a/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
@@ -8,7 +8,7 @@
       - sap_ha_pacemaker_cluster_hana_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Requires 'sap_ha_pacemaker_cluster_hana_sid' to be defined!
+      Requires:'sap_ha_pacemaker_cluster_hana_sid' to be defined as 3 capital letters!
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
@@ -34,46 +34,167 @@
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
+
+# - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate SAP System ID"
+#   ansible.builtin.assert:
+#     that:
+#       - sap_ha_pacemaker_cluster_nwas_sid | length == 3
+#       - sap_ha_pacemaker_cluster_nwas_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
+#     fail_msg: |
+#       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+#       Requires 'sap_ha_pacemaker_cluster_nwas_sid' to be defined as 3 capital letters!
+#   when:
+#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
+
+# TODO: Remove backwards compatibility to nwas_abap_ascs
 - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate SAP System ID"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_nwas_abap_sid | length == 3
-      - sap_ha_pacemaker_cluster_nwas_abap_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
+      - __nwas_sid | length == 3
+      - __nwas_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Requires 'sap_ha_pacemaker_cluster_nwas_abap_sid' to be defined!
+      Current value: {{ __nwas_sid }}
+      Requires 'sap_ha_pacemaker_cluster_nwas_sid' to be defined as 3 capital letters!
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
+  vars:
+    __nwas_sid: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | d(sap_swpm_sid) | d('')
+      if sap_ha_pacemaker_cluster_nwas_sid | length == 0 else sap_ha_pacemaker_cluster_nwas_sid }}"
 
+
+# TODO: Remove backwards compatibility to nwas_abap_ascs
+- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Backwards compatibility: Instance Number ASCS/ERS"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+  ansible.builtin.set_fact:
+    sap_ha_pacemaker_cluster_nwas_ascs_instance_nr:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | d(sap_swpm_ascs_instance_nr) | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0
+        and sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr is defined
+        and sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | length > 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+
+    sap_ha_pacemaker_cluster_nwas_ers_instance_nr:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | d(sap_swpm_ers_instance_nr) | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_instance_nr | length == 0
+        and sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr is defined
+        and sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | length > 0
+      else sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+
+
+# Validate SAP Instance Number
 - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate SAP Instance Number"
   when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
+    - __instance_nr | length > 0
   ansible.builtin.assert:
     that:
-      - (
-          ascs_ers_nr_item | type_debug != 'int'
-          and ascs_ers_nr_item | length == 2
-        )
-        or
-        (
-          ascs_ers_nr_item | type_debug == 'int'
-          and ascs_ers_nr_item is regex("^[0-9][0-9]$")
-        )
+      - (__instance_nr | string) | length == 2
+      - (__instance_nr | string) is match('^[0-9]{2}$')
     fail_msg: |
-
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Requires the ASCS/ERS instance numbers to be defined:
-      - sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr
-      - sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr
-
       The instance number must be exactly 2 digits.
       Add quotes if the number starts with a 0!
 
+      Required:
+      {% if sap_ha_pacemaker_cluster_host_type == 'nwas_abap_ascs_ers' %}
+      - sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
+      - sap_ha_pacemaker_cluster_nwas_ers_instance_nr
+
+      {% elif sap_ha_pacemaker_cluster_host_type == 'nwas_java_scs_ers' %}
+      - sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+      - sap_ha_pacemaker_cluster_nwas_ers_instance_nr
+
+      {% elif sap_ha_pacemaker_cluster_host_type == 'nwas_abap_pas_aas' %}
+      - sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
+      - sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
+
+      {% else %}
+      Invalid sap_ha_pacemaker_cluster_host_type provided.
+      {% endif %}
+
   loop:
-    - "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}"
-    - "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}"
+    - sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
+    - sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+    - sap_ha_pacemaker_cluster_nwas_ers_instance_nr
+    - sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
+    - sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
   loop_control:
-    loop_var: ascs_ers_nr_item
+    loop_var: item
+  vars:
+    __instance_nr: "{{ lookup('ansible.builtin.vars', item) }}"
+
+
+# Ensure that storage definition is provided for Filesystem based scenarios
+- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate storage definition"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
+    - not sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_storage_definition is defined
+      - sap_ha_pacemaker_cluster_storage_definition | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      Classic cluster without Simple Mount requires:
+      - sap_ha_pacemaker_cluster_storage_definition
+
+
+# TODO: Remove backwards compatibility to nwas_abap_ascs
+- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Backwards compatibility: Instance Names"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+  ansible.builtin.set_fact:
+    sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length == 0
+        and sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name is defined
+        and sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | length > 0
+      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+
+    sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name:
+      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | d('')
+      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length == 0
+        and sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name is defined
+        and sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | length > 0
+      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+
+# Ensure that SAP profile names are defined
+- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver ASCS) Validate SAP instance name"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name is defined
+      - sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      ASCS Instance Name is mandatory: sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
+
+- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver SCS) Validate SAP instance name"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name is defined
+      - sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      SCS Instance Name is mandatory: sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name
+
+- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver ERS) Validate SAP instance name"
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name is defined
+      - sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      ERS Instance Name is mandatory: sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name
 
 
 # NIC definition validation
@@ -112,35 +233,45 @@
 - name: "SAP HA Prepare Pacemaker - (NetWeaver ASCS) Verify that the VIP is defined"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address' is not defined."
+      - sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address is defined
+      - sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | length > 0
+    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address' is not defined."
   when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs') | length > 0
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
-# - name: "SAP HA Prepare Pacemaker - (NetWeaver ERS) Verify that the VIP is defined"
+- name: "SAP HA Prepare Pacemaker - (NetWeaver SCS) Verify that the VIP is defined"
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address is defined
+      - sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | length > 0
+    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address' is not defined."
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+
+- name: "SAP HA Prepare Pacemaker - (NetWeaver ERS) Verify that the VIP is defined"
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address is defined
+      - sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | length > 0
+    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address' is not defined."
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
+
+# - name: "SAP HA Prepare Pacemaker - (NetWeaver PAS) Verify that the VIP is defined"
 #   ansible.builtin.assert:
 #     that:
-#       - sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address is defined
-#       - sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address | length > 0
-#     fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address' is not defined."
+#       - sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address is defined
+#       - sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | length > 0
+#     fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address' is not defined."
 #   when:
-#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas') | length > 0
 
-- name: "SAP HA Prepare Pacemaker - (NetWeaver PAS) Verify that the VIP is defined"
-  ansible.builtin.assert:
-    that:
-      - sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address' is not defined."
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas') | length > 0
-
-- name: "SAP HA Prepare Pacemaker - (NetWeaver AAS) Verify that the ERS VIP is defined"
-  ansible.builtin.assert:
-    that:
-      - sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address' is not defined."
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas_aas') | length > 0
+# - name: "SAP HA Prepare Pacemaker - (NetWeaver AAS) Verify that the ERS VIP is defined"
+#   ansible.builtin.assert:
+#     that:
+#       - sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address is defined
+#       - sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | length > 0
+#     fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address' is not defined."
+#   when:
+#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas_aas') | length > 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
@@ -4,8 +4,8 @@
 - name: "SAP HA Prepare Pacemaker - (SAP HANA) Validate SAP System ID"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_hana_sid | length == 3
-      - sap_ha_pacemaker_cluster_hana_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
+      - __sap_ha_pacemaker_cluster_hana_sid | length == 3
+      - __sap_ha_pacemaker_cluster_hana_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
       Requires:'sap_ha_pacemaker_cluster_hana_sid' to be defined as 3 capital letters!
@@ -15,15 +15,8 @@
 - name: "SAP HA Prepare Pacemaker - (SAP HANA) Validate SAP Instance Number"
   ansible.builtin.assert:
     that:
-      - (
-          sap_ha_pacemaker_cluster_hana_instance_nr | type_debug != 'int'
-          and sap_ha_pacemaker_cluster_hana_instance_nr | length == 2
-        )
-        or
-        (
-          sap_ha_pacemaker_cluster_hana_instance_nr | type_debug == 'int'
-          and sap_ha_pacemaker_cluster_hana_instance_nr is regex("^[0-9][0-9]$")
-        )
+      - (__sap_ha_pacemaker_cluster_hana_instance_nr | string) | length == 2
+      - (__sap_ha_pacemaker_cluster_hana_instance_nr | string) is match('^[0-9]{2}$')
     fail_msg: |
 
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
@@ -35,52 +28,17 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 
-# - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate SAP System ID"
-#   ansible.builtin.assert:
-#     that:
-#       - sap_ha_pacemaker_cluster_nwas_sid | length == 3
-#       - sap_ha_pacemaker_cluster_nwas_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
-#     fail_msg: |
-#       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-#       Requires 'sap_ha_pacemaker_cluster_nwas_sid' to be defined as 3 capital letters!
-#   when:
-#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
-
-# TODO: Remove backwards compatibility to nwas_abap_ascs
 - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate SAP System ID"
   ansible.builtin.assert:
     that:
-      - __nwas_sid | length == 3
-      - __nwas_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
+      - __sap_ha_pacemaker_cluster_nwas_sid | length == 3
+      - __sap_ha_pacemaker_cluster_nwas_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Current value: {{ __nwas_sid }}
+      Current value: {{ __sap_ha_pacemaker_cluster_nwas_sid }}
       Requires 'sap_ha_pacemaker_cluster_nwas_sid' to be defined as 3 capital letters!
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
-  vars:
-    __nwas_sid: "{{ sap_ha_pacemaker_cluster_nwas_abap_sid | d(sap_swpm_sid) | d('')
-      if sap_ha_pacemaker_cluster_nwas_sid | length == 0 else sap_ha_pacemaker_cluster_nwas_sid }}"
-
-
-# TODO: Remove backwards compatibility to nwas_abap_ascs
-- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Backwards compatibility: Instance Number ASCS/ERS"
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
-  ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_nwas_ascs_instance_nr:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | d(sap_swpm_ascs_instance_nr) | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_instance_nr | length == 0
-        and sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr is defined
-        and sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr | length > 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
-
-    sap_ha_pacemaker_cluster_nwas_ers_instance_nr:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | d(sap_swpm_ers_instance_nr) | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_instance_nr | length == 0
-        and sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr is defined
-        and sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr | length > 0
-      else sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 
 
 # Validate SAP Instance Number
@@ -98,15 +56,15 @@
       Add quotes if the number starts with a 0!
 
       Required:
-      {% if sap_ha_pacemaker_cluster_host_type == 'nwas_abap_ascs_ers' %}
+      {% if sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0 %}
       - sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
       - sap_ha_pacemaker_cluster_nwas_ers_instance_nr
 
-      {% elif sap_ha_pacemaker_cluster_host_type == 'nwas_java_scs_ers' %}
+      {% elif sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0 %}
       - sap_ha_pacemaker_cluster_nwas_scs_instance_nr
       - sap_ha_pacemaker_cluster_nwas_ers_instance_nr
 
-      {% elif sap_ha_pacemaker_cluster_host_type == 'nwas_abap_pas_aas' %}
+      {% elif sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas_aas') | length > 0 %}
       - sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
       - sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
 
@@ -115,11 +73,11 @@
       {% endif %}
 
   loop:
-    - sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
-    - sap_ha_pacemaker_cluster_nwas_scs_instance_nr
-    - sap_ha_pacemaker_cluster_nwas_ers_instance_nr
-    - sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
-    - sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
+    - __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
+    - __sap_ha_pacemaker_cluster_nwas_scs_instance_nr
+    - __sap_ha_pacemaker_cluster_nwas_ers_instance_nr
+    # - __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
+    # - __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
   loop_control:
     loop_var: item
   vars:
@@ -141,34 +99,14 @@
       - sap_ha_pacemaker_cluster_storage_definition
 
 
-# TODO: Remove backwards compatibility to nwas_abap_ascs
-- name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Backwards compatibility: Instance Names"
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
-      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
-  ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length == 0
-        and sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name is defined
-        and sap_ha_pacemaker_cluster_nwas_abap_ascs_sapinstance_instance_name | length > 0
-      else sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
-
-    sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name:
-      "{{ sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | d('')
-      if sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length == 0
-        and sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name is defined
-        and sap_ha_pacemaker_cluster_nwas_abap_ers_sapinstance_instance_name | length > 0
-      else sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
-
 # Ensure that SAP profile names are defined
 - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver ASCS) Validate SAP instance name"
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name is defined
-      - sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length > 0
+      - __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name is defined
+      - __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name | length > 0
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
       ASCS Instance Name is mandatory: sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
@@ -178,20 +116,20 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name is defined
-      - sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name | length > 0
+      - __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name is defined
+      - __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name | length > 0
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
       SCS Instance Name is mandatory: sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name
 
 - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver ERS) Validate SAP instance name"
   when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap') | length > 0
-      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java') | length > 0
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+      or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name is defined
-      - sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length > 0
+      - __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name is defined
+      - __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name | length > 0
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
       ERS Instance Name is mandatory: sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name
@@ -203,7 +141,7 @@
     that:
       - sap_ha_pacemaker_cluster_vip_client_interface is defined
       - sap_ha_pacemaker_cluster_vip_client_interface | length > 0
-    fail_msg:
+    fail_msg: |
       Multiple interfaces are found on the system.
 
       {{ ansible_interfaces | to_nice_yaml }}
@@ -224,54 +162,62 @@
 - name: "SAP HA Prepare Pacemaker - (HANA primary) Verify that the VIP is defined"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_vip_hana_primary_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_hana_primary_ip_address' is not defined."
+      - __sap_ha_pacemaker_cluster_vip_hana_primary_ip_address is defined
+      - __sap_ha_pacemaker_cluster_vip_hana_primary_ip_address | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      Required input 'sap_ha_pacemaker_cluster_vip_hana_primary_ip_address' is not defined or empty.
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - (NetWeaver ASCS) Verify that the VIP is defined"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address' is not defined."
+      - __sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address is defined
+      - __sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      Required input 'sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address' is not defined or empty.
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - (NetWeaver SCS) Verify that the VIP is defined"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address' is not defined."
+      - __sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address is defined
+      - __sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      Required input 'sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address' is not defined or empty.
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - (NetWeaver ERS) Verify that the VIP is defined"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address is defined
-      - sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | length > 0
-    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address' is not defined."
+      - __sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address is defined
+      - __sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address | length > 0
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+      Required input 'sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address' is not defined or empty.
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
       or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_java_scs_ers') | length > 0
 
-# - name: "SAP HA Prepare Pacemaker - (NetWeaver PAS) Verify that the VIP is defined"
-#   ansible.builtin.assert:
-#     that:
-#       - sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address is defined
-#       - sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | length > 0
-#     fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address' is not defined."
-#   when:
-#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas') | length > 0
+- name: "SAP HA Prepare Pacemaker - (NetWeaver PAS) Verify that the VIP is defined"
+  ansible.builtin.assert:
+    that:
+      - __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address is defined
+      - __sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address | length > 0
+    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address' is not defined."
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas') | length > 0
 
-# - name: "SAP HA Prepare Pacemaker - (NetWeaver AAS) Verify that the ERS VIP is defined"
-#   ansible.builtin.assert:
-#     that:
-#       - sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address is defined
-#       - sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | length > 0
-#     fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address' is not defined."
-#   when:
-#     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas_aas') | length > 0
+- name: "SAP HA Prepare Pacemaker - (NetWeaver AAS) Verify that the ERS VIP is defined"
+  ansible.builtin.assert:
+    that:
+      - __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address is defined
+      - __sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address | length > 0
+    fail_msg: "Host type = '{{ sap_ha_pacemaker_cluster_host_type }}', but 'sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address' is not defined."
+  when:
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_pas_aas') | length > 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/validate_input_parameters.yml
@@ -8,7 +8,7 @@
       - __sap_ha_pacemaker_cluster_hana_sid not in __sap_ha_pacemaker_cluster_sid_prohibited
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Requires:'sap_ha_pacemaker_cluster_hana_sid' to be defined as 3 capital letters!
+      Requires: 'sap_ha_pacemaker_cluster_hana_sid' to be defined as 3 capital letters!
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
@@ -18,9 +18,8 @@
       - (__sap_ha_pacemaker_cluster_hana_instance_nr | string) | length == 2
       - (__sap_ha_pacemaker_cluster_hana_instance_nr | string) is match('^[0-9]{2}$')
     fail_msg: |
-
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
-      Requires 'sap_ha_pacemaker_cluster_hana_instance_nr' to be defined.
+      Requires: 'sap_ha_pacemaker_cluster_hana_instance_nr' to be defined.
 
       The instance number must be exactly 2 digits.
       Add quotes if the number starts with a 0!
@@ -36,7 +35,7 @@
     fail_msg: |
       Host type = {{ sap_ha_pacemaker_cluster_host_type }}
       Current value: {{ __sap_ha_pacemaker_cluster_nwas_sid }}
-      Requires 'sap_ha_pacemaker_cluster_nwas_sid' to be defined as 3 capital letters!
+      Requires: 'sap_ha_pacemaker_cluster_nwas_sid' to be defined as 3 capital letters!
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
 
@@ -88,7 +87,7 @@
 - name: "SAP HA Prepare Pacemaker - (SAP NetWeaver) Validate storage definition"
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
-    - not sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+    - not __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
   ansible.builtin.assert:
     that:
       - sap_ha_pacemaker_cluster_storage_definition is defined

--- a/roles/sap_ha_pacemaker_cluster/templates/cluster_create_config.j2
+++ b/roles/sap_ha_pacemaker_cluster/templates/cluster_create_config.j2
@@ -6,58 +6,58 @@
 # Created by: {{ ansible_role_name }}
 
 # The name of the cluster
-ha_cluster_cluster_name: {{ ha_cluster_cluster_name | default('<ha_cluster LSR default>') }}
+ha_cluster_cluster_name: {{ ha_cluster_cluster_name | d('<ha_cluster LSR default>') }}
 
 # Properties that enable and control cluster behavior
 ha_cluster_cluster_properties:
-{{ ha_cluster_cluster_properties | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_cluster_properties | d() | to_nice_yaml(indent=2) }}
 
 # Definition of resource defaults
 ha_cluster_resource_defaults:
-{{ ha_cluster_resource_defaults | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_resource_defaults | d() | to_nice_yaml(indent=2) }}
 
 # Definition of operation defaults
 ha_cluster_resource_operation_defaults:
-{{ ha_cluster_resource_operation_defaults | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_resource_operation_defaults | d() | to_nice_yaml(indent=2) }}
 
 # Definition of resources which depend on other resources
 ha_cluster_constraints_colocation:
-{{ ha_cluster_constraints_colocation | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_constraints_colocation | d() | to_nice_yaml(indent=2) }}
 
 # Definition of resources which have specific location dependencies or preferences
 ha_cluster_constraints_location:
-{{ ha_cluster_constraints_location | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_constraints_location | d() | to_nice_yaml(indent=2) }}
 
 # Definition of an order in which resources must be started.
 # They are automatically stopped in reverse order.
 ha_cluster_constraints_order:
-{{ ha_cluster_constraints_order | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_constraints_order | d() | to_nice_yaml(indent=2) }}
 
 # Extra packages that are needed for this HA environment
 ha_cluster_extra_packages:
-{{ ha_cluster_extra_packages | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_extra_packages | d() | to_nice_yaml(indent=2) }}
 
 # Fence agent package(s) for this HA environment
 ha_cluster_fence_agent_packages:
-{{ ha_cluster_fence_agent_packages | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_fence_agent_packages | d() | to_nice_yaml(indent=2) }}
 
 # Definition of repositories to enable (if disable) to ensure
 # access to all required packages
 __ha_cluster_repos:
-{{ __ha_cluster_repos | default() | to_nice_yaml(indent=2) }}
+{{ __ha_cluster_repos | d() | to_nice_yaml(indent=2) }}
 
 # Definition of resources that are cloned and monitored on all nodes
 ha_cluster_resource_clones:
-{{ ha_cluster_resource_clones | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_resource_clones | d() | to_nice_yaml(indent=2) }}
 
 # Definition of resources that are grouped together
 ha_cluster_resource_groups:
-{{ ha_cluster_resource_groups | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_resource_groups | d() | to_nice_yaml(indent=2) }}
 
 # Definition of all cluster resources
 ha_cluster_resource_primitives:
-{{ ha_cluster_resource_primitives | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_resource_primitives | d() | to_nice_yaml(indent=2) }}
 
 # Definition of corosync totem settings
 ha_cluster_totem:
-{{ ha_cluster_totem | default() | to_nice_yaml(indent=2) }}
+{{ ha_cluster_totem | d() | to_nice_yaml(indent=2) }}

--- a/roles/sap_ha_pacemaker_cluster/templates/sudofile_20-saphana.j2
+++ b/roles/sap_ha_pacemaker_cluster/templates/sudofile_20-saphana.j2
@@ -6,23 +6,23 @@
 #  to update the SAP HANA cluster resource status.
 
 {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}
-Cmnd_Alias {{ node.hana_site | upper }}_SOK = /usr/sbin/crm_attribute -n hana_{{ sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SOK -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
-Cmnd_Alias {{ node.hana_site | upper }}_SFAIL = /usr/sbin/crm_attribute -n hana_{{ sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SFAIL -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
+Cmnd_Alias {{ node.hana_site | upper }}_SOK = /usr/sbin/crm_attribute -n hana_{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SOK -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
+Cmnd_Alias {{ node.hana_site | upper }}_SFAIL = /usr/sbin/crm_attribute -n hana_{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SFAIL -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
 {% endfor %}
 {% if __sap_ha_pacemaker_cluster_hana_hook_tkover and __sap_ha_pacemaker_cluster_saphanasr_angi_available %}
-Cmnd_Alias HOOK_HELPER  = /usr/bin/SAPHanaSR-hookHelper --sid={{ sap_ha_pacemaker_cluster_hana_sid | upper }} --case=checkTakeover
+Cmnd_Alias HOOK_HELPER  = /usr/bin/SAPHanaSR-hookHelper --sid={{ __sap_ha_pacemaker_cluster_hana_sid | upper }} --case=checkTakeover
 
-{{ sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
+{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
 
 Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER !requiretty
 {% elif __sap_ha_pacemaker_cluster_hana_hook_tkover and not __sap_ha_pacemaker_cluster_saphanasr_angi_available %}
-Cmnd_Alias HOOK_HELPER  = /usr/sbin/SAPHanaSR-hookHelper --sid={{ sap_ha_pacemaker_cluster_hana_sid | upper }} --case=checkTakeover
+Cmnd_Alias HOOK_HELPER  = /usr/sbin/SAPHanaSR-hookHelper --sid={{ __sap_ha_pacemaker_cluster_hana_sid | upper }} --case=checkTakeover
 
-{{ sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
+{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
 
 Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER !requiretty
 {% else %}
-{{ sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}
+{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}
 
 Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %} !requiretty
 {% endif %}

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_perf.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_perf.yml
@@ -8,7 +8,7 @@
 #  minimal base packages required for all scenarios
 #  scenario specific packages
 __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
-  __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | default([])
+  __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | d([])
   + (__sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_angi
     if __sap_ha_pacemaker_cluster_saphanasr_angi_available
     else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_scaleout) }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
@@ -8,7 +8,7 @@
 #  minimal base packages required for all scenarios
 #  scenario specific packages
 __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
-  __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | default([])
+  __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | d([])
   + (__sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_angi
     if __sap_ha_pacemaker_cluster_saphanasr_angi_available
     else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_scaleup) }}"
@@ -30,9 +30,9 @@ __sap_ha_pacemaker_cluster_hana_hook_chksrv:
 __sap_ha_pacemaker_cluster_hana_hooks: "{{
   lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).saphanasr
   + (lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).tkover
-   | default([]) if __sap_ha_pacemaker_cluster_hana_hook_tkover else [])
+   | d([]) if __sap_ha_pacemaker_cluster_hana_hook_tkover else [])
   + (lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).chksrv
-   | default([]) if __sap_ha_pacemaker_cluster_hana_hook_chksrv else [])
+   | d([]) if __sap_ha_pacemaker_cluster_hana_hook_chksrv else [])
   }}"
 
 # Define sap_ha_pacemaker_cluster_hadr_provider_name for jinja2 template

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -45,16 +45,16 @@ __sap_ha_pacemaker_cluster_available_vip_agents:
 __sap_ha_pacemaker_cluster_vip_resource_list:
   - "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
   - "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_ers_resource_name }}"
+  - "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
+  - "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
   - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
   - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
 
 __sap_ha_pacemaker_cluster_healthcheck_resource_list:
   - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}"
   - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_resource_name }}"
+  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name }}"
+  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name }}"
   - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name }}"
   - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name }}"
 
@@ -64,8 +64,13 @@ __sap_ha_pacemaker_cluster_healthcheck_resource_list:
 # includes when not overridden.
 sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: ''
 sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: ''
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port: ''
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: ''
+# TODO: Remove backwards compatibility to nwas_abap_ascs
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port:
+  "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port | d('') }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_scs_port: ''
+# TODO: Remove backwards compatibility to nwas_abap_ascs
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port:
+  "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port | d('') }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: ''
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: ''
 

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -41,23 +41,6 @@ __sap_ha_pacemaker_cluster_available_vip_agents:
   ipaddr:
     agent: "ocf:heartbeat:IPaddr2"
 
-# For convenience to distinguish between VIP and HC resources:
-__sap_ha_pacemaker_cluster_vip_resource_list:
-  - "{{ sap_ha_pacemaker_cluster_vip_hana_primary_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name }}"
-
-__sap_ha_pacemaker_cluster_healthcheck_resource_list:
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name }}"
-  - "{{ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name }}"
-
 # Health check default port as string
 # Note: difference between HANA primary and read-only required
 # Ports must be pre-defined empty to skip entering construct_vars_vip_resources_*

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_abap_ascs_ers.yml
@@ -4,11 +4,11 @@
 # definition.
 # Therefore, the /usr/sap prefix must be left out of the listed path items.
 __sap_ha_pacemaker_cluster_nwas_ascs_ers_filesystems:
-  - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/ASCS{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
-  - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/ERS{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_sid }}/ASCS{{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_sid }}/ERS{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 
 # List of ASCS/ERS profile names.
 # Used in tasks/configure_nwas_postinstallation.yml for sap_cluster_connector setup.
 __sap_ha_pacemaker_cluster_nwas_ascs_ers_profile_paths:
-  - "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
-  - "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
@@ -9,7 +9,7 @@
 #  scenario specific packages
 #  halib package if selected
 __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
-  __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | default([])
+  __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | d([])
   + ([__sap_ha_pacemaker_cluster_halib_package]
     if sap_ha_pacemaker_cluster_enable_cluster_connector else [])
   + __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas | unique }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_java_scs_ers.yml
@@ -3,12 +3,12 @@
 # The following directories are appended to the 'nfs_path' of the '/usr/sap' storage
 # definition.
 # Therefore, the /usr/sap prefix must be left out of the listed path items.
-__sap_ha_pacemaker_cluster_nwas_ascs_ers_filesystems:
-  - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/ASCS{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+__sap_ha_pacemaker_cluster_nwas_scs_ers_filesystems:
+  - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SCS{{ sap_ha_pacemaker_cluster_nwas_scs_instance_nr }}"
   - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/ERS{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 
-# List of ASCS/ERS profile names.
+# List of SCS/ERS profile names.
 # Used in tasks/configure_nwas_postinstallation.yml for sap_cluster_connector setup.
-__sap_ha_pacemaker_cluster_nwas_ascs_ers_profile_paths:
-  - "{{ sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }}"
+__sap_ha_pacemaker_cluster_nwas_scs_ers_profile_paths:
+  - "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
   - "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_java_scs_ers.yml
@@ -4,11 +4,11 @@
 # definition.
 # Therefore, the /usr/sap prefix must be left out of the listed path items.
 __sap_ha_pacemaker_cluster_nwas_scs_ers_filesystems:
-  - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/SCS{{ sap_ha_pacemaker_cluster_nwas_scs_instance_nr }}"
-  - "{{ sap_ha_pacemaker_cluster_nwas_sid | upper }}/ERS{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_sid }}/SCS{{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_sid }}/ERS{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 
 # List of SCS/ERS profile names.
 # Used in tasks/configure_nwas_postinstallation.yml for sap_cluster_connector setup.
 __sap_ha_pacemaker_cluster_nwas_scs_ers_profile_paths:
-  - "{{ sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
-  - "{{ sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }}"
+  - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -6,13 +6,13 @@
 
 # Package definition
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform:
-  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws_ec2_vs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_aws_ec2_vs | d([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws_ec2_vs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_aws_ec2_vs | d([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_aws_ec2_vs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_aws_ec2_vs | d([]) }}"
 
 
 # Stonith dictionary for default stonith agents.
@@ -219,7 +219,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_aws_ec2_vs | default('aws_vpc_move_ip') }}"
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_aws_ec2_vs | d('aws_vpc_move_ip') }}"
 sap_ha_pacemaker_cluster_vip_group_prefix: ''  # the default supported VIP agent is a single resource only
 
 __sap_ha_pacemaker_cluster_available_vip_agents:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -91,15 +91,15 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # GCP needs haproxy and ports defined
-sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
-  {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
-    620{{ sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
+  {% if __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
+    620{{ __sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
   {%- else %}{% endif %}
-sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
 
 # Platform specific VIP handling

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -5,13 +5,13 @@
 # TODO: make sure to first respect 'ha_cluster' native variables
 
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform:
-  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp_ce_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_gcp_ce_vm | d([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp_ce_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_gcp_ce_vm | d([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_gcp_ce_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_gcp_ce_vm | d([]) }}"
 
 
 # Stonith dictionary for default stonith agents.
@@ -96,8 +96,8 @@ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
   {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
     620{{ sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
   {%- else %}{% endif %}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
@@ -110,7 +110,7 @@ sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker
 # RHEL - VIP: IPaddr2, Healthcheck: haproxy
 #   HANA: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-rhel#create_a_virtual_ip_address_resource
 #   NWAS: https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-rhel#create_a_virtual_ip_address_resource
-sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_gcp_ce_vm | default('gcp_nlb_reserved_ip_haproxy') }}"
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_gcp_ce_vm | d('gcp_nlb_reserved_ip_haproxy') }}"
 
 sap_ha_pacemaker_cluster_vip_group_prefix: group_
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_powervs.yml
@@ -5,13 +5,13 @@
 # TODO: make sure to first respect 'ha_cluster' native variables
 
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform:
-  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_powervs | d([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_powervs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_powervs | d([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_ibmcloud_powervs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_ibmcloud_powervs | d([]) }}"
 
 
 # Stonith dictionary for default stonith agents.
@@ -40,12 +40,12 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
           # Dependent on network interface attachments, if no public network interface
           # then 'private' value must be provided.
           - name: api-type
-            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type | default('public') }}"
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type | d('public') }}"
 
           # Dependent on network interface attachments, if no public network interface
           # then a valid HTTP Proxy URL value must be provided.
           - name: proxy
-            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | default('') }}"
+            value: "{{ sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url | d('') }}"
 
           # String of cluster hosts defined in include_vars_platform
           - name: pcmk_host_map
@@ -74,7 +74,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_ibmcloud_powervs | default('ipaddr_custom') }}"
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_ibmcloud_powervs | d('ipaddr_custom') }}"
 
 __sap_ha_pacemaker_cluster_available_vip_agents:
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -5,13 +5,13 @@
 # TODO: make sure to first respect 'ha_cluster' native variables
 
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform:
-  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_ibmcloud_vs | d([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_vs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_ibmcloud_vs | d([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_ibmcloud_vs | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_ibmcloud_vs | d([]) }}"
 
 
 # Stonith dictionary for default stonith agents.
@@ -50,7 +50,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_ibmcloud_vs | default('ibmcloud_alb_haproxy') }}"
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_ibmcloud_vs | d('ibmcloud_alb_haproxy') }}"
 
 # For HAPROXY an non-empty port default is required to enter the resource creation flow.
 # TODO: task logic that configures actual haproxy listening ports,
@@ -60,8 +60,8 @@ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
   {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
     620{{ sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
   {%- else %}{% endif %}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_ibmcloud_vs.yml
@@ -55,15 +55,15 @@ sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_d
 # For HAPROXY an non-empty port default is required to enter the resource creation flow.
 # TODO: task logic that configures actual haproxy listening ports,
 # otherwise pairs like ASCS/ERS will conflict
-sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
-  {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
-    620{{ sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
+  {% if __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
+    620{{ __sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
   {%- else %}{% endif %}
-sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
 
 __sap_ha_pacemaker_cluster_available_vip_agents:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -123,15 +123,15 @@ sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_d
 # The VIP layer consists of 2 components - the VIP and the health check resource
 sap_ha_pacemaker_cluster_vip_group_prefix: group_
 
-sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ sap_ha_pacemaker_cluster_hana_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
-  {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
-    620{{ sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
+  {% if __sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
+    620{{ __sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
   {%- else %}{% endif %}
-sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ __sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ __sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 
 __sap_ha_pacemaker_cluster_available_vip_agents:
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -8,13 +8,13 @@
 # Any packages that are pre-requisites for variable construction must be installed before, e.g.
 # in the preconfigure-* tasks.
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform:
-  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.cloud_msazure_vm | d([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_msazure_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.cloud_msazure_vm | d([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_msazure_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.cloud_msazure_vm | d([]) }}"
 
 
 # Stonith dictionary for default stonith agents.
@@ -118,7 +118,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_msazure_vm | default('azure_lb') }}"
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_msazure_vm | d('azure_lb') }}"
 
 # The VIP layer consists of 2 components - the VIP and the health check resource
 sap_ha_pacemaker_cluster_vip_group_prefix: group_
@@ -128,8 +128,8 @@ sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-
   {% if sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address | length > 0 -%}
     620{{ sap_ha_pacemaker_cluster_hana_instance_nr | int + 1 }}
   {%- else %}{% endif %}
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ascs_instance_nr }}"
-sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_ers_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_port: "620{{ sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }}"
+sap_ha_pacemaker_cluster_healthcheck_nwas_ers_port: "620{{ sap_ha_pacemaker_cluster_nwas_ers_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_port: "620{{ sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr }}"
 

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_hyp_ibmpower_vm.yml
@@ -5,13 +5,13 @@
 # TODO: make sure to first respect 'ha_cluster' native variables
 
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform:
-  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_dict.hyp_ibmpower_vm | d([]) }}"
 
 __sap_ha_pacemaker_cluster_platform_extra_packages:
-  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.hyp_ibmpower_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_platform_extra_packages_dict.hyp_ibmpower_vm | d([]) }}"
 
 __sap_ha_pacemaker_cluster_repos:
-  "{{ __sap_ha_pacemaker_cluster_repos_dict.hyp_ibmpower_vm | default([]) }}"
+  "{{ __sap_ha_pacemaker_cluster_repos_dict.hyp_ibmpower_vm | d([]) }}"
 
 
 # Stonith dictionary for default stonith agents.
@@ -31,7 +31,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
           - name: password
             value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password }}"
           - name: hmc_version
-            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version | default('4') }}"
+            value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version | d('4') }}"
           - name: managed
             value: "{{ sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_host_mtms }}"
 
@@ -70,7 +70,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
 
 
 # Platform specific VIP handling
-sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.hyp_ibmpower_vm | default('ipaddr') }}"
+sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.hyp_ibmpower_vm | d('ipaddr') }}"
 
 __sap_ha_pacemaker_cluster_available_vip_agents:
 

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -52,8 +52,6 @@ __sap_ha_pacemaker_cluster_connector_config_lines:
 __sap_ha_pacemaker_cluster_command:
   resource_stop: "pcs resource disable"
   resource_start: "pcs resource enable"
-  resource_defaults_show: "pcs resource defaults config"
-  resource_defaults_update: "pcs resource defaults update"
   resource_restart: "pcs resource restart"
   resource_cleanup: "pcs resource cleanup"
 

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -43,8 +43,7 @@ __sap_ha_pacemaker_cluster_repos_dict:
 
 __sap_ha_pacemaker_cluster_halib_package: sap-cluster-connector
 
-# List of configuration lines that must be added to the instance profiles.
-# Used in tasks/configure_nwas_ascs_ers_postinstallation.yml for SAP HA Interface setup.
+# List of configuration lines that must be added to the instance profiles for SAP HA Interface setup.
 __sap_ha_pacemaker_cluster_connector_config_lines:
   - "service/halib = $(DIR_EXECUTABLE)/saphascriptco.so"
   - "service/halib_cluster_connector = /usr/bin/sap_cluster_connector"

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -138,6 +138,6 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 __sap_ha_pacemaker_cluster_hana_hook_tkover: false
 __sap_ha_pacemaker_cluster_hana_hook_chksrv: false
 
-# Enable ASCS/ERS Simple Mount as default
+# Central Services Cluster Simple Mount: Enabled as default
 # TODO: Enable when SAPStartSrv resource agents are available on Red Hat
-sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount: false
+sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: false

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -6,8 +6,7 @@
 
 __sap_ha_pacemaker_cluster_halib_package: sap-suse-cluster-connector
 
-# List of configuration lines that must be added to the instance profiles.
-# Used in tasks/configure_nwas_ascs_ers_postinstallation.yml for SAP HA Interface setup.
+# List of configuration lines that must be added to the instance profiles for SAP HA Interface setup.
 __sap_ha_pacemaker_cluster_connector_config_lines:
   - "service/halib = $(DIR_EXECUTABLE)/saphascriptco.so"
   - "service/halib_cluster_connector = /usr/bin/sap_suse_cluster_connector"
@@ -134,11 +133,6 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleup_perf_angi:
 # Placeholder dictionaries
 __sap_ha_pacemaker_cluster_hook_hana_scaleout: []
 __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
-
-# Overwrite resource clone name for SAP HANA
-# SAPHanaSR-angi uses different variables, so it applies only to classic HANA.
-sap_ha_pacemaker_cluster_hana_resource_clone_name:
-  "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
 
 # Central Services Cluster Simple Mount: Enabled as default
 sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: true

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -15,8 +15,6 @@ __sap_ha_pacemaker_cluster_connector_config_lines:
 __sap_ha_pacemaker_cluster_command:
   resource_stop: "crm resource stop"
   resource_start: "crm resource start"
-  resource_defaults_show: "crm configure show type:rsc_defaults"
-  resource_defaults_update: "crm configure rsc_defaults"
   resource_restart: "crm resource restart"
   resource_cleanup: "crm resource cleanup"
 

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -140,5 +140,5 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 sap_ha_pacemaker_cluster_hana_resource_clone_name:
   "{{ sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
 
-# Enable ASCS/ERS Simple Mount as default
-sap_ha_pacemaker_cluster_nwas_abap_ascs_ers_simple_mount: true
+# Central Services Cluster Simple Mount: Enabled as default
+sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: true


### PR DESCRIPTION
## Purpose
1. Add SAP Netweaver SCS/ERS cluster scenario
2. Simplify variables to align with SAP naming (ASCS is ABAP SCS, there is no reason to specify ABAP ASCS as it is contained in its name).

## Changes

1. Added SCS/ERS ENSA1 and ENSA2 Classic and Simple Mount (same code as ASCS since there are no differences in config itself)

3. Refactor of all variables with `*nwas_abap_*` to `*nwas_*` to work with java and to make more sense in regards to SAP naming.
   - `*nwas_abap_*` is retained only as part of `sap_ha_pacemaker_cluster_host_type`
```yaml
nwas_abap_ascs_ers
nwas_abap_pas_aas
nwas_java_scs_ers
```

4. Refactor of private variables to remove all calculations from defaults and vars. All of them are moved to include_vars tasks separately so we can do
   - Use backwards compatible variables until they are removed
   - Use user variables if specified
   - Default back to empty string or calculated variable of user did not specify.

5. New asserts to cover mandatory variables, that were mandatory before, but never validated with assert.

6. Added variables for future proofing PAS/AAS, but not actual cluster setup code.

7. argument_spec and readme updated with variables that were not listed before (health checks, VIP, etc.)

8. Added `DEPRECATED_VARIABLES.md` with list of changed variables and their status.

## Tested and validated on
### Operating system:
- SUSE Linux Enterprise Server for SAP applications 15 SP5
- SUSE Linux Enterprise Server for SAP applications 15 SP6

### Platforms:
- AWS
- Azure
- Google Cloud

### Tested scenarios:
- SAP HANA HA
- SAP ASCS/ERS
- SAP SCS/ERS