### PR TITLE
sap_hana_preconfigure: Do not install compat-sap-c++-13 on RHEL 9.0

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.0.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.0.yml
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# supported RHEL 9 minor releases for SAP HANA:
+__sap_hana_preconfigure_supported_rhel_minor_releases:
+  - "9.0"
+  - "9.2"
+  - "9.4"
+
+# required repos for RHEL 9:
+__sap_hana_preconfigure_req_repos_redhat_9_0_x86_64:
+  - "rhel-9-for-x86_64-baseos-e4s-rpms"
+  - "rhel-9-for-x86_64-appstream-e4s-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_0_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-e4s-rpms"
+  - "rhel-9-for-ppc64le-appstream-e4s-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_1_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_1_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_2_x86_64:
+  - "rhel-9-for-x86_64-baseos-e4s-rpms"
+  - "rhel-9-for-x86_64-appstream-e4s-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_2_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-e4s-rpms"
+  - "rhel-9-for-ppc64le-appstream-e4s-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_3_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_3_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_4_x86_64:
+  - "rhel-9-for-x86_64-baseos-e4s-rpms"
+  - "rhel-9-for-x86_64-appstream-e4s-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_4_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-e4s-rpms"
+  - "rhel-9-for-ppc64le-appstream-e4s-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_5_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_5_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_6_x86_64:
+  - "rhel-9-for-x86_64-baseos-e4s-rpms"
+  - "rhel-9-for-x86_64-appstream-e4s-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_6_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-e4s-rpms"
+  - "rhel-9-for-ppc64le-appstream-e4s-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_7_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_7_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_8_x86_64:
+  - "rhel-9-for-x86_64-baseos-e4s-rpms"
+  - "rhel-9-for-x86_64-appstream-e4s-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_8_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-e4s-rpms"
+  - "rhel-9-for-ppc64le-appstream-e4s-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-e4s-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_9_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_9_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_10_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms"
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_10_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
+# required SAP notes for RHEL 9:
+__sap_hana_preconfigure_sapnotes_versions_x86_64:
+  - { number: '3108302', version: '11' }
+  - { number: '2382421', version: '47' }
+  - { number: '3024346', version: '11' }
+
+__sap_hana_preconfigure_sapnotes_versions_ppc64le:
+  - { number: '2055470', version: '90' }
+  - { number: '3108302', version: '11' }
+  - { number: '2382421', version: '47' }
+  - { number: '3024346', version: '11' }
+
+__sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_preconfigure_sapnotes_versions_' + ansible_architecture) }}"
+
+# In SAP Note XXX, certain minimal required packages for the different RHEL 9 minor releases are listed.
+# The following will assign them properly to __sap_hana_preconfigure_min_pkgs.
+# If variable __sap_hana_preconfigure_min_packages_VERSION_ARCH is not defined,
+# variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
+
+# Minimum required package levels for RHEL 9.0:
+__sap_hana_preconfigure_min_packages_9_0_x86_64:
+  - [ 'kernel', '5.14.0-70.22.1.el9_0' ]
+
+__sap_hana_preconfigure_min_packages_9_0_ppc64le:
+  - [ 'kernel', '5.14.0-70.43.1.el9_0' ]
+  - [ 'glibc', '2.34-28.el9_0.3' ]
+
+__sap_hana_preconfigure_min_packages_9_1_x86_64:
+
+__sap_hana_preconfigure_min_packages_9_1_ppc64le:
+
+__sap_hana_preconfigure_min_packages_9_2_x86_64:
+  - [ 'kernel', '5.14.0-284.25.1.el9_2' ]
+
+__sap_hana_preconfigure_min_packages_9_2_ppc64le:
+  - [ 'kernel', '5.14.0-284.25.1.el9_2' ]
+
+__sap_hana_preconfigure_min_packages_9_3_x86_64:
+
+__sap_hana_preconfigure_min_packages_9_3_ppc64le:
+
+__sap_hana_preconfigure_min_packages_9_4_x86_64:
+  - [ 'kernel', '5.14.0-427.16.1.el9_4' ]
+
+__sap_hana_preconfigure_min_packages_9_4_ppc64le:
+  - [ 'kernel', '5.14.0-427.16.1.el9_4' ]
+
+__sap_hana_preconfigure_min_packages_9_5_x86_64:
+
+__sap_hana_preconfigure_min_packages_9_5_ppc64le:
+
+__sap_hana_preconfigure_min_packages_9_6_x86_64:
+
+__sap_hana_preconfigure_min_packages_9_6_ppc64le:
+
+__sap_hana_preconfigure_min_packages_9_7_x86_64:
+
+__sap_hana_preconfigure_min_packages_9_7_ppc64le:
+
+__sap_hana_preconfigure_min_packages_9_8_x86_64:
+
+__sap_hana_preconfigure_min_packages_9_8_ppc64le:
+
+__sap_hana_preconfigure_min_pkgs: "{{ lookup('vars', '__sap_hana_preconfigure_min_packages_' + ansible_distribution_version | string | replace(\".\", \"_\") + '_' + ansible_architecture) }}"
+
+__sap_hana_preconfigure_packages:
+# SAP NOTE 3108316:
+  - expect
+# package gtk2: only needed if the SAP HANA installation tools hdblcmgui and hdbsetup are used
+  - gtk2
+  - krb5-workstation
+  - libatomic
+  - libcanberra-gtk2
+  - libtool-ltdl
+  - numactl
+  - PackageKit-gtk3-module
+  - xorg-x11-xauth
+# package chkconfig: needed by hdblcm to be able to access /etc/init.d
+  - chkconfig
+# package compat-openssl11: needed for HANA scale-out and when configuring HANA backup on Azure
+  - compat-openssl11
+# package libxcrypt-compat: needed SAP HANA and also by sapstartsrv on RHEL 9:
+#  - libxcrypt-compat       # now installed by role sap_general_preconfigure, see also SAP note 3108316, version 4.
+# For support purposes:
+# package graphwiz: graph visualization tools, for supportability)
+  - graphviz
+# package iptraf-ng: TCP/IP network monitor, for supportability)
+  - iptraf-ng
+# package lm-sensors: TCP/IP network monitor, for supportability)
+  - lm_sensors
+# package nfs-utils: support utilities for NFS, for supportability)
+  - nfs-utils
+# SAP NOTE 3108302:
+  - tuned-profiles-sap-hana
+
+__sap_hana_preconfigure_packages_min_install:
+# SAP NOTE 3108316:
+  - expect
+# package gtk2: only needed if the SAP HANA installation tools hdblcmgui and hdbsetup are used
+#  - gtk2
+  - krb5-workstation
+  - libatomic
+  - libcanberra-gtk2
+  - libtool-ltdl
+  - numactl
+  - PackageKit-gtk3-module
+  - xorg-x11-xauth
+# package compat-openssl11: needed for HANA scale-out and when configuring HANA backup on Azure
+  - compat-openssl11
+# required for SAP HANA on RHEL 9:
+  - libxcrypt-compat
+# For support purposes:
+# package graphwiz: graph visualization tools, for supportability)
+#  - graphviz
+# package iptraf-ng: TCP/IP network monitor, for supportability)
+#  - iptraf-ng
+# package lm-sensors: TCP/IP network monitor, for supportability)
+#  - lm_sensors
+# package nfs-utils: support utilities for NFS, for supportability)
+#  - nfs-utils
+# SAP NOTE 3108302:
+  - tuned-profiles-sap-hana
+
+# URL for the IBM Power Systems service and productivity tools, see https://www.ibm.com/support/pages/service-and-productivity-tools
+__sap_hana_preconfigure_ibm_power_repo_url: 'https://public.dhe.ibm.com/software/server/POWER/Linux/yum/download/ibm-power-repo-latest.noarch.rpm'
+
+__sap_hana_preconfigure_required_ppc64le:
+  - ibm-power-managed-rhel9
+
+# Network related kernel parameters as set in SAP Note 2382421:
+__sap_hana_preconfigure_kernel_parameters_default:
+# The following parameter should always be set:
+  - { name: net.ipv4.tcp_max_syn_backlog, value: 8192 }
+# The following two parameters are automatically set by SAP Host Agent
+#  - { name: net.ipv4.ip_local_port_range, value: "40000 61000" }
+#  - { name: net.ipv4.ip_local_reserved_ports, value: -> SAP NOTE 2477204 }
+# The following two parameters do not work when communicating with hosts behind NAT firewall:
+#  - { name: net.ipv4.tcp_tw_reuse, value: 1 }
+#  - { name: net.ipv4.tcp_tw_recycle, value: 1 }
+# The following parameter should always be set but might not work on Azure (see SAP Note 2382421):
+  - { name: net.ipv4.tcp_timestamps, value: 1 }
+# The following parameter should always be set:
+  - { name: net.ipv4.tcp_slow_start_after_idle, value: 0 }
+# Tune the next four parameters for low latency system replication:
+#  - { net.ipv4.tcp_wmem, value }
+#  - { net.ipv4.tcp_rmem, value }
+#  - { net.core.wmem_max, value }
+#  - { net.core.rmem_max, value }
+# Should be set correctly already on most systems, according to SAP Note 2382421:
+#  - { net.ipv4.tcp_window_scaling, 1 }
+# The following only applies to HANA 1 <= 122.14 and HANA 2 SPS00.
+# So we do not change the default.
+#  - { name: net.ipv4.tcp_syn_retries, value: 8 }
+
+# Network related kernel parameters for ppc64le:
+__sap_hana_preconfigure_kernel_parameters_default_ppc64le:
+  - { name: net.core.rmem_max, value: 56623104 }
+  - { name: net.core.wmem_max, value: 56623104 }
+  - { name: net.ipv4.tcp_rmem, value: "65536 262088 56623104" }
+  - { name: net.ipv4.tcp_wmem, value: "65536 262088 56623104" }
+  - { name: net.ipv4.tcp_mem, value: "56623104 56623104 56623104" }
+
+# Network related kernel parameters for NetApp NFS, as set in SAP Note 3024346:
+__sap_hana_preconfigure_kernel_parameters_netapp_nfs:
+  - { name: net.core.rmem_max, value: 16777216 }
+  - { name: net.core.wmem_max, value: 16777216 }
+  - { name: net.ipv4.tcp_rmem, value: "4096 131072 16777216" }
+  - { name: net.ipv4.tcp_wmem, value: "4096 16384 16777216" }
+  - { name: net.core.netdev_max_backlog, value: 300000 }
+# already set in SAP note 2382421:
+#  - { name: net.ipv4.tcp_slow_start_after_idle, value: 0 }
+  - { name: net.ipv4.tcp_no_metrics_save, value: 1 }
+  - { name: net.ipv4.tcp_moderate_rcvbuf, value: 1 }
+  - { name: net.ipv4.tcp_window_scaling, value: 1 }
+# already set in SAP note 2382421:
+#  - { name: net.ipv4.tcp_timestamps, value: 1 }
+  - { name: net.ipv4.tcp_sack, value: 1 }
+
+# yamllint disable rule:commas rule:colons
+__sap_hana_preconfigure_packages_and_services:
+  abrtd:     { pkg: 'abrt',            svc: 'abrtd',     systemd_enabled: 'no', systemd_state: 'stopped', svc_status: 'disabled', svc_state: 'inactive' }
+  abrt-ccpp: { pkg: 'abrt-addon-ccpp', svc: 'abrt-ccpp', systemd_enabled: 'no', systemd_state: 'stopped', svc_status: 'disabled', svc_state: 'inactive' }
+  numad:     { pkg: 'numad',           svc: 'numad',     systemd_enabled: 'no', systemd_state: 'stopped', svc_status: 'disabled', svc_state: 'inactive' }
+  kdump:     { pkg: 'kexec-tools',     svc: 'kdump',     systemd_enabled: 'no', systemd_state: 'stopped', svc_status: 'disabled', svc_state: 'inactive' }
+  firewalld: { pkg: 'firewalld',       svc: 'firewalld', systemd_enabled: 'no', systemd_state: 'stopped', svc_status: 'disabled', svc_state: 'inactive' }
+# yamllint enable rule:commas rule:colons


### PR DESCRIPTION
... because HANA 2.0 SPS08 (GCC13 based) has only been validated by SAP starting with RHEL 9.2

Fixes issue #901.