### PR TITLE
sap_swpm: removed duplicates from credentials_hana section

### DIFF
--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -229,8 +229,6 @@ storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
 #                                                                 #
 #  END  section credentials_hana                                  #
 ###################################################################
-HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_swpm_db_schema_password }}
-storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
 {% endif %}
 {% if 'credentials_anydb_ibmdb2' in sap_swpm_inifile_sections_list %}
 


### PR DESCRIPTION
The lines for HDB_Schema_Check_Dialogs.schemaPassword and storageBasedCopy.hdb.systemPassword were within the credentials_hana section and again directly below it. I removed the duplicate outside the section.