### PR TITLE
collection and sap_hostagent: ansible-lint fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,7 @@
 # Collection wide lint-file
 # DO NOT CHANGE
 exclude_paths:
+  - .ansible/
   - .cache/
   - .github/
   #- docs/
@@ -9,11 +10,12 @@ exclude_paths:
   - playbooks/
   - roles/sap_anydb_install_oracle
   #- roles/sap_general_preconfigure
+  #- roles/sap_ha_install_anydb_ibmdb2
   #- roles/sap_ha_install_hana_hsr
   #- roles/sap_ha_pacemaker_cluster
   #- roles/sap_hana_install
   #- roles/sap_hana_preconfigure
-  - roles/sap_hostagent
+  #- roles/sap_hostagent
   #- roles/sap_install_media_detect
   #- roles/sap_netweaver_preconfigure
   #- roles/sap_storage_setup

--- a/roles/sap_hostagent/defaults/main.yml
+++ b/roles/sap_hostagent/defaults/main.yml
@@ -12,8 +12,5 @@ sap_hostagent_agent_tmp_directory: "/tmp/hostagent"
 # Remove the temporary directory after the installation has been done
 sap_hostagent_clean_tmp_directory: false
 
-# This role must be run as ROOT user
-ansible_become: true
-
 # SSL Variables
 sap_hostagent_config_ssl: False

--- a/roles/sap_hostagent/tasks/config_ssl.yml
+++ b/roles/sap_hostagent/tasks/config_ssl.yml
@@ -32,7 +32,7 @@
     -x "{{ sap_hostagent_ssl_passwd }}"
     -r /tmp/myhost-csr.p10
     "CN={{ ansible_fqdn }}, O={{ sap_hostagent_ssl_org }}, C={{ sap_hostagent_ssl_country }}"
-  become: yes
+  become: true
   become_user: sapadm
   args:
     chdir: /usr/sap/hostctrl/exe/
@@ -48,7 +48,7 @@
     -p SAPSSLS.pse
     -x "{{ sap_hostagent_ssl_passwd }}"
     -O sapadm
-  become: yes
+  become: true
   become_user: sapadm
   args:
     chdir: /usr/sap/hostctrl/exe/
@@ -79,7 +79,7 @@
     /usr/sap/hostctrl/exe/sapgenpse get_my_name
     -x "{{ sap_hostagent_ssl_passwd }}"
     -v
-  become: yes
+  become: true
   become_user: sapadm
   args:
     chdir: /usr/sap/hostctrl/exe/


### PR DESCRIPTION
- **collection**: added `.ansible/` to excludes, this is auto-created by pre-commit and contains the collection, on which the role excludes do not work

- **sap_hostagent**: removed `ansible_become` from defaults, it does not belong in the role but in the playbook, and it triggers the no-role-prefix rule

- **sap_hostagent**: changed some truthy values for consistency

- **sap_hostagent** is now free of linter errors and included in checks