### PR TITLE
sap_ha_pacemaker_cluster: fix(check-mode)

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_hana.yml
@@ -15,6 +15,7 @@
       ansible.builtin.command:
         cmd: dnf provides sap-hana-ha
       changed_when: false
+      check_mode: false
       register: __sap_ha_pacemaker_cluster_saphanasr_angi_check
       failed_when:
         - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc != 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/RedHat/pre_steps_nwas_ascs_ers.yml
@@ -12,6 +12,7 @@
           dnf info resource-agents-sap | awk '/^Version/ {print $3}' | sort | tail -n1
       register: __sap_ha_pacemaker_cluster_sapstartsrv_check
       changed_when: false
+      check_mode: false
       failed_when: false
 
     - name: "SAP HA Prepare Pacemaker - Disable Simple Mount when min. package version is not available"

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -20,7 +20,6 @@
     - name: "SAP HA Install Pacemaker - Put cluster in maintenance mode"
       ansible.builtin.command:
         cmd: crm --force configure property maintenance-mode=true
-      check_mode: false
       changed_when: true
 
     - name: "SAP HA Install Pacemaker - Verify that maintenance-mode is true"
@@ -31,7 +30,6 @@
       delay: 5
       until:
         '"Resource management is DISABLED" in __sap_ha_pacemaker_cluster_crm_status_maint.stdout'
-      check_mode: false
       changed_when: false
       run_once: true  # noqa: run_once[task]
 
@@ -39,7 +37,6 @@
       ansible.builtin.command:
         cmd: cibadmin --query
       register: __sap_ha_pacemaker_cluster_cib_query
-      check_mode: false
       changed_when: false
 
     - name: "SAP HA Install Pacemaker - Save CIB configuration"
@@ -49,7 +46,7 @@
         owner: root
         group: root
         mode: '0600'
-      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # SAPStartSrv - Remove monitor, start, stop operations from SAPStartSrv
     # These operations are not supported and not recommended.
@@ -74,5 +71,4 @@
     - name: "SAP HA Install Pacemaker - Disable maintenance mode"
       ansible.builtin.command:
         cmd: crm --force configure property maintenance-mode=false
-      check_mode: false
       changed_when: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_abap_ascs_ers.yml
@@ -26,12 +26,13 @@
       ansible.builtin.command:
         cmd: crm status
       register: __sap_ha_pacemaker_cluster_crm_status_maint
-      retries: 10
+      retries: "{{ 1 if ansible_check_mode else 10 }}"
       delay: 5
       until:
         '"Resource management is DISABLED" in __sap_ha_pacemaker_cluster_crm_status_maint.stdout'
       changed_when: false
       run_once: true  # noqa: run_once[task]
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Install Pacemaker - Fetch CIB configuration"
       ansible.builtin.command:

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
@@ -20,7 +20,6 @@
     - name: "SAP HA Install Pacemaker - Put cluster in maintenance mode"
       ansible.builtin.command:
         cmd: crm --force configure property maintenance-mode=true
-      check_mode: false
       changed_when: true
 
     - name: "SAP HA Install Pacemaker - Verify that maintenance-mode is true"
@@ -31,7 +30,6 @@
       delay: 5
       until:
         '"Resource management is DISABLED" in __sap_ha_pacemaker_cluster_crm_status_maint.stdout'
-      check_mode: false
       changed_when: false
       run_once: true  # noqa: run_once[task]
 
@@ -39,7 +37,6 @@
       ansible.builtin.command:
         cmd: cibadmin --query
       register: __sap_ha_pacemaker_cluster_cib_query
-      check_mode: false
       changed_when: false
 
     - name: "SAP HA Install Pacemaker - Save CIB configuration"
@@ -49,7 +46,7 @@
         owner: root
         group: root
         mode: '0600'
-      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # SAPStartSrv - Remove monitor, start, stop operations from SAPStartSrv
     # These operations are not supported and not recommended.
@@ -74,5 +71,4 @@
     - name: "SAP HA Install Pacemaker - Disable maintenance mode"
       ansible.builtin.command:
         cmd: crm --force configure property maintenance-mode=false
-      check_mode: false
       changed_when: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_nwas_java_scs_ers.yml
@@ -26,12 +26,13 @@
       ansible.builtin.command:
         cmd: crm status
       register: __sap_ha_pacemaker_cluster_crm_status_maint
