### PR TITLE
sap_*_preconfigure/Suse: Enhance saptune revert logic

### DIFF
--- a/roles/sap_general_preconfigure/tasks/sapnote/2578899/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2578899/configuration.yml
@@ -17,29 +17,44 @@
   when: __sap_general_preconfigure_grub_cmdline | length > 0
 
 
-- name: Apply SAP note 2578899 using saptune
+# Verify SAP Note before block and revert if found invalid
+- name: Verify SAP note 2578899 before changes
+  ansible.builtin.command:
+    cmd: saptune note verify 2578899
+  register: __sap_general_preconfigure_verify_2578899_before
+  changed_when: false
+  ignore_errors: true
   when: __sap_general_preconfigure_use_saptune | d(true)
-  block:
 
-    - name: Apply SAP note 2578899 using saptune
+- name: Apply SAP note 2578899 using saptune
+  when:
+    - __sap_general_preconfigure_use_saptune | d(true)
+    - __sap_general_preconfigure_verify_2578899_before.rc != 0
+  block:
+    - name: Revert SAP note 2578899
+      ansible.builtin.command:
+        cmd: saptune note revert 2578899
+      changed_when: true
+
+    - name: Apply SAP note 2578899
       ansible.builtin.command:
         cmd: saptune note apply 2578899
       changed_when: true
 
-    - name: Verify SAP note 2578899 using saptune
+    - name: Verify SAP note 2578899 after changes
       ansible.builtin.command:
-        cmd: saptune note verify 2578899
-      register: __sap_general_preconfigure_saptune_verify_2578899
+        cmd: saptune note verify --show-non-compliant 2578899
+      register: __sap_general_preconfigure_verify_2578899_after
       changed_when: false
       ignore_errors: true
 
     - name: Display error if saptune verify failed
       ansible.builtin.debug:
         msg: |
-          {{ __sap_general_preconfigure_saptune_verify_2578899.stdout_lines }}
-          {{ __sap_general_preconfigure_saptune_verify_2578899.stderr_lines }}
+          {{ __sap_general_preconfigure_verify_2578899_after.stdout_lines }}
+          {{ __sap_general_preconfigure_verify_2578899_after.stderr_lines }}
       when:
-        __sap_general_preconfigure_saptune_verify_2578899.rc != 0
+        __sap_general_preconfigure_verify_2578899_after.rc != 0
 
 
 - name: Configuration changes without saptune

--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -24,54 +24,43 @@
     - __sap_hana_preconfigure_use_saptune
 
 
-- name: Apply saptune solution
+# Verify SAP Solution before block and revert if found invalid
+- name: Verify saptune solution before changes
+  ansible.builtin.command:
+    cmd: "saptune solution verify {{ sap_hana_preconfigure_saptune_solution }}"
+  register: __sap_hana_preconfigure_register_solution_verify_before
+  changed_when: false
+  failed_when: false
   when: __sap_hana_preconfigure_use_saptune
+
+- name: Apply saptune solution
+  when:
+    - __sap_hana_preconfigure_use_saptune
+    - __sap_hana_preconfigure_register_solution_verify_before.rc != 0
   block:
-    - name: Discover active solution
+    - name: Revert saptune configuration
       ansible.builtin.command:
-        cmd: saptune solution enabled
-      register: __sap_hana_preconfigure_register_saptune_status
-      changed_when: false
-
-    - name: Set fact for active solution
-      ansible.builtin.set_fact:
-        # Capture the first block on none whitespace
-        __sap_hana_preconfigure_register_solution_configured:
-          "{{ (__sap_hana_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
-
-
-    - name: Revert solution when different to sap_hana_preconfigure_saptune_solution
-      ansible.builtin.command:
-        cmd: "saptune solution revert {{ __sap_hana_preconfigure_register_solution_configured }}"
+        cmd: "saptune revert all"
       changed_when: true
