### PR TITLE
sap_netweaver_preconfigure: Sync with applicable SAP notes for Adobe DS

### DIFF
--- a/roles/sap_netweaver_preconfigure/defaults/main.yml
+++ b/roles/sap_netweaver_preconfigure/defaults/main.yml
@@ -14,7 +14,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: true
 
 sap_netweaver_preconfigure_rpath: '/usr/sap/lib'
 
-sap_netweaver_preconfigure_use_adobe_doc_services: true
+sap_netweaver_preconfigure_use_adobe_doc_services: false
 
 # (SUSE specific) Version of saptune to install.
 # It is recommended to install latest version by keeping this variable empty.

--- a/roles/sap_netweaver_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/RedHat/installation.yml
@@ -6,8 +6,10 @@
     state: present
     name: "{{ __sap_netweaver_preconfigure_packages }}"
 
-- name: Ensure required packages for Adobe Document Services are installed
+- name: Ensure required packages for Adobe Document Services are installed, x86_64 only
   ansible.builtin.package:
     state: present
     name: "{{ __sap_netweaver_preconfigure_adobe_doc_services_packages }}"
-  when: sap_netweaver_preconfigure_use_adobe_doc_services
+  when:
+    - ansible_architecture == 'x86_64'
+    - sap_netweaver_preconfigure_use_adobe_doc_services

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_7.yml
@@ -12,6 +12,7 @@ __sap_netweaver_preconfigure_sapnotes_versions:
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap
 
+# SAP note 2135057 v11:
 __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - autoconf.noarch
   - automake.noarch
@@ -19,26 +20,26 @@ __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - expat.x86_64
   - fontconfig.x86_64
   - freetype.x86_64
-  - glibc.x86_64
-  - glibc-devel.x86_64
+  - glibc.i686
+  - glibc-devel.i686
   - keyutils-libs.x86_64
   - krb5-libs.x86_64
   - libcom_err.x86_64
-  - libgcc.x86_64
+  - libgcc.i686
   - libidn.x86_64
   - libidn-devel.x86_64
   - libselinux.x86_64
   - libssh2.x86_64
-  - libX11.x86_64
-  - libXau.x86_64
-  - libxcb.x86_64
+  - libX11.i686
+  - libXau.i686
+  - libxcb.i686
   - nspr.x86_64
   - nss.x86_64
   - nss-softokn.x86_64
-  - nss-softokn-freebl.x86_64
+  - nss-softokn-freebl.i686
   - nss-util.x86_64
   - openldap.x86_64
   - openssl.x86_64
   - transfig.x86_64
   - zlib.x86_64
-  - libuuid.x86_64
+  - libuuid.i686

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_8.yml
@@ -14,6 +14,7 @@ __sap_netweaver_preconfigure_sapnotes_versions:
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap
 
+# SAP note 2920407 v6:
 __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - autoconf.noarch
   - automake.noarch
@@ -26,7 +27,6 @@ __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - libcom_err.x86_64
   - libidn2.x86_64
   - libselinux.x86_64
-  - libssh2.x86_64
   - libxcb.i686
   - nspr.x86_64
   - nss.x86_64

--- a/roles/sap_netweaver_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_netweaver_preconfigure/vars/RedHat_9.yml
@@ -12,6 +12,7 @@ __sap_netweaver_preconfigure_sapnotes_versions:
 __sap_netweaver_preconfigure_packages:
   - tuned-profiles-sap
 
+# SAP note 3242422 v2:
 __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - autoconf.noarch
   - automake.noarch
@@ -24,7 +25,6 @@ __sap_netweaver_preconfigure_adobe_doc_services_packages:
   - libcom_err.x86_64
   - libidn2.x86_64
   - libselinux.x86_64
-  - libssh2.x86_64
   - libxcb.i686
   - nspr.x86_64
   - nss.x86_64


### PR DESCRIPTION
Solves issue #689.

Further changes in this commit:
- Add the SAP note numbers and versions in a comment before the list of packages in the RedHat*.yml files in vars.

- Add 'ansible_architecture' as a condition in the related installation task, so that there is no task failure when running on another architecture than 'x86_64'.

- Also revert back to the default of 'false' for the role variable 'sap_netweaver_preconfigure_use_adobe_doc_services'. See commit 384f4d82, PR #876.