### PR TITLE
sap_hana_install: Set the install execution mode to 'optimized'

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -374,7 +374,11 @@ With the following tags, the role can be called to perform certain activities on
 
 <!-- BEGIN Further Information -->
 ## Further Information
-For more examples on how to use this role in different installation scenarios, refer to the [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) playbooks.
+- Starting with SAP HANA 2.0 SPS08, the component LSS (Local Secure Store) will be installed by default
+when installing SAP HANA. This requires the installation execution mode to be set to 'optimized', which is
+now set in the file `defaults/main.yml`.
+
+- For more examples on how to use this role in different installation scenarios, refer to the [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) playbooks.
 <!-- END Further Information -->
 
 ## License

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -140,6 +140,12 @@ sap_hana_install_system_usage: 'custom'
 sap_hana_install_restrict_max_mem: 'n'
 sap_hana_install_max_mem:
 
+# Starting with SAP HANA 2.0 SPS08, the component LSS (Local Secure Store) will be installed by default
+# when installing SAP HANA. This requires the installation execution mode to be set to 'optimized'.
+# You can change the following variable to the default of 'standard' in your playbook or inventory,
+# for example when installing an older version of SAP HANA or when not installing the 'lss' component.
+sap_hana_install_install_execution_mode: 'optimized'
+
 # hdblcm will use default ids if blank
 sap_hana_install_userid:
 sap_hana_install_groupid:


### PR DESCRIPTION
This is required when installing the HANA component 'LSS', which is the default in HANA 2.0 SPS08. The installation execution mode can be set to the previous value of 'standard' by using the role variable 'sap_hana_install_install_execution_mode'. See the file `defaults/main.yml` of this role.

Solves issue #894.