### PR TITLE
sap_ha_pacemaker_cluster: Fix haproxy and minor lint issues

### DIFF
--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/db2_hadr_enable.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/db2_hadr_enable.yml
@@ -4,7 +4,7 @@
 # See IBM Db2 documentation 'HADR and network address translation (NAT) support' - https://www.ibm.com/docs/en/db2/11.5?topic=support-hadr-nat
 # These are the HADR Ports used for internode communication, and are unrelated to Health Check probe port from a Load Balancer
 - name: SAP HA AnyDB - IBM Db2 HADR - Append IBM Db2 HA Ports to /etc/services
-  ansible.builtin.lineinfile:
+  ansible.builtin.lineinfile: # noqa no-tabs
     path: /etc/services
     line: "{{ item }}"
     state: present

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
@@ -81,7 +81,7 @@
           {% set idname = __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name %}
         {% elif '/usr/sap/trans' in __mountpoint -%}
           {% set idname = __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name %}
-        {% elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid) + '/SYS' in __mountpoint -%}
+        {% elif '/usr/sap/' + __sap_ha_pacemaker_cluster_nwas_sid + '/SYS' in __mountpoint -%}
           {% set idname = __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name %}
         {% endif %}
         {{ idname }}
@@ -162,7 +162,7 @@
           {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}
-        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid) + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + __sap_ha_pacemaker_cluster_nwas_sid + '/SYS' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}
         {%- endif %}
       resource_id: |-
@@ -170,7 +170,7 @@
           {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}
-        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid) + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + __sap_ha_pacemaker_cluster_nwas_sid + '/SYS' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}
         {%- endif %}
       meta_attrs:

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_common.yml
@@ -81,7 +81,7 @@
           {% set idname = __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name %}
         {% elif '/usr/sap/trans' in __mountpoint -%}
           {% set idname = __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name %}
-        {% elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid ) + '/SYS' in __mountpoint -%}
+        {% elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid) + '/SYS' in __mountpoint -%}
           {% set idname = __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name %}
         {% endif %}
         {{ idname }}
@@ -162,7 +162,7 @@
           {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name }}
-        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid ) + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid) + '/SYS' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name }}
         {%- endif %}
       resource_id: |-
@@ -170,7 +170,7 @@
           {{ __sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name }}
         {%- elif '/usr/sap/trans' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name }}
-        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid ) + '/SYS' in __mountpoint -%}
+        {%- elif '/usr/sap/' + (__sap_ha_pacemaker_cluster_nwas_sid) + '/SYS' in __mountpoint -%}
           {{ __sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name }}
         {%- endif %}
       meta_attrs:

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
@@ -33,14 +33,26 @@
         insertafter: '^[Unit]$'
       notify: "systemd daemon-reload"
 
-    - name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template environment"
-      ansible.builtin.lineinfile:
-        backup: true
+    - name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template"
+      ansible.builtin.replace:
+        backup: false
         path: /etc/systemd/system/haproxy@.service
-        regexp: '^Environment='
-        line: 'Environment="CONFIG=/etc/haproxy/haproxy-%i.cfg" "PIDFILE=/run/haproxy-%i.pid"'
-        state: present
-        insertafter: '^[Service]$'
+        regexp: '{{ replace_item.orig }}'
+        replace: '{{ replace_item.new | d() }}'
+      loop:
+        - orig: '^(.+)haproxy.cfg(.*)$'
+          new: '\1haproxy-%i.cfg\2'
+          label: 'Replace haproxy.cfg with haproxy-%i.cfg'
+        - orig: '^(.+)haproxy.pid(.*)$'
+          new: '\1haproxy-%i.pid\2'
+          label: 'Replace haproxy.pid with haproxy-%i.pid'
+        - orig: '\"CFGDIR=(\/\w*)*\.d\"'
+          label: 'Delete definition of CFGDIR'
+        - orig: '\ -f \$CFGDIR'
+          label: 'Remove "-f $CFGDIR"'
+      loop_control:
+        loop_var: replace_item
+        label: "{{ replace_item.label }}"
       notify: "systemd daemon-reload"
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for HANA"

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
@@ -55,24 +55,26 @@
     insertafter: '^[Unit]$'
   notify: "systemd daemon-reload"
 
-- name: "SAP HA Install Pacemaker - IBM Cloud VS - Update haproxy service template environment"
-  ansible.builtin.lineinfile:
-    backup: true
+- name: "SAP HA Install Pacemaker - IBM Cloud VS - Update haproxy service template"
+  ansible.builtin.replace:
+    backup: false
     path: /etc/systemd/system/haproxy@.service
