### PR TITLE
sap_swpm: Fix link in README.md

### DIFF
--- a/roles/sap_swpm/README.md
+++ b/roles/sap_swpm/README.md
@@ -51,7 +51,7 @@ Alternatively, you can place all the files mentioned above into a single directo
 ### Recommended
 It is recommended to execute this role together with other roles in this collection, in the following order:</br>
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
-2. [sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_preconfigure)
+2. [sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_netweaver_preconfigure)
 3. [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect)
 4. *`sap_swpm`*
 


### PR DESCRIPTION
Fixes #969.

This PR replaces the original fix provided by SunnyCrockett in https://github.com/sap-linuxlab/community.sap_install/pull/968, as that one contained additional commits.