### PR TITLE
sap_hana_preconfigure: Add compat-sap-c++-13

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -212,6 +212,8 @@ __sap_hana_preconfigure_packages:
   - nfs-utils
 # SAP NOTE 3108302:
   - tuned-profiles-sap-hana
+# SAP NOTE 3449186 - Required for HANA 2.0 SPS08:
+  - compat-sap-c++-13
 
 __sap_hana_preconfigure_packages_min_install:
 # SAP NOTE 3108316:
@@ -240,6 +242,8 @@ __sap_hana_preconfigure_packages_min_install:
 #  - nfs-utils
 # SAP NOTE 3108302:
   - tuned-profiles-sap-hana
+# SAP NOTE 3449186 - Required for HANA 2.0 SPS08:
+  - compat-sap-c++-13
 
 # URL for the IBM Power Systems service and productivity tools, see https://www.ibm.com/support/pages/service-and-productivity-tools
 __sap_hana_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'


### PR DESCRIPTION
SAP HANA 2.0 SPS08 is built with GCC13, so we need to install compat-sap-c++-13.

Solves #893.