### PR TITLE
sap_hana_preconfigure/SLES: Add package libltdl7 to vars

### DIFF
--- a/roles/sap_hana_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_15.yml
@@ -35,6 +35,10 @@ __sap_hana_preconfigure_packages:
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit
 
+  # 2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"
+  # 3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file
+  - libltdl7
+
   # Recommended for System monitoring
   - cpupower
   # - "{{ 'libcpupower0' if ansible_distribution_version.split('.')[1] | int < 6 else 'libcpupower1' }}"

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
@@ -35,6 +35,10 @@ __sap_hana_preconfigure_packages:
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit
 
+  # 2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"
+  # 3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file
+  - libltdl7
+
   # Recommended for System monitoring
   - cpupower
   # - "{{ 'libcpupower0' if ansible_distribution_version.split('.')[1] | int < 6 else 'libcpupower1' }}"

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
@@ -23,6 +23,10 @@ __sap_hana_preconfigure_packages:
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit
 
+  # 2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"
+  # 3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file
+  - libltdl7
+
   # Recommended for System monitoring
   - cpupower
   - libcpupower1


### PR DESCRIPTION
### Description
- Package `libltdl7` is required for SAP HANA installation on SLES, but it is only preinstalled on Cloud images. This change adds it to list of required packages to be installed for `sap_hana_preconfigure` role.

### Testing
- Tested on SLES4SAP 15 SP6 on AWS and local VM.

### Sources
[2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"](https://me.sap.com/notes/3029056)
[3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file: No such file or directory](https://me.sap.com/notes/2998886)