### PR TITLE
sap_ha_pacemaker_cluster: ANGI on RHEL and small improvements

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_hana.yml
@@ -1,7 +1,51 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Identify if SAPHanaSR-angi package is available for installation.
-# SAPHanaSR-angi replaces SAPHanaSR and SAPHanaSR-ScaleOut.
+# Identify if 'sap-hana-ha' package is available for installation.
+# sap-hana-ha replaces resource-agents-sap-hana and resource-agents-sap-hana-scaleout.
 
-# TODO:
-# Add RedHat specific steps to identify SAPHanaSR-angi package.
+- name: "SAP HA Prepare Pacemaker - Block for detection of 'SAPHanaSR-angi'"
+  when: (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
+  block:
+
+    - name: "SAP HA Prepare Pacemaker - Gather installed packages facts"
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: "SAP HA Prepare Pacemaker - Check the availability of 'sap-hana-ha'"
+      ansible.builtin.command:
+        cmd: dnf provides sap-hana-ha
+      changed_when: false
+      register: __sap_ha_pacemaker_cluster_saphanasr_angi_check
+      failed_when: false
+
+      # The provision role should not fix packages if run against systems that
+      # were previously installed with the conflicting packages. System state is
+      # unclear at this moment and the role should rather fail early.
+    - name: "SAP HA Prepare Pacemaker - Fail if there are package conflicts"
+      ansible.builtin.assert:
+        that:
+          - "'resource-agents-sap-hana' not in packages or
+            __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc == 0"
+        fail_msg: |
+
+          ERROR: Conflicting packages.
+
+          Package available and to be installed: sap-hana-ha
+
+          Conflicting packages are installed:
+          {% for finding in (packages | select('match', 'resource-agents-sap.*')) %}
+          - {{ finding }}
+          {% endfor %}
+
+          Remove the conflicting packages to continue the setup with the
+          detected resource agent package.
+          Alternatively: Disable the package detection
+          (sap_ha_pacemaker_cluster_saphanasr_angi_detection = false)
+          to continue the setup using the installed resource agents.
+
+    - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
+      when:
+        - __sap_ha_pacemaker_cluster_saphanasr_angi_check is defined
+        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc == 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
@@ -26,14 +26,14 @@
         __sap_ha_pacemaker_cluster_hana_hook_chksrv: false
 
     # tkover and chksrv variables are updated if their providers are detected
-    - name: "SAP HA Pacemaker srHook - Set tkover true if present"
+    - name: "SAP HA Pacemaker srHook - Set tkover true if defined and enabled"
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_hana_hook_tkover: true
       when:
         - sap_ha_pacemaker_cluster_hana_hooks | selectattr(
           'provider', 'search', 'tkover', 'i') | list | length > 0
 
-    - name: "SAP HA Pacemaker srHook - Set chksrv true if present"
+    - name: "SAP HA Pacemaker srHook - Set chksrv true if defined and enabled"
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_hana_hook_chksrv: true
       when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
@@ -9,7 +9,9 @@
     __constraint_order_vip:
       id: "{{ __sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name }}"
       resource_first:
-        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
+          if __sap_ha_pacemaker_cluster_saphanasr_angi_available
+           else __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: promote
       resource_then:
         id: "{{ __res_or_grp }}"
@@ -48,7 +50,9 @@
     __constraint_order_vip:
       id: "{{ __sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name }}"
       resource_first:
-        id: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
+        id: "{{ __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
+          if __sap_ha_pacemaker_cluster_saphanasr_angi_available
+           else __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         action: start
       resource_then:
         id: "{{ __res_or_grp }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
@@ -3,7 +3,7 @@
 # Detect presence of SAPHanaSR-angi package before loading HANA variables
 # Detection of package availability was chosen instead of OS version check.
 # SAPHanaSR-angi will be retrofitted to older SP repositories in future.
-- name: "SAP HA Prepare Pacemaker - Detect SAPHanaSR-angi availability"
+- name: "SAP HA Install Pacemaker - Run SAP HANA pre-steps"
   ansible.builtin.include_tasks:
     file: "{{ ansible_facts['os_family'] }}/pre_steps_hana.yml"
   when:
@@ -81,7 +81,7 @@
         else sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
 
     __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name:
-      "{{ 'mst_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+      "{{ 'cln_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
         if sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name | string | length == 0
         else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/ascertain_platform_type.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/ascertain_platform_type.yml
@@ -81,14 +81,14 @@
   changed_when: false
   when: ansible_architecture == "ppc64le"
 
-- name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - RSCT binary check"
+- name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - Fail if RSCT binary is missing"
   ansible.builtin.fail:
     msg: Please install RSCT from IBM Power Systems service and productivity tools repository
   when:
     - ansible_architecture == "ppc64le"
     - __sap_ha_pacemaker_cluster_power_rsct_check.stdout == ""
 
-- name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - RSCT binary check"
+- name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - Run 'ctgethscid'"
   ansible.builtin.shell: |
     /opt/rsct/bin/ctgethscid
   register: __sap_ha_pacemaker_cluster_power_rsct_hscid

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
@@ -20,11 +20,15 @@ __sap_ha_pacemaker_cluster_hana_hook_dictionary:
 
 # Recommended srhooks are set to true only if default dictionary is populated
 __sap_ha_pacemaker_cluster_hana_hook_tkover:
-  "{{ true if lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).tkover
-   is defined else false }}"
+  "{{ true if 
+    (lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).tkover
+    is defined and (sap_ha_pacemaker_cluster_hana_hook_tkover | bool))
+    else false }}"
 __sap_ha_pacemaker_cluster_hana_hook_chksrv:
