### PR TITLE
sap_swpm, sap_general_preconfigure: feat: add variables for sap_install collection name for calling roles

### DIFF
--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -31,6 +31,9 @@ sap_general_preconfigure_system_roles_collection: 'fedora.linux_system_roles'
 # - fedora.linux_system_roles
 # - redhat.rhel_system_roles
 
+sap_general_preconfigure_sap_install_collection: 'community.sap_install'
+# Set which Ansible Collection to use for the sap_install.
+
 sap_general_preconfigure_enable_repos: false
 # Set to `true` if you want the role to enable the repos as configured by the following repo related parameters.
 # The default is `false`, meaning that the role will not enable repos.

--- a/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2002167/03-setting-the-hostname.yml
@@ -16,7 +16,7 @@
 
 - name: Import role sap_maintain_etc_hosts
   ansible.builtin.import_role:
-    name: 'community.sap_install.sap_maintain_etc_hosts'
+    name: '{{ sap_general_preconfigure_sap_install_collection }}.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_general_preconfigure_ip }}"

--- a/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2772999/03-configure-hostname.yml
@@ -16,7 +16,7 @@
 
 - name: Import role sap_maintain_etc_hosts
   ansible.builtin.import_role:
-    name: 'community.sap_install.sap_maintain_etc_hosts'
+    name: '{{ sap_general_preconfigure_sap_install_collection }}.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_general_preconfigure_ip }}"

--- a/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/3108316/03-configure-hostname.yml
@@ -16,7 +16,7 @@
 
 - name: Import role sap_maintain_etc_hosts
   ansible.builtin.import_role:
-    name: 'community.sap_install.sap_maintain_etc_hosts'
+    name: '{{ sap_general_preconfigure_sap_install_collection }}.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_general_preconfigure_ip }}"

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -449,3 +449,6 @@ sap_swpm_update_etchosts: false
 
 # Display SAP SWPM Unattended Mode output (sapinst stdout)
 sap_swpm_display_unattended_output: false
+
+# Set which Ansible Collection to use for the sap_install.
+sap_swpm_sap_install_collection: 'community.sap_install'

--- a/roles/sap_swpm/tasks/pre_install/update_etchosts.yml
+++ b/roles/sap_swpm/tasks/pre_install/update_etchosts.yml
@@ -12,7 +12,7 @@
 
 - name: SAP SWPM Pre Install - Update '/etc/hosts' for NW
   ansible.builtin.import_role:
-    name: 'community.sap_install.sap_maintain_etc_hosts'
+    name: '{{ sap_swpm_sap_install_collection }}.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ ansible_default_ipv4.address | d(ansible_all_ipv4_addresses[0]) }}"
@@ -46,7 +46,7 @@
 
 - name: SAP SWPM Pre Install - Update '/etc/hosts' for HANA
   ansible.builtin.import_role:
-    name: 'community.sap_install.sap_maintain_etc_hosts'
+    name: '{{ sap_swpm_sap_install_collection }}.sap_maintain_etc_hosts'
   vars:
     sap_maintain_etc_hosts_list:
       - node_ip: "{{ sap_swpm_db_ip }}"


### PR DESCRIPTION
## Description
- Add variables for setting collection name to remove hardcode dependency.
- Affected: `sap_swpm` and `sap_general_preconfigure` for calling `sap_maintain_etc_hosts`

## Validation
Change was tested on SLES4SAP 15 SP6 on AWS with SAP ASCS/ERS HA build. 