### PR TITLE
sap_*_preconfigure/Suse: Switch saptune from present to latest

### DIFF
--- a/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_install.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_install.yml
@@ -20,10 +20,11 @@
 - name: Block to ensure saptune is installed
   when: __sap_general_preconfigure_use_saptune | d(true)
   block:
-    - name: Ensure latest saptune is installed
+    # Reason for noqa: Zypper supports "state: latest"
+    - name: Ensure latest saptune is installed  # noqa package-latest
       ansible.builtin.package:
         name: saptune
-        state: present
+        state: latest
       when:
         - sap_general_preconfigure_saptune_version is undefined
          or sap_general_preconfigure_saptune_version | length == 0

--- a/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_install.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_install.yml
@@ -20,7 +20,8 @@
 - name: Block to ensure saptune is installed
   when: __sap_hana_preconfigure_use_saptune | d(true)
   block:
-    - name: Ensure latest saptune is installed
+    # Reason for noqa: Zypper supports "state: latest"
+    - name: Ensure latest saptune is installed  # noqa package-latest
       ansible.builtin.package:
         name: saptune
         state: present

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_install.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_install.yml
@@ -20,7 +20,8 @@
 - name: Block to ensure saptune is installed
   when: __sap_netweaver_preconfigure_use_saptune | d(true)
   block:
-    - name: Ensure latest saptune is installed
+    # Reason for noqa: Zypper supports "state: latest"
+    - name: Ensure latest saptune is installed  # noqa package-latest
       ansible.builtin.package:
         name: saptune
         state: present


### PR DESCRIPTION
## Description
Some older images contain older saptune version `3.1.2` which will not be upgraded to latest with `present` state.

This change is ensuring actual latest package version is installed, which then helps with subsequent verification steps (example: kernel.pid_max works different on `3.1.2` versus `3.1.4`)

## Tested
Validated on SLES4SAP 15 SP6 on AWS:
- PAYG with saptune `3.1.2`
- BYOS with saptune `3.1.4`