-      retries: 10
+      retries: "{{ 1 if ansible_check_mode else 10 }}"
       delay: 5
       until:
         '"Resource management is DISABLED" in __sap_ha_pacemaker_cluster_crm_status_maint.stdout'
       changed_when: false
       run_once: true  # noqa: run_once[task]
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Install Pacemaker - Fetch CIB configuration"
       ansible.builtin.command:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -14,6 +14,7 @@
     loop_var: sapstartsrv_srv_item
   when:
     - __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+  ignore_errors: "{{ ansible_check_mode }}"
 
 
 # Block for configuring the SAP HA Interface (sap_cluster_connector).
@@ -47,8 +48,9 @@
         label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
     # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
       throttle: 1
-      retries: 30
-      delay: 10
+      retries: "{{ 1 if ansible_check_mode else 30 }}"
+      delay: "{{ 1 if ansible_check_mode else 10 }}"
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
@@ -59,7 +61,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
-      when: not ansible_check_mode
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
@@ -69,14 +71,13 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
-      when: not ansible_check_mode
+      check_mode: false
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
     # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ascs
@@ -87,7 +88,6 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
@@ -154,13 +154,11 @@
       ansible.builtin.shell: |
         {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
       changed_when: true
-      when: not ansible_check_mode
 
     # Block to restart cluster resources if RestartService is not enough.
     # This is required for SUSE, where SAP needs full restart to load HAlib.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
       when:
-        - not ansible_check_mode
         - "(__sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
            and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout)
           or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
@@ -213,7 +211,6 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
@@ -223,11 +220,12 @@
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout"
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
@@ -236,18 +234,21 @@
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
       #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout
@@ -255,13 +256,14 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
       #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout
@@ -272,17 +274,16 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
-        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+
 
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
         - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
-        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
@@ -292,7 +293,6 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
-        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -62,6 +62,7 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
@@ -72,6 +73,7 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
     # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
@@ -107,6 +109,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
@@ -118,6 +121,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
@@ -139,6 +143,7 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -59,6 +59,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
+      when: not ansible_check_mode
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
@@ -68,12 +69,14 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
+      when: not ansible_check_mode
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
     # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ascs
@@ -84,6 +87,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
@@ -102,6 +106,7 @@
         sleep 10
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
@@ -112,6 +117,7 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
@@ -132,6 +138,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when: false
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
@@ -147,11 +154,13 @@
       ansible.builtin.shell: |
         {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
       changed_when: true
+      when: not ansible_check_mode
 
     # Block to restart cluster resources if RestartService is not enough.
     # This is required for SUSE, where SAP needs full restart to load HAlib.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
       when:
+        - not ansible_check_mode
         - "(__sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
            and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout)
           or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
@@ -198,10 +207,13 @@
             {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
           changed_when: true
 
+    ### END of BLOCK for instance restarts.
+
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
@@ -215,6 +227,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
@@ -228,6 +241,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
@@ -241,6 +255,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
@@ -257,6 +272,7 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
+        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
@@ -266,6 +282,7 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
         - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
+        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
@@ -275,6 +292,7 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
+        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -79,6 +79,7 @@
     # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -89,6 +90,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -100,6 +102,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -113,6 +116,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -125,6 +129,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -134,6 +139,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -147,6 +153,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -183,6 +190,7 @@
           loop_control:
             loop_var: restart_item
           when:
+            - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
             - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
           changed_when: true
 
@@ -215,6 +223,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -230,6 +239,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -245,6 +255,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -260,6 +271,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -277,6 +289,7 @@
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ASCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -287,6 +300,7 @@
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
         - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -296,6 +310,7 @@
     # HACheckConfig shows same statues on both nodes, therefore only ASCS is shown
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
         - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -62,6 +62,7 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
@@ -72,6 +73,7 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
     # it might be good to remove them in future and leave reload to "SCS ERS restart" block.
@@ -107,6 +109,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
@@ -118,6 +121,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
@@ -139,6 +143,7 @@
       changed_when: false
       failed_when: false
       check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -59,6 +59,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
+      when: not ansible_check_mode
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
@@ -68,12 +69,14 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
+      when: not ansible_check_mode
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
     # it might be good to remove them in future and leave reload to "SCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the SCS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_scs
@@ -84,6 +87,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
@@ -102,6 +106,7 @@
         sleep 10
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
@@ -112,6 +117,7 @@
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
@@ -132,6 +138,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HACheckConfig
       changed_when: false
       failed_when: false
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
@@ -147,11 +154,13 @@
       ansible.builtin.shell: |
         {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
       changed_when: true
+      when: not ansible_check_mode
 
     # Block to restart cluster resources if RestartService is not enough.
     # This is required for SUSE, where SAP needs full restart to load HAlib.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for SCS ERS restart"
       when:
+        - not ansible_check_mode
         - "(__sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout is defined
            and 'FALSE' in __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout)
           or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
@@ -198,10 +207,13 @@
             {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
           changed_when: true
 
+    ### END of BLOCK for instance restarts.
+
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for SCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_scs_ha_check_config
@@ -215,6 +227,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
@@ -228,6 +241,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for SCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_scs_ha_failover_config
@@ -241,6 +255,7 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
+        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
@@ -257,6 +272,7 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines is defined
+        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines }}
@@ -266,6 +282,7 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
         - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
