### PR TITLE
sap_general_preconfigure: fix var role prefix

### DIFF
--- a/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
@@ -29,4 +29,4 @@ __sap_general_preconfigure_envgroups:
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.
-__sap_hana_preconfigure_use_saptune: true
+__sap_general_preconfigure_use_saptune: true


### PR DESCRIPTION
ansible-lint complained about this:

```
var-naming[no-role-prefix]: Variables names from within roles should use sap_general_preconfigure_ as a prefix. (vars: __sap_hana_preconfigure_use_saptune)
roles/sap_general_preconfigure/vars/SLES_SAP_16.yml:32
```