### PR TITLE
sap_general_preconfigure: No longer install locale packages in RHEL 7

### DIFF
--- a/roles/sap_general_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_7.yml
@@ -94,9 +94,6 @@ __sap_general_preconfigure_packages_x86_64:
   - compat-sap-c++-7
   - compat-sap-c++-9
   - compat-sap-c++-10
-# English locale packages are required as per SAP note 2369910:
-  - langpacks-en
-  - glibc-langpack-en
 
 __sap_general_preconfigure_packages_ppc64le:
   - uuidd
@@ -107,26 +104,17 @@ __sap_general_preconfigure_packages_ppc64le:
   - compat-sap-c++-7
   - compat-sap-c++-9
   - compat-sap-c++-10
-# English locale packages are required as per SAP note 2369910:
-  - langpacks-en
-  - glibc-langpack-en
 
 __sap_general_preconfigure_packages_ppc64:
   - uuidd
   - tcsh
   - psmisc
   - compat-sap-c++-5
-# English locale packages are required as per SAP note 2369910:
-  - langpacks-en
-  - glibc-langpack-en
 
 __sap_general_preconfigure_packages_s390x:
   - uuidd
   - tcsh
   - psmisc
-# English locale packages are required as per SAP note 2369910:
-  - langpacks-en
-  - glibc-langpack-en
 
 __sap_general_preconfigure_packages: "{{ lookup('vars', '__sap_general_preconfigure_packages_' + ansible_architecture) }}"
 


### PR DESCRIPTION
I am not aware of any issues related to missing English locales on RHEL 7, so we can safely assume that a RHEL 7 system will have all necessary English locale packages installed as part of installing the mandatory software environment group.