+        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
@@ -275,6 +292,7 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines is defined
+        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -14,6 +14,7 @@
     loop_var: sapstartsrv_srv_item
   when:
     - __sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
+  ignore_errors: "{{ ansible_check_mode }}"
 
 
 # Block for configuring the SAP HA Interface (sap_cluster_connector).
@@ -47,8 +48,9 @@
         label: "{{ nwas_profile_item.0 }} -> {{ nwas_profile_item.1 }}"
     # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
       throttle: 1
-      retries: 30
-      delay: 10
+      retries: "{{ 1 if ansible_check_mode else 30 }}"
+      delay: "{{ 1 if ansible_check_mode else 10 }}"
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for SCS to be up and running"
@@ -59,7 +61,7 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
-      when: not ansible_check_mode
+      check_mode: false
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
@@ -69,14 +71,13 @@
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
       changed_when: false
       failed_when: false
-      when: not ansible_check_mode
+      check_mode: false
 
     # NOTE: RestartService can cause fencing lockup and hang forever,
     # it might be good to remove them in future and leave reload to "SCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the SCS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_scs
@@ -87,7 +88,6 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_restart_ers
@@ -154,13 +154,11 @@
       ansible.builtin.shell: |
         {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
       changed_when: true
-      when: not ansible_check_mode
 
     # Block to restart cluster resources if RestartService is not enough.
     # This is required for SUSE, where SAP needs full restart to load HAlib.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for SCS ERS restart"
       when:
-        - not ansible_check_mode
         - "(__sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout is defined
            and 'FALSE' in __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout)
           or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
@@ -213,7 +211,6 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for SCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_scs_ha_check_config
@@ -223,11 +220,12 @@
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout"
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
@@ -236,18 +234,21 @@
       changed_when: false
       failed_when:
         - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
 
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for SCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_scs_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_scs_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout is defined
       #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout
@@ -255,13 +256,14 @@
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - not ansible_check_mode
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
       ansible.builtin.shell: |
         /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
       changed_when: false
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
       # failed_when:
       #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
       #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout
@@ -272,7 +274,6 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines is defined
-        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines }}
@@ -282,7 +283,6 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
         - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
-        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
@@ -292,7 +292,6 @@
       when:
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines is defined
-        - not ansible_check_mode
       ansible.builtin.debug:
         msg: |
           {{ __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines }}

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_java_scs_ers_post_install.yml
@@ -79,6 +79,7 @@
     # it might be good to remove them in future and leave reload to "SCS ERS restart" block.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the SCS service"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -89,6 +90,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -100,6 +102,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for SCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -113,6 +116,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -125,6 +129,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -134,6 +139,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for SCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -147,6 +153,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -215,6 +222,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for SCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -230,6 +238,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -245,6 +254,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for SCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -260,6 +270,7 @@
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
@@ -277,6 +288,7 @@
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on SCS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -286,6 +298,7 @@
     # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
         - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
       ansible.builtin.debug:
@@ -295,6 +308,7 @@
     # HACheckConfig shows same statues on both nodes, therefore only SCS is shown
     - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
       when:
