### PR TITLE
sap_ha_pacemaker_cluster: fix ASCS/ERS systemd

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/ascertain_sap_landscape.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/ascertain_sap_landscape.yml
@@ -39,7 +39,10 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 - name: "SAP HA Prepare Pacemaker - Include NETWEAVER specific variables"
+  tags: nwas_postinst
   ansible.builtin.include_tasks:
     file: include_vars_nwas.yml
+    apply:
+      tags: nwas_postinst
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -26,24 +26,6 @@
   retries: 30
   delay: 10
 
-# Comment out lines in /usr/sap/sapservices, which
-# - contain the target instance profile names
-# - are not commented out yet
-# TODO: This is not matching systemd services. To be clarified if needed.
-- name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
-  ansible.builtin.replace:
-    path: /usr/sap/sapservices
-    backup: true
-    regexp: '^([^#\n].+{{ sapserv_item }}.+)$'
-    replace: '# \1'
-  loop:
-    - "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
-    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
-  loop_control:
-    loop_var: sapserv_item
-  when:
-    - ansible_os_family == 'RedHat'
-
 - name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
   ansible.builtin.stat:
     path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ systemd_item }}.service"
@@ -137,6 +119,23 @@
         loop_var: dropfile_item
 
 ### END of BLOCK for systemd setup.
+
+# Comment out lines in /usr/sap/sapservices, which
+# - contain the target instance profile names
+# - are not commented out yet
+- name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
+  ansible.builtin.replace:
+    path: /usr/sap/sapservices
+    backup: true
+    regexp: '^(?!#)(.*{{ sapserv_item }}.*)$'
+    replace: '# \1'
+  loop:
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+  loop_control:
+    loop_var: sapserv_item
+  when:
+    - ansible_os_family == 'RedHat'
 
 # SAPStartSrv resource agent / Simple Mount
 - name: "SAP HA Pacemaker - Make sure SAPStartSrv systemd units are enabled"

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -29,6 +29,7 @@
 # Comment out lines in /usr/sap/sapservices, which
 # - contain the target instance profile names
 # - are not commented out yet
+# TODO: This is not matching systemd services. To be clarified if needed.
 - name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
   ansible.builtin.replace:
     path: /usr/sap/sapservices
@@ -40,6 +41,8 @@
     - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
   loop_control:
     loop_var: sapserv_item
+  when:
+    - ansible_os_family == 'RedHat'
 
 - name: "SAP HA Pacemaker - (systemd) Check for ASCS/ERS services"
   ansible.builtin.stat:
@@ -54,27 +57,55 @@
 
 - name: "SAP HA Pacemaker - (systemd) Save found ASCS/ERS services"
   ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_instance_services_fact: "{{
+    sap_ha_pacemaker_cluster_instance_service_node_fact: "{{
       __sap_ha_pacemaker_cluster_register_instance_service.results
       | selectattr('stat.exists')
       | map(attribute='stat.path')
       | regex_replace('/etc/systemd/system/', '')
       }}"
 
+- name: "SAP HA Pacemaker - (systemd) Combine instance services from all nodes"
+  ansible.builtin.set_fact:
+    sap_ha_pacemaker_cluster_instance_service_all_fact: "{{
+      (sap_ha_pacemaker_cluster_instance_service_all_fact | d([])
+      + hostvars[task_host_item].sap_ha_pacemaker_cluster_instance_service_node_fact)
+      | unique
+      }}"
+  loop: "{{ ansible_play_hosts }}"
+  loop_control:
+    loop_var: task_host_item
+
+
 # BLOCK:
-# When the systemd based SAP startup framework is used, make sure that the
+# 1. When the systemd based SAP startup framework is used, make sure that the
 # instance services do not auto-start.
-- name: "SAP HA Pacemaker - Block to disable systemd auto-start of instances"
+# 2. Make sure that the SAP instance service units are registered and present on all hosts.
+- name: "SAP HA Pacemaker - Block to handle SAP service systemd configuration"
   when:
