### PR TITLE
sap_ha_pacemaker_cluster: enable Simple Mount on RHEL

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Identify the version of the resource agents and disable
+# the use of "SimpleMount" if a minimum version is not satisfied.
+
+- name: "SAP HA Prepare Pacemaker - Block for detection of 'SAPStartSrv' availability"
+  block:
+
+    - name: "SAP HA Prepare Pacemaker - Check the resource agents package"
+      ansible.builtin.shell:
+        set -o pipefail && \
+          dnf info resource-agents-sap | awk '/^Version/ {print $3}' | sort | tail -n1
+      register: __sap_ha_pacemaker_cluster_sapstartsrv_check
+      changed_when: false
+      failed_when: false
+
+    - name: "SAP HA Prepare Pacemaker - Disable Simple Mount when min. package version is not available"
+      ansible.builtin.set_fact:
+        sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: false
+      when:
+        - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
+        - __sap_ha_pacemaker_cluster_sapstartsrv_check.stdout is defined
+        - "(__sap_ha_pacemaker_cluster_sapstartsrv_check.stdout) is version(__sap_ha_pacemaker_cluster_nwas_simple_mount_version, '<')"

--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
@@ -16,7 +16,7 @@
 
     - name: "SAP HA Prepare Pacemaker - Disable Simple Mount when min. package version is not available"
       ansible.builtin.set_fact:
-        sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: false
+        __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: false
       when:
         - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
         - __sap_ha_pacemaker_cluster_sapstartsrv_check.stdout is defined

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
@@ -13,6 +13,12 @@
   when:
     - "(role_path + '/vars/' + include_item + '.yml') is file"
 
+- name: "SAP HA Prepare Pacemaker - Run NETWEAVER pre-steps"
+  ansible.builtin.include_tasks:
+    file: "{{ ansible_facts['os_family'] }}/pre_steps_nwas_ascs_ers.yml"
+  when:
+    - ansible_os_family == 'RedHat'
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
 
 # Private variables are assigned following logic:
 # 1. Use backwards compatible var if new var is empty

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_nwas.yml
@@ -13,13 +13,6 @@
   when:
     - "(role_path + '/vars/' + include_item + '.yml') is file"
 
-- name: "SAP HA Prepare Pacemaker - Run NETWEAVER pre-steps"
-  ansible.builtin.include_tasks:
-    file: "{{ ansible_facts['os_family'] }}/pre_steps_nwas_ascs_ers.yml"
-  when:
-    - ansible_os_family == 'RedHat'
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
-
 # Private variables are assigned following logic:
 # 1. Use backwards compatible var if new var is empty
 # 2. Use user input if new var is not empty
@@ -397,3 +390,13 @@
     # TODO: Remove backwards compatibility to typo
     __sap_ha_pacemaker_cluster_storage_nfs_filesystem_type:
       "{{ sap_ha_pacemaker_cluster_storage_nfs_filesytem_type | d(sap_ha_pacemaker_cluster_storage_nfs_filesystem_type) }}"
+
+# This must be run after the  assignment of
+# __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+# TODO: separate pre-steps from variable includes for NW and HANA
+- name: "SAP HA Prepare Pacemaker - Run NETWEAVER pre-steps"
+  ansible.builtin.include_tasks:
+    file: "{{ ansible_facts['os_family'] }}/pre_steps_nwas_ascs_ers.yml"
+  when:
+    - ansible_os_family == 'RedHat'
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0

--- a/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
@@ -158,4 +158,5 @@ sap_ha_pacemaker_cluster_hana_hook_chksrv: true
 
 # Central Services Cluster Simple Mount: Enabled as default
 # TODO: Enable when SAPStartSrv resource agents are available on Red Hat
-sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: false
+sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount: true
+__sap_ha_pacemaker_cluster_nwas_simple_mount_version: 4.15.1


### PR DESCRIPTION
### New for RHEL
- Simple-Mount is enabled by default
- Netweaver pre-steps check the resource agents package version and disable Simple-Mount if the defined minimum version is not available

Tested with different package versions available.
The pre-step check overrules custom vars.
