### PR TITLE
sap_ha_pacemaker_cluster: fix ASCS constraint

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers.yml
@@ -304,8 +304,10 @@
   when:
     - __constraint_colo_ers.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
 
-# Optional: ASCS should be started before ERS
-- name: "SAP HA Prepare Pacemaker - Add order constraint: first start ASCS group, then ERS group"
+# Order: ERS should be stopped after ASCS started.
+# After a failover, ASCS must start and read replication data from ERS, before ERS should be stopped
+# to fail over to the other node following the colocation constraint.
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start ASCS group, then stop ERS group"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
   vars:
@@ -313,16 +315,15 @@
       id: "{{ __sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
       resource_first:
         id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
-        role: started
+        action: start
       resource_then:
         id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        action: stop
       options:
         - name: symmetrical
           value: "false"
         - name: kind
           value: Optional
-#  when:
-#    - __constraint_order_ascs_ers.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))
 
 # ENSA1 only: location rule for ASCS to follow ERS
 - name: "SAP HA Prepare Pacemaker - Add location constraint: ASCS follows ERS in ENSA1 setup"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
@@ -189,8 +189,10 @@
   when:
     - __constraint_colo_ers.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))
 
-# Optional: ASCS should be started before ERS
-- name: "SAP HA Prepare Pacemaker - Add order constraint: first start ASCS group, then ERS group"
+# Order: ERS should be stopped after ASCS started.
+# After a failover, ASCS must start and read replication data from ERS, before ERS should be stopped
+# to fail over to the other node following the colocation constraint.
+- name: "SAP HA Prepare Pacemaker - Add order constraint: first start ASCS group, then stop ERS group"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order + [__constraint_order_ascs_ers] }}"
   vars:
@@ -198,13 +200,12 @@
       id: "{{ __sap_ha_pacemaker_cluster_nwas_order_ascs_first_name }}"
       resource_first:
         id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
-        role: started
+        action: start
       resource_then:
         id: "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
+        action: stop
       options:
         - name: symmetrical
           value: "false"
         - name: kind
           value: Optional
-  when:
-    - __constraint_order_ascs_ers.resource_then not in (__sap_ha_pacemaker_cluster_constraints_order | map(attribute='resource_then'))


### PR DESCRIPTION
Start order when ASCS and ERS are both down does not matter. 
However, After an ASCS failover, ERS should stay until ASCS has been started. ASCS needs to read enqueue data from ERS at start.

The "start order" conditional was incorrect by mistake.

RHEL and SLES documentations contain the order constraint as "start ASCS, then stop ERS".

_Tested on RHEL with "Simple Mount" setup._