-      when:
-        - __sap_hana_preconfigure_register_solution_configured != 'NONE'
-        - __sap_hana_preconfigure_register_solution_configured != sap_hana_preconfigure_saptune_solution
-
-
-    - name: Verify saptune solution
-      ansible.builtin.command:
-        cmd: "saptune solution verify {{ sap_hana_preconfigure_saptune_solution }}"
-      register: __sap_hana_preconfigure_register_saptune_verify
-      changed_when: false
-      failed_when: false
-      when:
-        - __sap_hana_preconfigure_register_solution_configured == sap_hana_preconfigure_saptune_solution
-
 
     - name: Ensure saptune solution is applied
       ansible.builtin.command:
         cmd: "saptune solution apply {{ sap_hana_preconfigure_saptune_solution }}"
       changed_when: true
-      when:
-        - __sap_hana_preconfigure_register_solution_configured != sap_hana_preconfigure_saptune_solution
-          or __sap_hana_preconfigure_register_saptune_verify.rc != 0
 
-
-    - name: Ensure solution was successful
+    - name: Verify saptune solution after changes
       ansible.builtin.command:
-        cmd: "saptune solution verify {{ sap_hana_preconfigure_saptune_solution }}"
+        cmd: "saptune solution verify --show-non-compliant {{ sap_hana_preconfigure_saptune_solution }}"
       changed_when: false
+      failed_when: false
+      register: __sap_hana_preconfigure_register_solution_verify_after
+
+    - name: Display error if saptune verify failed
+      ansible.builtin.fail:
+        msg: |
+          {{ __sap_hana_preconfigure_register_solution_verify_after.stdout_lines }}
+          {{ __sap_hana_preconfigure_register_solution_verify_after.stderr_lines }}
+      when: __sap_hana_preconfigure_register_solution_verify_after.rc != 0
 
 
 - name: Configure - Include configuration actions for required sapnotes

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
@@ -9,29 +9,44 @@
   when: __sap_hana_preconfigure_grub_cmdline | length > 0
 
 
-- name: Apply SAP note 2684254 using saptune
+# Verify SAP Note before block and revert if found invalid
+- name: Verify SAP note 2684254 before changes
+  ansible.builtin.command:
+    cmd: saptune note verify 2684254
+  register: __sap_hana_preconfigure_verify_2684254_before
+  changed_when: false
+  ignore_errors: true
   when: __sap_hana_preconfigure_use_saptune | d(true)
-  block:
 
-    - name: Apply SAP note 2684254 using saptune
+- name: Apply SAP note 2684254 using saptune
+  when:
+    -__sap_hana_preconfigure_use_saptune | d(true)
+    - __sap_hana_preconfigure_verify_2684254_before.rc != 0
+  block:
+    - name: Revert SAP note 2684254
+      ansible.builtin.command:
+        cmd: saptune note revert 2684254
+      changed_when: true
+
+    - name: Apply SAP note 2684254
       ansible.builtin.command:
         cmd: saptune note apply 2684254
       changed_when: true
 
-    - name: Verify SAP note 2684254 using saptune
+    - name: Verify SAP note 2684254 after changes
       ansible.builtin.command:
-        cmd: saptune note verify 2684254
-      register: __sap_hana_preconfigure_saptune_verify_2684254
+        cmd: saptune note verify --show-non-compliant 2684254
+      register: __sap_hana_preconfigure_verify_2684254_after
       changed_when: false
       ignore_errors: true
 
     - name: Display error if saptune verify failed
       ansible.builtin.debug:
         msg: |
-          {{ __sap_hana_preconfigure_saptune_verify_2684254.stdout_lines }}
-          {{ __sap_hana_preconfigure_saptune_verify_2684254.stderr_lines }}
+          {{ __sap_hana_preconfigure_verify_2684254_after.stdout_lines }}
+          {{ __sap_hana_preconfigure_verify_2684254_after.stderr_lines }}
       when:
