### PR TITLE
sap_swpm, sap_general_preconfigure: Fix some leftovers from #925

### DIFF
--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -32,7 +32,7 @@ sap_general_preconfigure_system_roles_collection: 'fedora.linux_system_roles'
 # - redhat.rhel_system_roles
 
 sap_general_preconfigure_sap_install_collection: 'community.sap_install'
-# Set which Ansible Collection to use for the sap_install.
+# Set which Ansible Collection to use when calling sap_install roles.
 
 sap_general_preconfigure_enable_repos: false
 # Set to `true` if you want the role to enable the repos as configured by the following repo related parameters.

--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -75,6 +75,12 @@ argument_specs:
         required: false
         type: str
 
+      sap_general_preconfigure_sap_install_collection:
+        default: 'community.sap_install'
+        description: Set which Ansible Collection to use when calling sap_install roles.
+        required: false
+        type: str
+
       sap_general_preconfigure_enable_repos:
         default: false
         description:

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -450,5 +450,5 @@ sap_swpm_update_etchosts: false
 # Display SAP SWPM Unattended Mode output (sapinst stdout)
 sap_swpm_display_unattended_output: false
 
-# Set which Ansible Collection to use for the sap_install.
+# Set which Ansible Collection to use when calling sap_install roles.
 sap_swpm_sap_install_collection: 'community.sap_install'


### PR DESCRIPTION
I added the missing entry in `sap_general_preconfigure/meta/argument_specs.yml` and slightly modified the variable description.