### PR TITLE
sap_general_preconfigure: Fix check mode

### DIFF
--- a/roles/sap_general_preconfigure/tasks/sapnote/2369910.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2369910.yml
@@ -14,6 +14,8 @@
     - sap_general_preconfigure_configure_locale
   block:
     - name: Configure an English locale
+      ansible.builtin.command: "localectl set-locale LANG={{ sap_general_preconfigure_default_locale }}"
+      changed_when: true
       when:
         - sap_general_preconfigure_default_locale is defined and sap_general_preconfigure_default_locale
         - sap_general_preconfigure_default_locale == 'C.UTF-8' or
@@ -21,13 +23,12 @@
           sap_general_preconfigure_default_locale.startswith('en_') and
             (sap_general_preconfigure_default_locale.endswith('UTF-8') or
              sap_general_preconfigure_default_locale.endswith('utf8'))
-      ansible.builtin.command: "localectl set-locale LANG={{ sap_general_preconfigure_default_locale }}"
-      changed_when: true
 
     - name: Get the current default locale
       ansible.builtin.command: awk '{gsub("\"","")}/^LANG=/&&(/=C\./||/=en_/)&&(/utf8$/||/UTF-8$/){print}' /etc/locale.conf
-      changed_when: false
+      check_mode: false
       register: __sap_general_preconfigure_current_default_locale
+      changed_when: false
 
     - name: Assert that an English locale is the default
       ansible.builtin.assert:

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -297,7 +297,7 @@
 
 # Save all the constructed cluster parameters into a vars file.
 #
-# This will help re-using ha_cluster afterwards without losing the already
+# This will help reusing ha_cluster afterwards without losing the already
 # configured resources and constraints.
 # The ha_cluster role will otherwise remove configuration that is not part
 # of the parameters provided during any subsequent run outside of the current


### PR DESCRIPTION
Fixes issue #934.

Note: I also moved the `when:` lines to the end of the task `Configure an English locale` to match our current standard. For `Get the current default locale`, I moved changed_when to the end because that appears to be our default as well.