### PR TITLE
sap_general_preconfigure/SLES: Add etc hosts setup to configure steps

### DIFF
--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -411,19 +411,20 @@ sap_general_preconfigure_kernel_parameters:
 
 The maximum length of the hostname. See SAP note 611361.<br>
 
-### sap_hostname
+### sap_general_preconfigure_hostname
 - _Type:_ `str`
 - _Default:_ `"{{ ansible_hostname }}"`
 
 The hostname to be used for updating or checking `/etc/hosts` entries.<br>
 
-### sap_domain
+### sap_general_preconfigure_domain
 - _Type:_ `str`
 - _Default:_ `"{{ ansible_domain }}"`
 
 The DNS domain name to be used for updating or checking `/etc/hosts` entries.<br>
+Mandatory parameter when sap_general_preconfigure_modify_etc_hosts is set to true.<br>
 
-### sap_ip
+### sap_general_preconfigure_ip
 - _Type:_ `str`
 - _Default:_ `"{{ ansible_default_ipv4.address }}"`
 

--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -162,6 +162,7 @@ sap_general_preconfigure_hostname: "{{ sap_hostname | d(ansible_hostname) }}"
 
 sap_general_preconfigure_domain: "{{ sap_domain | d(ansible_domain) }}"
 # The DNS domain name to be used for updating or checking `/etc/hosts` entries.
+# Mandatory parameter when sap_general_preconfigure_modify_etc_hosts is set to true.
 
 # sap_general_preconfigure_db_group_name: (not defined by default)
 # (RedHat specific) Use this variable to specify the name of the RHEL group which is used for the database processes.

--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -328,6 +328,7 @@ argument_specs:
         default: "{{ ansible_domain }}"
         description:
           - The DNS domain name to be used for updating or checking `/etc/hosts` entries.
+          - Mandatory parameter when `sap_general_preconfigure_modify_etc_hosts` is set to true.
         required: false
         type: str
 

--- a/roles/sap_general_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/configuration.yml
@@ -5,6 +5,20 @@
   ansible.builtin.debug:
     var: __sap_general_preconfigure_sapnotes_versions | difference([''])
 
+# Configure /etc/hosts
+- name: Import role sap_maintain_etc_hosts
+  ansible.builtin.import_role:
+    name: '{{ sap_general_preconfigure_sap_install_collection }}.sap_maintain_etc_hosts'
+  vars:
+    sap_maintain_etc_hosts_list:
+      - node_ip: "{{ sap_general_preconfigure_ip }}"
+        node_name: "{{ sap_general_preconfigure_hostname }}"
+        node_domain: "{{ sap_general_preconfigure_domain }}"
+        state: present
+  when: sap_general_preconfigure_modify_etc_hosts
+  tags:
+    - sap_general_preconfigure_etc_hosts
+
 - name: Configure - Include configuration actions for required sapnotes
   ansible.builtin.include_tasks: "sapnote/{{ sap_note_line_item.number }}.yml"
   loop: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"


### PR DESCRIPTION
### Description
1. Add support for `/etc/hosts` changes to SUSE configuration steps, same as done in RedHat steps.
2. Update `sap_general_preconfigure_domain` comments to correctly spell out how mandatory it is.
3. Rename readme variables to correctly represent role variables.

### Testing
Tested on SLES4SAP 15 SP6 on AWS and Local VM where `sap_general_preconfigure_domain` is mandatory because `ansible_domain` is undefined (requires `/etc/hosts` first).