-        __sap_hana_preconfigure_saptune_verify_2684254.rc != 0
+        __sap_hana_preconfigure_verify_2684254_after.rc != 0
 
 
 - name: Configuration changes without saptune

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -1,54 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: Apply saptune solution
+# Verify SAP Solution before block and revert if found invalid
+- name: Verify saptune solution before changes
+  ansible.builtin.command:
+    cmd: "saptune solution verify {{ sap_netweaver_preconfigure_saptune_solution }}"
+  register: __sap_netweaver_preconfigure_register_solution_verify_before
+  changed_when: false
+  failed_when: false
   when: __sap_netweaver_preconfigure_use_saptune
+
+- name: Apply saptune solution
+  when:
+    - __sap_netweaver_preconfigure_use_saptune
+    - __sap_netweaver_preconfigure_register_solution_verify_before.rc != 0
   block:
-    - name: Discover active solution
+    - name: Revert saptune configuration
       ansible.builtin.command:
-        cmd: saptune solution enabled
-      register: __sap_netweaver_preconfigure_register_saptune_status
-      changed_when: false
-
-    - name: Set fact for active solution
-      ansible.builtin.set_fact:
-        # Capture the first block on none whitespace
-        __sap_netweaver_preconfigure_register_solution_configured:
-          "{{ (__sap_netweaver_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
-
-
-    - name: Revert solution when different to sap_netweaver_preconfigure_saptune_solution
-      ansible.builtin.command:
-        cmd: "saptune solution revert {{ __sap_netweaver_preconfigure_register_solution_configured }}"
+        cmd: "saptune revert all"
       changed_when: true
-      when:
-        - __sap_netweaver_preconfigure_register_solution_configured != 'NONE'
-        - __sap_netweaver_preconfigure_register_solution_configured != sap_netweaver_preconfigure_saptune_solution
-
-
-    - name: Verify saptune solution
-      ansible.builtin.command:
-        cmd: "saptune solution verify {{ sap_netweaver_preconfigure_saptune_solution }}"
-      register: __sap_netweaver_preconfigure_register_saptune_verify
-      changed_when: false
-      failed_when: false
-      when:
-        - __sap_netweaver_preconfigure_register_solution_configured == sap_netweaver_preconfigure_saptune_solution
-
 
     - name: Ensure saptune solution is applied
       ansible.builtin.command:
         cmd: "saptune solution apply {{ sap_netweaver_preconfigure_saptune_solution }}"
       changed_when: true
-      when:
-        - __sap_netweaver_preconfigure_register_solution_configured != sap_netweaver_preconfigure_saptune_solution
-          or __sap_netweaver_preconfigure_register_saptune_verify.rc != 0
 
-
-    - name: Ensure solution was successful
+    - name: Ensure solution was successful after changes
       ansible.builtin.command:
-        cmd: "saptune solution verify {{ sap_netweaver_preconfigure_saptune_solution }}"
+        cmd: "saptune solution verify --show-non-compliant {{ sap_netweaver_preconfigure_saptune_solution }}"
       changed_when: false
+      failed_when: false
+      register: __sap_netweaver_preconfigure_register_solution_verify_after
+
+    - name: Display error if saptune verify failed
+      ansible.builtin.fail:
+        msg: |
+          {{ __sap_netweaver_preconfigure_register_solution_verify_after.stdout_lines }}
+          {{ __sap_netweaver_preconfigure_register_solution_verify_after.stderr_lines }}
+      when: __sap_netweaver_preconfigure_register_solution_verify_after.rc != 0
 
 
 - name: Warn if not enough swap space is configured


### PR DESCRIPTION
### Description
PR https://github.com/sap-linuxlab/community.sap_install/pull/930 has introduced new way of handling `saptune` workflow, but it has shown new edge case where:
1. `sap_general_preconfigure` saptune applies sap note `2578899`
2. `sap_hana_preconfigure`: saptune applies solution HANA which already contains `2578899`
3. `sap_hana_preconfigure`: saptune verification of solution HANA fails, because: Application of solution skipped note `2578899`, which was older version, resulting in return code 1 in verification.

It is recommended to always revert saptune before applying solutions and this PR is handling that. 

### Test Results
This issue appeared on Cloud PAYG instances and this PR was tested on AWS and AZ with SLES4SAP 15 SP6, which had issue before.