+        - __sap_ha_pacemaker_cluster_register_where_scs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_scs.rc == 0
         - __sap_ha_pacemaker_cluster_register_scs_ha_check_config.stdout_lines is defined
       ansible.builtin.debug:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_srhook.yml
@@ -11,6 +11,7 @@
     cmd: cat "{{ __sap_ha_pacemaker_cluster_hana_global_ini_path }}"
   register: __sap_ha_pacemaker_cluster_global_ini_contents
   changed_when: false
+  check_mode: false
 
 # Following tasks will prepare srhook list if user input is detected
 - name: "SAP HA Pacemaker srHook - Block for user provided hooks"

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -317,6 +317,7 @@
         name: "{{ sap_ha_pacemaker_cluster_system_roles_collection }}.ha_cluster"
         apply:
           tags: run_ha_cluster
+          ignore_errors: "{{ ansible_check_mode }}"
       no_log: "{{ __sap_ha_pacemaker_cluster_no_log }}"  # some parameters contain secrets
       tags: run_ha_cluster
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/ascertain_platform_type.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/ascertain_platform_type.yml
@@ -79,6 +79,7 @@
     set -o pipefail && rpm -qa | grep -E -e "rsct.basic"
   register: __sap_ha_pacemaker_cluster_power_rsct_check
   changed_when: false
+  check_mode: false
   when: ansible_architecture == "ppc64le"
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - Fail if RSCT binary is missing"
@@ -93,6 +94,7 @@
     /opt/rsct/bin/ctgethscid
   register: __sap_ha_pacemaker_cluster_power_rsct_hscid
   changed_when: false
+  check_mode: false
   when:
     - ansible_architecture == "ppc64le"
     - __sap_ha_pacemaker_cluster_power_rsct_check.stdout != ""

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
@@ -22,6 +22,7 @@
         mode: '0644'
       when:
         - not __sap_ha_pacemaker_cluster_register_haproxy_template.stat.exists
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template description"
       ansible.builtin.lineinfile:
@@ -32,6 +33,7 @@
         state: present
         insertafter: '^[Unit]$'
       notify: "systemd daemon-reload"
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Update haproxy service template"
       ansible.builtin.replace:
@@ -54,6 +56,7 @@
         loop_var: replace_item
         label: "{{ replace_item.label }}"
       notify: "systemd daemon-reload"
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Define healthcheck details for HANA"
       ansible.builtin.set_fact:
@@ -121,6 +124,7 @@
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
         - haproxy_item.port | length > 4
+      ignore_errors: "{{ ansible_check_mode }}"
 
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for NWAS ASCS/ERS instances"
@@ -161,6 +165,7 @@
         label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
+      ignore_errors: "{{ ansible_check_mode }}"
 
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Ensure that haproxy service is running"
@@ -168,3 +173,4 @@
         name: haproxy
         enabled: false
         state: started
+      ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_gcp_ce_vm.yml
@@ -124,7 +124,6 @@
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
         - haproxy_item.port | length > 4
-      ignore_errors: "{{ ansible_check_mode }}"
 
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Create haproxy config for NWAS ASCS/ERS instances"
@@ -165,7 +164,6 @@
         label: "{{ haproxy_item.name }}: {{ haproxy_item.port }}"
       when:
         - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_abap_ascs_ers') | length > 0
-      ignore_errors: "{{ ansible_check_mode }}"
 
 
     - name: "SAP HA Install Pacemaker - GCP CE VM - Ensure that haproxy service is running"

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/preconfigure_cloud_ibmcloud_vs.yml
@@ -44,6 +44,7 @@
     mode: '0644'
   when:
     - not __sap_ha_pacemaker_cluster_register_haproxy_template.stat.exists
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "SAP HA Install Pacemaker - IBM Cloud VS - Update haproxy service template description"
   ansible.builtin.lineinfile:
@@ -54,6 +55,7 @@
     state: present
     insertafter: '^[Unit]$'
   notify: "systemd daemon-reload"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "SAP HA Install Pacemaker - IBM Cloud VS - Update haproxy service template"
   ansible.builtin.replace:
@@ -76,6 +78,7 @@
     loop_var: replace_item
     label: "{{ replace_item.label }}"
   notify: "systemd daemon-reload"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "SAP HA Install Pacemaker - IBM Cloud VS - Define healthcheck details for HANA"
   ansible.builtin.set_fact:
