### PR TITLE
sap_ha_pacemaker_cluster: Regressions in Dev version for vmware/bare-metal deployments

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -67,7 +67,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_fence_agent_packages: "{{
       (__sap_ha_pacemaker_cluster_fence_agent_packages_minimal_combined
-      + __sap_ha_pacemaker_cluster_fence_agent_packages_platform
+      + __sap_ha_pacemaker_cluster_fence_agent_packages_platform | d([])
       + sap_ha_pacemaker_cluster_fence_agent_packages)
       | unique }}"
   vars:

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -67,7 +67,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_fence_agent_packages: "{{
       (__sap_ha_pacemaker_cluster_fence_agent_packages_minimal_combined
-      + __sap_ha_pacemaker_cluster_fence_agent_packages_platform | d([])
+      + __sap_ha_pacemaker_cluster_fence_agent_packages_platform
       + sap_ha_pacemaker_cluster_fence_agent_packages)
       | unique }}"
   vars:

--- a/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
@@ -57,7 +57,7 @@ __sap_ha_pacemaker_cluster_command:
 
 # Default corosync options - OS specific
 __sap_ha_pacemaker_cluster_corosync_totem_default:
-  options: []
+  options: {}
 
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -93,6 +93,7 @@ __sap_ha_pacemaker_cluster_pcmk_host_map: ''
 # Pre-define internal optional parameters to avoid defaults in the code:
 __sap_ha_pacemaker_cluster_sap_extra_packages: []
 __sap_ha_pacemaker_cluster_platform_extra_packages: []
+__sap_ha_pacemaker_cluster_fence_agent_packages_platform: []
 
 __sap_ha_pacemaker_cluster_cluster_properties: []
 __sap_ha_pacemaker_cluster_resource_defaults:


### PR DESCRIPTION
@marcelmamula @ja9fuchs 
I've found a few regressions in 1.5.0 (or current dev branch) which broke the role when executing on bare metal or vmware systems. I see most changes which caused this are related to cloud systems. This PR  should fix both known errors (another error has been fixed in the current dev branch).