### PR TITLE
sap_netweaver_preconfigure: fix argument_specs validation error

### DIFF
--- a/roles/sap_netweaver_preconfigure/README.md
+++ b/roles/sap_netweaver_preconfigure/README.md
@@ -115,6 +115,13 @@ In assertion mode, the role will abort when encountering any assertion error.<br
 If this parameter is set to `false`, the role will *not* abort when encountering an assertion error.<br>
 This is useful if the role is used for reporting a system's SAP notes compliance.<br>
 
+### sap_netweaver_preconfigure_packages
+- _Type:_ `list` with elements of type `str`
+- _Default:_ (set by platform/environment specific variables)
+
+The list of packages to be installed for SAP NETWEAVER.<br>
+The default for this variable is set in the vars file which corresponds to the detected OS version.<br>
+
 ### sap_netweaver_preconfigure_min_swap_space_mb
 - _Type:_ `str`
 - _Default:_ `20480`

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -8,15 +8,6 @@ argument_specs:
     short_description: Variables for SAP NetWeaver preconfiguration
     options:
 
-      sap_netweaver_preconfigure_packages:
-        default: "{{ __sap_netweaver_preconfigure_packages }}"
-        description:
-          - The list of packages to be installed for SAP NETWEAVER.
-          - The default for this variable is set in the vars file which corresponds to the detected OS version.
-        required: false
-        type: list
-        elements: str
-
       sap_netweaver_preconfigure_config_all:
         default: true
         description:
@@ -56,6 +47,15 @@ argument_specs:
           - This is useful if the role is used for reporting a system's SAP notes compliance.
         required: false
         type: bool
+
+      sap_netweaver_preconfigure_packages:
+        default: "{{ __sap_netweaver_preconfigure_packages }}"
+        description:
+          - The list of packages to be installed for SAP NETWEAVER.
+          - The default for this variable is set in the vars file which corresponds to the detected OS version.
+        required: false
+        type: list
+        elements: str
 
       sap_netweaver_preconfigure_min_swap_space_mb:
         default: '20480'

--- a/roles/sap_netweaver_preconfigure/vars/main.yml
+++ b/roles/sap_netweaver_preconfigure/vars/main.yml
@@ -4,3 +4,6 @@
 # define variables here that will not change
 # Those are valid for all OS
 #
+
+# dummy entry for passing the arg spec validation:
+__sap_netweaver_preconfigure_packages: []


### PR DESCRIPTION
Solves #939.

Also moved sap_netweaver_preconfigure_packages to a similar place as in the other preconfigure roles and added this variable to README.md