### PR TITLE
sap_hana_install: Update fapolicyd conditionals

### DIFF
--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -209,6 +209,8 @@
 
 - name: SAP HANA Post Install, fapolicyd - Update config for desired integrity level and revert if validation fails
   when:
+    # Ensure fapolicyd is checked only on supported systems.
+    - ansible_os_family == "RedHat"
     - sap_hana_install_use_fapolicyd
     - '"fapolicyd" in ansible_facts.packages'
   tags: sap_hana_install_use_fapolicyd

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -34,18 +34,22 @@
 # Otherwise, the installation of SAP HANA will fail
 ################
 
-- name: SAP HANA Pre Install, fapolicyd - Gather package facts
-  ansible.builtin.package_facts:
-  tags: sap_hana_install_use_fapolicyd
-
-- name: SAP HANA Pre Install, fapolicyd - Disable fapolicyd
-  ansible.builtin.service:
-    name: fapolicyd
-    enabled: false
-    state: stopped
+- name: SAP HANA Pre Install, fapolicyd - Block to disable fapolicyd
   when:
-    - '"fapolicyd" in ansible_facts.packages'
+    # Ensure fapolicyd is checked only on supported systems.
+    - ansible_os_family == "RedHat"
   tags: sap_hana_install_use_fapolicyd
+  block:
+    - name: SAP HANA Pre Install, fapolicyd - Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: SAP HANA Pre Install, fapolicyd - Disable fapolicyd
+      ansible.builtin.service:
+        name: fapolicyd
+        enabled: false
+        state: stopped
+      when:
+        - '"fapolicyd" in ansible_facts.packages'
 
 ################
 # Prepare software path


### PR DESCRIPTION
### Description
- Add missing conditionals for `fapolicyd` related tasks that can run only on system where `fapolicyd` is supported.

### Reasoning
- `fapolicyd` is not available or supported on SLES.
- Limiting `fapolicyd` tasks removes need to install `python3-rpm` on SLES in order to allow execution of `ansible.builtin.package_facts` which requires higher python version.