-  "{{ true if lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).chksrv
-   is defined else false }}"
+  "{{ true if
+    (lookup('ansible.builtin.vars', __sap_ha_pacemaker_cluster_hana_hook_dictionary).chksrv
+    is defined and (sap_ha_pacemaker_cluster_hana_hook_chksrv | bool))
+    else false }}"
 
 # Combine final list of srhooks based on user input and angi availability
 __sap_ha_pacemaker_cluster_hana_hooks: "{{

--- a/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/redhat.yml
@@ -91,6 +91,8 @@ __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
 
 # Dictionary with additional cluster packages for specific scenarios
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
+  hana_angi:
+    - sap-hana-ha
   hana_scaleout:
     - resource-agents-sap-hana-scaleout
   hana_scaleup:
@@ -105,13 +107,10 @@ __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
 __sap_ha_pacemaker_cluster_resource_agents:
   saphanatopology: "ocf:heartbeat:SAPHanaTopology"
   saphana: "ocf:heartbeat:SAPHana"
-# TODO: Uncomment when SAPHanaSR-angi is available on Red Hat
-#  saphanacontroller: "ocf:heartbeat:SAPHanaController"
-#  saphanafilesystem: "ocf:heartbeat:SAPHanaFilesystem"
-# TODO: Uncomment when SAPStartSrv is available on Red Hat
-#  sapstartsrv: "ocf:heartbeat:SAPStartSrv"
+  saphanacontroller: "ocf:heartbeat:SAPHanaController"
+  saphanafilesystem: "ocf:heartbeat:SAPHanaFilesystem"
+  sapstartsrv: "ocf:heartbeat:SAPStartSrv"
 
-# TODO: Uncomment when SAPHanaSR-angi is available on Red Hat
 __sap_ha_pacemaker_cluster_saphanasr_angi_available: false
 
 # Default SAP HANA hook parameters combined based on user decision
@@ -122,18 +121,39 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleup_perf:
       options:
         - name: execution_order
           value: 1
-# TODO: Add additional hooks
+  chksrv:
+    - provider: ChkSrv
+      path: /usr/share/SAPHanaSR/srHook/
+      options:
+        - name: execution_order
+          value: 2
+        - name: action_on_lost
+          value: stop
 
-# Placeholder dictionaries
-# TODO: Define hooks when SAPHanaSR-angi is available on Red Hat
-__sap_ha_pacemaker_cluster_hook_hana_scaleup_perf_angi: []
+__sap_ha_pacemaker_cluster_hook_hana_scaleup_perf_angi:
+  saphanasr:
+    - provider: HanaSR
+      path: /usr/share/sap-hana-ha/
+      options:
+        - name: execution_order
+          value: 1
+  chksrv:
+    - provider: ChkSrv
+      path: /usr/share/sap-hana-ha/
+      options:
+        - name: execution_order
+          value: 2
+        - name: action_on_lost
+          value: stop
+        - name: stop_timeout
+          value: 25
+
 __sap_ha_pacemaker_cluster_hook_hana_scaleout: []
 __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 
-# Disabled additional hooks until they are present in dictionary above
-# TODO: Remove when additional hooks are specified above.
-__sap_ha_pacemaker_cluster_hana_hook_tkover: false
-__sap_ha_pacemaker_cluster_hana_hook_chksrv: false
+# Enable default OS recommended hooks
+sap_ha_pacemaker_cluster_hana_hook_tkover: false
+sap_ha_pacemaker_cluster_hana_hook_chksrv: true
 
 # Central Services Cluster Simple Mount: Enabled as default
 # TODO: Enable when SAPStartSrv resource agents are available on Red Hat

--- a/roles/sap_ha_pacemaker_cluster/vars/suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/suse.yml
@@ -132,5 +132,9 @@ __sap_ha_pacemaker_cluster_hook_hana_scaleup_perf_angi:
 __sap_ha_pacemaker_cluster_hook_hana_scaleout: []
 __sap_ha_pacemaker_cluster_hook_hana_scaleout_angi: []
 
+# Enable default OS recommended hooks
+sap_ha_pacemaker_cluster_hana_hook_tkover: true
+sap_ha_pacemaker_cluster_hana_hook_chksrv: true
+
 # Central Services Cluster Simple Mount: Enabled as default
 sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: true


### PR DESCRIPTION
## Description
1. "ANGI" now also works on RHEL
   - RHEL pre-steps discover the package but will not resolve the package conflict if the classic agents are installed. A failure message explains the issue and the user has to solve it. This will prevent an unintended change of the entire setup if run against pre-configured nodes.
   - Adjustment of the VIP order constraint task to work with classic and 'angi'.

2. Adjustment of hook vars logic
   - Explicitly define hook preferences for `_tkover` and `_chksrv` vars in OS defaults.
   - The hook task now respects the hook control variable and the argument now works for user choices, overriding the OS preference.
   - The presence of the hook definition in the OS vars does not enforce the hook config anymore. This enables the definition of optional hooks.
   - In RHEL the `_chksrv` hook is also available and supported. The hook is optional, for customers to enable on demand.

3. A few cosmetical improvements of task names
4. Suspected typo fixed for `__sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name`
   - I could not find a reference to `mst_` and the argument default info also refers to `cln_` as the prefix.

## Tested
- ... on RHEL 9.4 in AWS for SAP HANA HA with 'classic' and 'angi' resource agents.
- Verified the hook enable choice to configure the hook that is not enabled by default on RHEL.