@@ -199,3 +202,4 @@
     name: haproxy
     state: started
     enabled: false # Do not start on boot
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
@@ -17,8 +17,9 @@
       else __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string
       }}"
   throttle: 1
-  retries: 30
-  delay: 10
+  retries: "{{ 1 if ansible_check_mode else 30 }}"
+  delay: "{{ 1 if ansible_check_mode else 10 }}"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "SAP HA Pacemaker - (ERS profile) Prevent automatic restart"
   ansible.builtin.replace:
@@ -28,8 +29,9 @@
     replace: 'Start_Program_00'
   # Throttle and retry loop was added to combat NFS write lockups on Azure NFS
   throttle: 1
-  retries: 30
-  delay: 10
+  retries: "{{ 1 if ansible_check_mode else 30 }}"
+  delay: "{{ 1 if ansible_check_mode else 10 }}"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "SAP HA Pacemaker - (systemd) Check for (A)SCS/ERS services"
   ansible.builtin.stat:
@@ -114,7 +116,6 @@
         # or
         # <SID> and ERS <nr> are both in the looped profile (reg_item)
         # and "SAP<SID>_<nr>.service" (ERS) are missing in the local systemd services list
-        - not ansible_check_mode
         - (__sap_ha_pacemaker_cluster_nwas_sid in reg_item
           and __task_cs_instance_nr in reg_item
           and ('SAP' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_' ~ __task_cs_instance_nr ~ '.service')
@@ -138,6 +139,7 @@
       loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: instance_srv_item
+      ignore_errors: "{{ ansible_check_mode }}"
 
     # Creates a config file for the services.
     # Parent directories will be created when missing.
@@ -152,6 +154,7 @@
       loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: dropfile_item
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (systemd) Disable (A)SCS/ERS instance unit auto-restart"
       ansible.builtin.lineinfile:
@@ -165,6 +168,7 @@
       loop: "{{ sap_ha_pacemaker_cluster_instance_service_all_fact }}"
       loop_control:
         loop_var: dropfile_item
+      ignore_errors: "{{ ansible_check_mode }}"
 
 ### END of BLOCK for systemd setup.
 
@@ -191,3 +195,4 @@
       }}"
   when:
     - ansible_os_family == 'RedHat'
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
@@ -114,6 +114,7 @@
         # or
         # <SID> and ERS <nr> are both in the looped profile (reg_item)
         # and "SAP<SID>_<nr>.service" (ERS) are missing in the local systemd services list
+        - not ansible_check_mode
         - (__sap_ha_pacemaker_cluster_nwas_sid in reg_item
           and __task_cs_instance_nr in reg_item
           and ('SAP' ~ __sap_ha_pacemaker_cluster_nwas_sid ~ '_' ~ __task_cs_instance_nr ~ '.service')


### PR DESCRIPTION
### Issue
The check-mode was inconsistent and some of it only surfaced on fresh nodes with no previous cluster config yet.

### Fix
Check-mode handling has been added to various tasks in different ways:
- `shell/command` tasks with no changes are executed, e.g. for discovering facts
- tasks that should never run in check-mode are skipped explicitly
- tasks that fail in check-mode ignore the failure - it is still useful to see what would be done

The last point especially concerns the `ha_cluster` role include. The entire include will be executed, but since the role is not check-mode safe, it will display the ignored errors. This way it is possible to see the workflow and review it as much as possible before the actual execution.

### Tested
- RHEL 9.4 on GCP
- RHEL 9.4 on AWS
- HANA scale-up
- NWAS ASCS/ERS
- fresh systems with no cluster installed before (no paths, no packages, etc.), but the SAP landscape is installed and configured as required
- re-run on the existing cluster, i.e. after the cluster configuration

@marcelmamula 
I was not sure about the desired check-mode behavior in the affected Suse tasks, that's why I did not make changes here:
- `tasks/Suse/post_steps_nwas_abap_ascs_ers.yml`
- `tasks/Suse/post_steps_nwas_java_scs_ers.yml`

However, they do need some improvements as well in my opinion, since there are a lot of commands executed in check-mode, which would either not work on fresh systems, or make actual changes in existing systems explicitly. Which is incorrect behavior in check-mode. Not sure if this is intended, so I kept my hands off for now. :) 