### PR TITLE
sap_install_media_detect: Fix wrong sap_export_solman_java detection

### DIFF
--- a/roles/sap_install_media_detect/files/tmp/sapfile
+++ b/roles/sap_install_media_detect/files/tmp/sapfile
@@ -286,7 +286,7 @@ for _FILE in "$@"; do
          /db2setup/{_sap_file_type="ibmdb2"; exit}
          /db6_update_client.sh/{_sap_file_type="ibmdb2_client"; exit}
          /db2aese_c.lic/{_sap_file_type="ibmdb2_license"; exit}
-         /DATA_UNITS\/JAVA_EXPORT_JDMP/{_sap_file_type="sap_export_nwas_java"; exit}
+         /DATA_UNITS\/JAVA_EXPORT_JDMP/{_sap_file_type="sap_export_nwas_java"}
          /DATA_UNITS\/EXPORT/{_sap_file_type="sap_export_ecc"; exit}
          /DATA_UNITS\/EXP[0-9]/{_sap_file_type="sap_export_nwas_abap"; exit}
          /DATA_UNITS\/SOLMAN/&&/_JAVA_UT/{_sap_file_type="sap_export_solman_java"; exit}


### PR DESCRIPTION
Fixes issue #912.

The SAP Solution Manager JAVA Export file (e.g. 51054655_4.zip) contains files with the search pattern for 'sap_export_nwas_java' before files with the search pattern for 'sap_export_solman_java'. So we do no longer exit for the search pattern of the SAP Netweaver Java files (e.g. 51055106.zip). This will work as long as such files do not have content which are matched by any other search pattern.

Tested with:
- `51050829_3` (NW 7.5 Installation Export)
- `51054655_1` (SAP Solution Manager 7.2 SR2 Installation Export I)
- `51054655_2` (SAP Solution Manager 7.2 SR2 Installation Export II)
- `51054655_4` (SAP Solution Manager 7.2 SR2 - Java)
- `51055106`   (SAP Netweaver 7.5 SP22 Java)

```
$ sapfile *.zip
51050829_3.zip:                          sap_export_nwas_abap
51054655_1.zip:                          sap_export_solman_abap
51054655_2.zip:                          sap_export_solman_abap
51054655_4.zip:                          sap_export_solman_java
51055106.zip:                            sap_export_nwas_java
```