-    - sap_ha_pacemaker_cluster_instance_services_fact is defined
-    - sap_ha_pacemaker_cluster_instance_services_fact | length > 0
+    # At least one systemd service should be found per node, to consider the setup
+    # "systemd enabled" and proceed with the related configuration.
+    - sap_ha_pacemaker_cluster_instance_service_node_fact is defined
+    - sap_ha_pacemaker_cluster_instance_service_node_fact | length > 0
   block:
+
+    # After the installation, the systemd units are only configured on the node
+    # they were first installed on.
+    # The registration ensures that
+    # - systemd units for both instances are configured
+    # - the 'sapstartsrv' file contains both start commands
+    - name: "SAP HA Pacemaker - (systemd) Register ASCS/ERS instances on all nodes"
+      ansible.builtin.shell: |
+        export LD_LIBRARY_PATH=/usr/sap/hostctrl/exe:$LD_LIBRARY_PATH
+        /usr/sap/hostctrl/exe/sapstartsrv pf={{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string }} -reg
+        /usr/sap/hostctrl/exe/sapstartsrv pf={{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }} -reg
+      register: __sap_ha_pacemaker_cluster_register_instance_reg
+      changed_when: true
 
     - name: "SAP HA Pacemaker - (systemd) Disable ASCS/ERS instance service"
       ansible.builtin.service:
         name: "{{ instance_srv_item }}"
         enabled: false
-      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: instance_srv_item
 
@@ -88,7 +119,7 @@
         owner: root
         group: root
         mode: '0644'
-      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: dropfile_item
 
@@ -101,11 +132,24 @@
         owner: root
         group: root
         mode: '0644'
-      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: dropfile_item
 
 ### END of BLOCK for systemd setup.
+
+# SAPStartSrv resource agent / Simple Mount
+- name: "SAP HA Pacemaker - Make sure SAPStartSrv systemd units are enabled"
+  ansible.builtin.service:
+    name: "{{ sapstartsrv_srv_item }}"
+    enabled: true
+  loop:
+    - sapping
+    - sappong
+  loop_control:
+    loop_var: sapstartsrv_srv_item
+  when:
+    - __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 
 # Block for configuring the SAP HA Interface (sap_cluster_connector).

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -26,21 +26,6 @@
   retries: 30
   delay: 10
 
-# Comment out lines in /usr/sap/sapservices, which
-# - contain the target instance profile names
-# - are not commented out yet
-- name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
-  ansible.builtin.replace:
-    path: /usr/sap/sapservices
-    backup: true
-    regexp: '^([^#\n].+{{ sapserv_item }}.+)$'
-    replace: '# \1'
-  loop:
-    - "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
-    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
-  loop_control:
-    loop_var: sapserv_item
-
 - name: "SAP HA Pacemaker - (systemd) Check for SCS/ERS services"
   ansible.builtin.stat:
     path: "/etc/systemd/system/SAP{{ __sap_ha_pacemaker_cluster_nwas_sid }}_{{ systemd_item }}.service"
@@ -54,27 +39,55 @@
 
 - name: "SAP HA Pacemaker - (systemd) Save found SCS/ERS services"
   ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_instance_services_fact: "{{
+    sap_ha_pacemaker_cluster_instance_service_node_fact: "{{
       __sap_ha_pacemaker_cluster_register_instance_service.results
       | selectattr('stat.exists')
       | map(attribute='stat.path')
       | regex_replace('/etc/systemd/system/', '')
       }}"
 
+- name: "SAP HA Pacemaker - (systemd) Combine instance services from all nodes"
+  ansible.builtin.set_fact:
+    sap_ha_pacemaker_cluster_instance_service_all_fact: "{{
+      (sap_ha_pacemaker_cluster_instance_service_all_fact | d([])
+      + hostvars[task_host_item].sap_ha_pacemaker_cluster_instance_service_node_fact)
+      | unique
+      }}"
+  loop: "{{ ansible_play_hosts }}"
+  loop_control:
+    loop_var: task_host_item
+
+
 # BLOCK:
-# When the systemd based SAP startup framework is used, make sure that the
+# 1. When the systemd based SAP startup framework is used, make sure that the
 # instance services do not auto-start.
-- name: "SAP HA Pacemaker - Block to disable systemd auto-start of instances"
+# 2. Make sure that the SAP instance service units are registered and present on all hosts.
+- name: "SAP HA Pacemaker - Block to handle SAP service systemd configuration"
   when:
