### PR TITLE
sap_ha_pacemaker_cluster/SUSE: Rework SAPHanaSR-angi pre-steps and add SLES 16 vars

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -883,7 +883,8 @@ sap_ha_pacemaker_cluster_resource_defaults:
 - _Type:_ `string`<br>
 - _Default:_ `True`<br>
 
-Disabling this variable enables to use Classic SAPHanaSR agents even on server, with SAPHanaSR-angi is available.<br>
+Disabling this variable enables to use Classic SAPHanaSR agents even on server, where SAPHanaSR-angi is available.<br>
+Value `false` (Classic) is ignored when only SAPHanaSR-angi packages are available.<br>
 
 ### sap_ha_pacemaker_cluster_sbd_devices
 - _Type:_ `list`<br>

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -558,7 +558,8 @@ argument_specs:
         default: true
         description:
           - Disabling this variable enables to use Classic SAPHanaSR agents even on server,
-            with SAPHanaSR-angi is available.
+            where SAPHanaSR-angi is available.
+          - Value `false` (Classic) is ignored when only SAPHanaSR-angi packages are available.
 
       ##########################################################################
       # NetWeaver specific parameters

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
@@ -6,7 +6,8 @@
 # This is destructive step if executed on running cluster
 # without proper migration from SAPHanaSR to SAPHanaSR-angi!
 
-- name: "SAP HA Prepare Pacemaker - Block for detection of SAPHanaSR-angi"
+
+- name: "SAP HA Prepare Pacemaker - Block for preparation of SAPHanaSR-angi HANA cluster"
   when: (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
   block:
     # Requirement for package_facts Ansible Module
@@ -27,6 +28,8 @@
       register: __sap_ha_pacemaker_cluster_zypper_angi_check
       failed_when: false
 
+
+    # Uninstall SAPHanaSR package on SLES 15
     # package can be replaced with "rpm -e --nodeps {{ item }}"
     - name: "SAP HA Prepare Pacemaker - Remove SAPHanaSR and SAPHanaSR-doc"
       ansible.builtin.package:
@@ -39,6 +42,8 @@
         - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
         - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
         - "'SAPHanaSR' in ansible_facts.packages"
+        # SAPHanaSR (Classic) is not available on SLES 16
+        - ansible_distribution_major_version | int < 16
 
     - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
       ansible.builtin.set_fact:
@@ -46,3 +51,43 @@
       when:
         - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
         - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
+
+
+- name: "SAP HA Prepare Pacemaker - Block for preparation of Classic HANA cluster"
+  when:
+    - not (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
+    # SAPHanaSR (Classic) is not available on SLES 16
+    - ansible_distribution_major_version | int < 16
+  block:
+    # Requirement for package_facts Ansible Module
+    # SLES: Ensure OS Package for Python Lib of rpm bindings is enabled for System Python
+    - name: "SAP HA Prepare Pacemaker - Ensure python3-rpm package is present"
+      ansible.builtin.package:
+        name: python3-rpm
+        state: present
+
+    - name: "SAP HA Prepare Pacemaker - Gather installed packages facts"
+      ansible.builtin.package_facts:
+        manager: auto
+
+    # package can be replaced with "rpm -e --nodeps {{ item }}"
+    - name: "SAP HA Prepare Pacemaker - Remove SAPHanaSR-angi"
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - SAPHanaSR-angi
+      when:
+        - "'SAPHanaSR-angi' in ansible_facts.packages"
+
+    - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_saphanasr_angi_available: false
+
+
+# Ensure that angi flag is always set for SLES 16
+- name: "SAP HA Prepare Pacemaker - Ensure angi_available is set for SLES 16"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
+  when:
+    - ansible_distribution_major_version | int > 15

--- a/roles/sap_ha_pacemaker_cluster/vars/SLES_16.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/SLES_16.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Variables specific to following versions:
+# - SUSE Linux Enterprise Server for SAP Applications 16
+# - SUSE Linux Enterprise Server 16
+
+# Dictionary with additional cluster packages for specific scenarios
+__sap_ha_pacemaker_cluster_sap_extra_packages_dict:
+  minimal: []  # All minimal packages are part of patterns
+  hana_scaleout:
+    - patterns-sap-HADB
+  hana_scaleup:
+    - patterns-sap-HADB
+  hana_angi: []  # SAPHanaSR-angi package is part of patterns-sap-HADB
+  nwas:
+    - patterns-sap-HAAPP
+
+# Package list was simplified because of new patterns below:
+
+# patterns-sap-HADB contains:
+# - patterns-sles_sap_DB
+# - patterns-ha-ha_sles
+# - SAPHanaSR-angi
+# - ClusterTools2
+# - supportutils-plugin-ha-sap
+# - socat
+
+# patterns-sap-HAAPP contains:
+# - patterns-sles_sap_APP
+# - patterns-ha-ha_sles
+# - sapstartsrv-resource-agents
+# - sap-suse-cluster-connector
+# - ClusterTools2
+# - supportutils-plugin-ha-sap
+# - socat

--- a/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
@@ -50,20 +50,9 @@ __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
     - socat
 
 # Dictionary with additional cluster packages for specific scenarios
+# All packages are defined in SLES_15 and SLES_16 var files.
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
-  minimal:
-    # Pattern contains all required cluster packages
-    - patterns-ha-ha_sles
-    - ClusterTools2
-  hana_scaleout:
-    - SAPHanaSR-ScaleOut
-  hana_scaleup:
-    - SAPHanaSR
-  hana_angi:
-    - SAPHanaSR-angi
-  nwas:
-    - sap-suse-cluster-connector
-    - sapstartsrv-resource-agents
+  {}
 
 # Dictionary with preferred platform specific VIP method that differs from default
 __sap_ha_pacemaker_cluster_vip_method_dict:


### PR DESCRIPTION
## Description
- `pre_steps_hana.yml` was updated with new logic to:
  - Angi: Uninstall `SAPHanaSR` only on SLES 15
  - Classic: Uninstall `SAPHanaSR-angi` only on SLES 15
 - `SLES_16` variables with updated packages

## Test results
Successfully tested on SLES4SAP 15 SP6 on AWS with SAP HANA HA scenario:
- Angi setup was followed by Classic to test if package uninstall works, then Angi again