### PR TITLE
sap_hana_preconfigure: No longer set net.core.somaxconn in RHEL 9

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -120,14 +120,14 @@ __sap_hana_preconfigure_req_repos_redhat_9_10_ppc64le:
 
 # required SAP notes for RHEL 9:
 __sap_hana_preconfigure_sapnotes_versions_x86_64:
-  - { number: '3108302', version: '9' }
-  - { number: '2382421', version: '45' }
+  - { number: '3108302', version: '11' }
+  - { number: '2382421', version: '47' }
   - { number: '3024346', version: '11' }
 
 __sap_hana_preconfigure_sapnotes_versions_ppc64le:
   - { number: '2055470', version: '90' }
-  - { number: '3108302', version: '9' }
-  - { number: '2382421', version: '45' }
+  - { number: '3108302', version: '11' }
+  - { number: '2382421', version: '47' }
   - { number: '3024346', version: '11' }
 
 __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_preconfigure_sapnotes_versions_' + ansible_architecture) }}"
@@ -249,8 +249,7 @@ __sap_hana_preconfigure_required_ppc64le:
 
 # Network related kernel parameters as set in SAP Note 2382421:
 __sap_hana_preconfigure_kernel_parameters_default:
-# The following two parameter should always be set:
-  - { name: net.core.somaxconn, value: 4096 }
+# The following parameter should always be set:
   - { name: net.ipv4.tcp_max_syn_backlog, value: 8192 }
 # The following two parameters are automatically set by SAP Host Agent
 #  - { name: net.ipv4.ip_local_port_range, value: "40000 61000" }


### PR DESCRIPTION
Solves issue #782.