-    - sap_ha_pacemaker_cluster_instance_services_fact is defined
-    - sap_ha_pacemaker_cluster_instance_services_fact | length > 0
+    # At least one systemd service should be found per node, to consider the setup
+    # "systemd enabled" and proceed with the related configuration.
+    - sap_ha_pacemaker_cluster_instance_service_node_fact is defined
+    - sap_ha_pacemaker_cluster_instance_service_node_fact | length > 0
   block:
+
+    # After the installation, the systemd units are only configured on the node
+    # they were first installed on.
+    # The registration ensures that
+    # - systemd units for both instances are configured
+    # - the 'sapstartsrv' file contains both start commands
+    - name: "SAP HA Pacemaker - (systemd) Register SCS/ERS instances on all nodes"
+      ansible.builtin.shell: |
+        export LD_LIBRARY_PATH=/usr/sap/hostctrl/exe:$LD_LIBRARY_PATH
+        /usr/sap/hostctrl/exe/sapstartsrv pf={{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string }} -reg
+        /usr/sap/hostctrl/exe/sapstartsrv pf={{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string }} -reg
+      register: __sap_ha_pacemaker_cluster_register_instance_reg
+      changed_when: true
 
     - name: "SAP HA Pacemaker - (systemd) Disable SCS/ERS instance service"
       ansible.builtin.service:
         name: "{{ instance_srv_item }}"
         enabled: false
-      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: instance_srv_item
 
@@ -88,7 +101,7 @@
         owner: root
         group: root
         mode: '0644'
-      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: dropfile_item
 
@@ -101,11 +114,41 @@
         owner: root
         group: root
         mode: '0644'
-      loop: "{{ sap_ha_pacemaker_cluster_instance_services_fact }}"
+      loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: dropfile_item
 
 ### END of BLOCK for systemd setup.
+
+# Comment out lines in /usr/sap/sapservices, which
+# - contain the target instance profile names
+# - are not commented out yet
+- name: "SAP HA Pacemaker - Update /usr/sap/sapservices"
+  ansible.builtin.replace:
+    path: /usr/sap/sapservices
+    backup: true
+    regexp: '^(?!#)(.*{{ sapserv_item }}.*)$'
+    replace: '# \1'
+  loop:
+    - "{{ __sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name }}"
+    - "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name }}"
+  loop_control:
+    loop_var: sapserv_item
+  when:
+    - ansible_os_family == 'RedHat'
+
+# SAPStartSrv resource agent / Simple Mount
+- name: "SAP HA Pacemaker - Make sure SAPStartSrv systemd units are enabled"
+  ansible.builtin.service:
+    name: "{{ sapstartsrv_srv_item }}"
+    enabled: true
+  loop:
+    - sapping
+    - sappong
+  loop_control:
+    loop_var: sapstartsrv_srv_item
+  when:
+    - __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
 
 
 # Block for configuring the SAP HA Interface (sap_cluster_connector).

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -21,13 +21,16 @@
 # supports.
 - name: "SAP HA Prepare Pacemaker - Include tasks from 'ha_cluster' role definitions"
   ansible.builtin.import_tasks: import_hacluster_vars_from_inventory.yml
+  tags: always
 
 - name: "SAP HA Prepare Pacemaker - Include facts and common variables"
   ansible.builtin.import_tasks: include_vars_common.yml
+  tags: always
 
 # Determine which SAP landscape we are going to configure in the cluster.
 - name: "SAP HA Prepare Pacemaker - Include tasks for SAP landscape calculation"
   ansible.builtin.import_tasks: ascertain_sap_landscape.yml
+  tags: always
 
 # Validate input variables after processing in include_vars_ tasks.
 - name: "SAP HA Prepare Pacemaker - Include parameter validation tasks"


### PR DESCRIPTION
Fixes issues #961 and #962.

1. When using the systemd start framework for SAP instances, the instance services must be registered on all nodes they are going to run on. This creates the systemd units consistently.

2. When using the SAPStartSrv resource, the related systemd units 'sapping' and 'sappong' must be enabled.

+ For convenience: tags added to enable role execution just for the NWAS post-installation tasks.

_Tested on RHEL_