### PR TITLE
sap_ha_pacemaker_cluster: fix internal-error

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -211,8 +211,10 @@
     # Cluster installation and configuration through the dedicated
     # linux system role 'ha_cluster'
     - name: "SAP HA Install Pacemaker - Include System Role 'ha_cluster'"
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: "{{ sap_ha_pacemaker_cluster_system_roles_collection }}.ha_cluster"
+        apply:
+          tags: run_ha_cluster
       no_log: "{{ __sap_ha_pacemaker_cluster_no_log }}"  # some parameters contain secrets
       tags: run_ha_cluster
 


### PR DESCRIPTION
For some reason the LSR collection variable is in the way of the ansible syntax-check of some tools, when the task that calls the ha_cluster LSR uses `import_role`.
The same syntax works without errors when the task uses `include_role` instead.

Fixes galaxy-importer error "internal-error: Unexpected error code 1".