### PR TITLE
sap_ha_pacemaker_cluster: fix package detection on RHEL

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_hana.yml
@@ -16,7 +16,9 @@
         cmd: dnf provides sap-hana-ha
       changed_when: false
       register: __sap_ha_pacemaker_cluster_saphanasr_angi_check
-      failed_when: false
+      failed_when:
+        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc != 0
+        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc != 1
 
       # The provision role should not fix packages if run against systems that
       # were previously installed with the conflicting packages. System state is
@@ -42,6 +44,9 @@
           Alternatively: Disable the package detection
           (sap_ha_pacemaker_cluster_saphanasr_angi_detection = false)
           to continue the setup using the installed resource agents.
+      when:
+        - __sap_ha_pacemaker_cluster_saphanasr_angi_check is defined
+        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc == 0
 
     - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
       ansible.builtin.set_fact:


### PR DESCRIPTION
The task return code was incorrect due to disabling `failed_when` entirely.
The new conditions should fix that.