-    regexp: '^Environment='
-    line: 'Environment="CONFIG=/etc/haproxy/haproxy-%i.cfg" "PIDFILE=/run/haproxy-%i.pid"'
-    state: present
-    insertafter: '^[Service]$'
-  notify: "systemd daemon-reload"
-
-- name: "SAP HA Install Pacemaker - IBM Cloud VS - Update haproxy service template environment"
-  ansible.builtin.lineinfile:
-    backup: true
-    path: /etc/systemd/system/haproxy@.service
-    regexp: '^Environment='
-    line: 'Environment="CONFIG=/etc/haproxy/haproxy-%i.cfg" "PIDFILE=/run/haproxy-%i.pid"'
-    state: present
-    insertafter: '^[Service]$'
+    regexp: '{{ replace_item.orig }}'
+    replace: '{{ replace_item.new | d() }}'
+  loop:
+    - orig: '^(.+)haproxy.cfg(.*)$'
+      new: '\1haproxy-%i.cfg\2'
+      label: 'Replace haproxy.cfg with haproxy-%i.cfg'
+    - orig: '^(.+)haproxy.pid(.*)$'
+      new: '\1haproxy-%i.pid\2'
+      label: 'Replace haproxy.pid with haproxy-%i.pid'
+    - orig: '\"CFGDIR=(\/\w*)*\.d\"'
+      label: 'Delete definition of CFGDIR'
+    - orig: '\ -f \$CFGDIR'
+      label: 'Remove "-f $CFGDIR"'
+  loop_control:
+    loop_var: replace_item
+    label: "{{ replace_item.label }}"
   notify: "systemd daemon-reload"
 
 - name: "SAP HA Install Pacemaker - IBM Cloud VS - Define healthcheck details for HANA"
@@ -100,7 +102,7 @@
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for HANA instances"
+- name: "SAP HA Install Pacemaker - IBM Cloud VS - Create haproxy config for HANA instances"
   ansible.builtin.blockinfile:
     backup: false
     create: true
@@ -141,7 +143,7 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
     - haproxy_item.port | length > 4
 
-- name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for NWAS ASCS/ERS instances"
+- name: "SAP HA Install Pacemaker - IBM Cloud VS - Create haproxy config for NWAS ASCS/ERS instances"
   ansible.builtin.blockinfile:
     create: true
     path: "/etc/haproxy/haproxy-{{ haproxy_item.name }}.cfg"


### PR DESCRIPTION
**ansible-lint**
- Jinja whitespace fixes
- noqa added to one task in role `sap_ha_install_anydb_ibmdb2` that includes tabs in the code on purpose

**haproxy config fix (GCP and IBM Cloud VS)**
RHEL: in haproxy 2.4.17 the default systemd service unit was enhanced with an auto-include of the default config file directory using the CFGDIR variable. When creating the unit template for the resources, our role replaced the *Environment* definition and the CFGDIR variable definition was removed, but not the newly added `-f $CFGDIR` in the various *Exec* lines. This broke the start of the unit and resources.

The solution in this PR changes the replaced patterns in the config to make sure the CFGDIR pieces are removed on all lines.

Original excerpt of the unit file section:
```
[Service]
EnvironmentFile=-/etc/sysconfig/haproxy
Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy.pid" "CFGDIR=/etc/haproxy/conf.d"
ExecStartPre=/usr/sbin/haproxy -f $CONFIG -f $CFGDIR -c -q $OPTIONS
ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -f $CFGDIR -p $PIDFILE $OPTIONS
ExecReload=/usr/sbin/haproxy -f $CONFIG -f $CFGDIR -c -q $OPTIONS
```

New config excerpt of the template copy:
```
[Service]
EnvironmentFile=-/etc/sysconfig/haproxy
Environment="CONFIG=/etc/haproxy/haproxy-%i.cfg" "PIDFILE=/run/haproxy-%i.pid" 
ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q $OPTIONS
ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE $OPTIONS
ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q $OPTIONS
```

The task now replaces the patterns in a loop with a human readable label.

*Resulting output:*
```
changed: [localhost] => (item=Replace haproxy.cfg with haproxy-%i.cfg)
changed: [localhost] => (item=Replace haproxy.pid with haproxy-%i.pid)
changed: [localhost] => (item=Delete definition of CFGDIR)
changed: [localhost] => (item=Remove "-f $CFGDIR")
```

This is only applied to the newly created template, which is a copy of the original service unit. The original remains untouched as before.

-- _**only locally tested**_ --