### PR TITLE
sap_ha_pacemaker_cluster: several bug fixes

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
@@ -20,4 +20,5 @@
       when:
         - sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount | bool
         - __sap_ha_pacemaker_cluster_sapstartsrv_check.stdout is defined
+        - __sap_ha_pacemaker_cluster_sapstartsrv_check.stdout | length > 0
         - "(__sap_ha_pacemaker_cluster_sapstartsrv_check.stdout) is version(__sap_ha_pacemaker_cluster_nwas_simple_mount_version, '<')"

--- a/roles/sap_ha_pacemaker_cluster/tasks/ascertain_sap_landscape.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/ascertain_sap_landscape.yml
@@ -32,6 +32,20 @@
   when:
     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
 
+# Host type rules:
+# - there can only be 0 or 1 HANA type in the list
+# - there can only be 0 or 1 NW (A)SCS/ERS type in the list
+- name: "SAP HA Prepare Pacemaker - Make sure that the host_type combination is valid"
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length < 2
+      - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_.*_ers') | length < 2
+    fail_msg: |
+      Host type = {{ sap_ha_pacemaker_cluster_host_type }}
+
+      Conflicting host types found!
+      There can only be max. 1 HANA and/or 1 NWAS (A)SCS/ERS type in the same definition.
+
 - name: "SAP HA Prepare Pacemaker - Include HANA specific variables"
   ansible.builtin.include_tasks:
     file: include_vars_hana.yml

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -109,6 +109,9 @@
       loop_control:
         loop_var: stonith_host_item
         label: "{{ stonith_host_item }}"
+      when:
+        - (hostvars[stonith_host_item].__sap_ha_pacemaker_cluster_stonith_default).id
+          not in (__sap_ha_pacemaker_cluster_stonith_resource | d([])| map(attribute='id'))
 
     # The location constraints are needed, when the fence resource is configured
     # per host and must not run on the host it targets.

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
@@ -188,17 +188,17 @@
       {%- endif -%}
 
     ## When in a group, increase the default base score by adding 1000 per resource in the group.
-    __colo_score: >-
+    __colo_score: |-
+      {% set score = namespace(value=sap_ha_pacemaker_cluster_constraint_colo_base_score) %}
       {% if __sap_ha_pacemaker_cluster_resource_groups | length > 0 -%}
         {% for group in __sap_ha_pacemaker_cluster_resource_groups -%}
           {% if group.id == (sap_ha_pacemaker_cluster_vip_group_prefix
             + __sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name) -%}
-            {{ (group.resource_ids | length * 1000) + sap_ha_pacemaker_cluster_constraint_colo_base_score }}
+            {% set score.value = (group.resource_ids | length * 1000) + sap_ha_pacemaker_cluster_constraint_colo_base_score %}
           {%- endif %}
         {%- endfor %}
-      {%- else -%}
-        {{ sap_ha_pacemaker_cluster_constraint_colo_base_score }}
       {%- endif %}
+      {{ score.value }}
 
   when:
     - __constraint_colo_vip.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_constraints_hana.yml
@@ -128,17 +128,17 @@
       {%- endif -%}
 
     ## When in a group, increase the default base score by adding 1000 per resource in the group.
-    __colo_score: >-
+    __colo_score: |-
+      {% set score = namespace(value=sap_ha_pacemaker_cluster_constraint_colo_base_score) %}
       {% if __sap_ha_pacemaker_cluster_resource_groups | length > 0 -%}
         {% for group in __sap_ha_pacemaker_cluster_resource_groups -%}
           {% if group.id == (sap_ha_pacemaker_cluster_vip_group_prefix
             + __sap_ha_pacemaker_cluster_vip_hana_primary_resource_name) -%}
-            {{ (group.resource_ids | length * 1000) + sap_ha_pacemaker_cluster_constraint_colo_base_score }}
+            {% set score.value = (group.resource_ids | length * 1000) + sap_ha_pacemaker_cluster_constraint_colo_base_score %}
           {%- endif %}
         {%- endfor %}
-      {%- else -%}
-        {{ sap_ha_pacemaker_cluster_constraint_colo_base_score }}
       {%- endif %}
+      {{ score.value }}
 
   when:
     - __constraint_colo_vip.resource_follower not in (__sap_ha_pacemaker_cluster_constraints_colocation | map(attribute='resource_follower'))

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -214,6 +214,7 @@
       ansible.builtin.import_role:
         name: "{{ sap_ha_pacemaker_cluster_system_roles_collection }}.ha_cluster"
       no_log: "{{ __sap_ha_pacemaker_cluster_no_log }}"  # some parameters contain secrets
+      tags: run_ha_cluster
 
 
     # Corosync post-inst

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
@@ -15,7 +15,8 @@ __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
 
 # Set variable with dictionary name based on angi availability
 __sap_ha_pacemaker_cluster_hana_hook_dictionary:
-  "{{ '__sap_ha_pacemaker_cluster_hook_' + sap_ha_pacemaker_cluster_host_type[0]
+  "{{ '__sap_ha_pacemaker_cluster_hook_'
+  + (sap_ha_pacemaker_cluster_host_type | select('search', 'hana'))[0]
   + ('_angi' if __sap_ha_pacemaker_cluster_saphanasr_angi_available else '') }}"
 
 # Recommended srhooks are set to true only if default dictionary is populated


### PR DESCRIPTION
A few bugs started showing during new tests and need fixing.

The combination of fixes was tested on AWS using
- RHEL 9.4
- HANA scale-up combined with NWAS ASCS/ERS on 2 nodes

### 1. Regression fix: Stonith resource duplicate definition
- This is a regression introduced in my previous stonith change. :/

During the previous change of the stonith code a conditional was removed that did not apply to the GCP default, but is required for other platform default stonith resources that use host maps.

### 2. Fix: Check-mode
Fixed a conditional that failed in check-mode. The .stout var is always defined, but can be empty and that fails the version comparison in the last conditional.

### 3. Fix: HANA VIP colocation score calculation
- This issue comes up due to the combination of HANA resources with NW groups.

This fixes the HANA VIP colocation constraint conditional to always apply the base score and recalculate only when HANA-VIP resource groups are present in the definition.
The previous code enhanced with an `else` in the loop for a default score ended up appending the loop results as strings.

Due to the combination of HANA and NW resource definitions the group loop was processed put the if-conditional does not match, so the issue started showing up in the form of an empty score returned due a missing fallback value inside the for-loop. This causes the ha_cluster role to fail when trying to apply the constraint.
The change to variable assignment was done to overcome the issue with the loop appending results instead of overriding one value.
    
Assigning new values inside blocks/loops does not work (anymore) and a namespace object has to be used instead.
    
Reference: https://jinja.palletsprojects.com/en/latest/templates/#assignments

### 4. Mini enhancement: tag ha_cluster role import task
Added a tag to allow running without executing the ha_cluster role by skipping the tag `run_ha_cluster`.
This speeds up the construction of the input config file for debugging purpose and could also be used to run everything else without recreating the cluster config again.

Example usage that saves ~7 minutes of execution time just for producing the input parameters for review:
```
ansible-playbook ... -e 'sap_ha_pacemaker_cluster_create_config_varfile: true' -C --skip-tags run_ha_cluster
```

### 5. Enhancement: flexibility for combined setups

- fixing the hook dictionary lookup in combined setups
- adds a check to the host type definition to prevent invalid combinations