### PR TITLE
sap_*_preconfigure/SLES: Enhance saptune handling and detection

### DIFF
--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -258,7 +258,7 @@ If you set the RHEL minor release, then you must also use the `eus` or `e4s` rep
 - _Type:_ `str`
 - _Default:_ (set by platform/environment specific variables)
 
-The name of the software package group to install.<br>
+(RedHat specific) The name of the software package group to install.<br>
 The default for this parameter is set in the vars file which corresponds to the detected OS version.<br>
 
 Example:
@@ -271,7 +271,7 @@ Example:
 - _Type:_ `str`
 - _Default:_ (set by platform/environment specific variables)
 
-The name of the software environment group to check.<br>
+(RedHat specific) The name of the software environment group to check.<br>
 The default for this parameter is set in the vars file which corresponds to the detected OS version.<br>
 
 Example:
@@ -279,6 +279,13 @@ Example:
 ```yaml
 '@minimal-environment'
 ```
+
+### sap_general_preconfigure_patterns
+- _Type:_ `list` with elements of type `str`
+- _Default:_ (set by platform/environment specific variables)
+
+(SUSE specific) The list of the zypper patterns to install.<br>
+The default for this parameter is set in the vars file which corresponds to the detected OS version.<br>
 
 ### sap_general_preconfigure_packages
 - _Type:_ `list` with elements of type `str`

--- a/roles/sap_general_preconfigure/defaults/main.yml
+++ b/roles/sap_general_preconfigure/defaults/main.yml
@@ -69,14 +69,18 @@ sap_general_preconfigure_set_minor_release: false
 # If you set the RHEL minor release, then you must also use the `eus` or `e4s` repos.
 
 sap_general_preconfigure_packagegroups: "{{ __sap_general_preconfigure_packagegroups }}"
-# The name of the software package group to install.
+# (RedHat specific) The name of the software package group to install.
 # The default for this parameter is set in the vars file which corresponds to the detected OS version.
 # Example: See README.md
 
 sap_general_preconfigure_envgroups: "{{ __sap_general_preconfigure_envgroups }}"
-# The name of the software environment group to check.
+# (RedHat specific) The name of the software environment group to check.
 # The default for this parameter is set in the vars file which corresponds to the detected OS version.
 # Example: See README.md
+
+sap_general_preconfigure_patterns: "{{ __sap_general_preconfigure_patterns }}"
+# (SUSE specific) The list of the zypper patterns to install.
+# The default for this parameter is set in the vars file which corresponds to the detected OS version.
 
 sap_general_preconfigure_packages: "{{ __sap_general_preconfigure_packages }}"
 # The list of packages to be installed.

--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -152,7 +152,7 @@ argument_specs:
       sap_general_preconfigure_packagegroups:
         default: "{{ __sap_general_preconfigure_packagegroups }}"
         description:
-          - The name of the software package group to install.
+          - (RedHat specific) The name of the software package group to install.
           - The default for this parameter is set in the vars file which corresponds to the detected OS version.
         example:
           '@minimal-environment'
@@ -162,12 +162,21 @@ argument_specs:
       sap_general_preconfigure_envgroups:
         default: "{{ __sap_general_preconfigure_envgroups }}"
         description:
-          - The name of the software environment group to check.
+          - (RedHat specific) The name of the software environment group to check.
           - The default for this parameter is set in the vars file which corresponds to the detected OS version.
         example:
           '@minimal-environment'
         required: false
         type: str
+
+      sap_general_preconfigure_patterns:
+        default: "{{ __sap_general_preconfigure_patterns }}"
+        description:
+          - (SUSE specific) The list of the zypper patterns to install.
+          - The default for this parameter is set in the vars file which corresponds to the detected OS version.
+        required: false
+        type: list
+        elements: str
 
       sap_general_preconfigure_packages:
         default: "{{ __sap_general_preconfigure_packages }}"

--- a/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
@@ -1,6 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __sap_general_preconfigure_register_patterns
+  changed_when: false
+  ignore_errors: true
+
+- name: Assert that all required zypper patterns are installed
+  ansible.builtin.assert:
+    that: "'{{ item }}' in __sap_general_preconfigure_register_patterns.stdout"
+    fail_msg: "FAIL: Pattern '{{ item }}' is not installed!"
+    success_msg: "PASS: Pattern '{{ item }}' is installed."
+  loop: "{{ sap_general_preconfigure_patterns }}"
+  ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
+
+
 # Both sap_general_preconfigure_packages and __sap_general_preconfigure_min_pkgs are checked at same time.
 # Check rpm --whatprovides only if package cannot be found directly.
 - name: Query RPM packages

--- a/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -62,27 +62,29 @@
       changed_when: false
 
 
-- name: Check active saptune solution
+- name: Block to show current enabled saptune solution
   when:
     - __sap_general_preconfigure_use_saptune
     - __sap_general_preconfigure_register_saptune_check_before.rc == 0
       or (__sap_general_preconfigure_register_saptune_check_after.rc == 0)
   block:
-    - name: Discover active solution
+    - name: Get current enabled saptune solution
       ansible.builtin.command:
         cmd: saptune solution enabled
-      register: __sap_general_preconfigure_register_saptune_status
+      register: __sap_general_preconfigure_register_saptune_enabled
       changed_when: false
+      failed_when: false
 
-    - name: Set fact for active solution
+    # Enabled solution contains newline, which has to be removed
+    - name: Cleanup saptune solution enabled output
       ansible.builtin.set_fact:
-        # Capture the first block on none whitespace
-        __sap_general_preconfigure_register_solution_configured:
-          "{{ (__sap_general_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
+        __sap_general_preconfigure_register_saptune_enabled_trim:
+          "{{ __sap_general_preconfigure_register_saptune_enabled.stdout | trim | replace('\n', '') }}"
 
-    - name: Show configured solution
+    - name: Show current enabled saptune solution
       ansible.builtin.debug:
-        var: __sap_general_preconfigure_register_solution_configured
+        msg: "{{ __sap_general_preconfigure_register_saptune_enabled_trim }}"
+      when: __sap_general_preconfigure_register_saptune_enabled_trim != ''
 
 
 - name: Enable sapconf

--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -29,10 +29,21 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+# Pattern installation will run only if pattern is not installed
+# This ensures that command module shows correct changed status
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __sap_general_preconfigure_register_patterns
+  changed_when: false
+  ignore_errors: true
+
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ sap_general_preconfigure_patterns }}"
+  when: item not in __sap_general_preconfigure_register_patterns.stdout
+  changed_when: item not in __sap_general_preconfigure_register_patterns.stdout
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:

--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -29,6 +29,11 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+- name: Ensure that the required zypper patterns are installed
+  ansible.builtin.command:
+    cmd: zypper install -y -t pattern {{ item }}
+  loop: "{{ sap_general_preconfigure_patterns }}"
+
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
     state: present

--- a/roles/sap_general_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_15.yml
@@ -9,7 +9,13 @@ __sap_general_preconfigure_sapnotes_versions:
   # 2369910 - SAP Software on Linux: General information
   - { number: '2369910', version: '18' }
 
+__sap_general_preconfigure_patterns:
+  - sap_server
+
 __sap_general_preconfigure_packages:
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
+
   - uuidd
   - tcsh
   - psmisc

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
@@ -9,9 +9,12 @@ __sap_general_preconfigure_sapnotes_versions:
   # 2369910 - SAP Software on Linux: General information
   - { number: '2369910', version: '18' }
 
+__sap_general_preconfigure_patterns:
+  - sap_server
+
 __sap_general_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-server-enterprise-sap_server
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
@@ -5,9 +5,12 @@
 
 __sap_general_preconfigure_sapnotes_versions: []
 
+__sap_general_preconfigure_patterns:
+  - sles_minimal_sap
+
 __sap_general_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-sap-base_sap_server
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh

--- a/roles/sap_general_preconfigure/vars/main.yml
+++ b/roles/sap_general_preconfigure/vars/main.yml
@@ -4,6 +4,7 @@
 # dummy entries for passing the arg spec validation:
 __sap_general_preconfigure_packagegroups: ''
 __sap_general_preconfigure_envgroups: ''
+__sap_general_preconfigure_patterns: []
 __sap_general_preconfigure_packages: []
 __sap_general_preconfigure_size_of_tmpfs_gb: ''
 __sap_general_preconfigure_kernel_parameters_default: []

--- a/roles/sap_hana_preconfigure/README.md
+++ b/roles/sap_hana_preconfigure/README.md
@@ -317,6 +317,13 @@ or a list of the minimum required packages for SAP HANA server (parameter `__sap
 SAP HANA requires certain minimum package versions to be supported. These minimum levels are listed in SAP Note 2235581.<br>
 Set this parameter to `false` if you want to ignore these requirements.<br>
 
+### sap_hana_preconfigure_patterns
+- _Type:_ `list` with elements of type `str`
+- _Default:_ (set by platform/environment specific variables)
+
+(SUSE specific) The list of the zypper patterns to install.<br>
+The default for this parameter is set in the vars file which corresponds to the detected OS version.<br>
+
 ### sap_hana_preconfigure_update
 - _Type:_ `bool`
 - _Default:_ `false`
@@ -448,6 +455,12 @@ This will replace the current installed version if present, even downgrade if ne
 
 (SUSE specific) Specifies the saptune solution to apply.<br>
 Available values: `HANA`, `NETWEAVER+HANA`, `S4HANA-APP+DB`, `S4HANA-DBSERVER`
+
+### sap_hana_preconfigure_saptune_solution_force
+- _Type:_ `bool`
+- _Default:_ `false`
+
+(SUSE specific) Apply saptune solution regardless if it is already enabled and verified.<br>
 
 ### sap_hana_preconfigure_saptune_azure
 - _Type:_ `bool`

--- a/roles/sap_hana_preconfigure/defaults/main.yml
+++ b/roles/sap_hana_preconfigure/defaults/main.yml
@@ -109,6 +109,10 @@ sap_hana_preconfigure_min_package_check: true
 # SAP HANA requires certain minimum package versions to be supported. These minimum levels are listed in SAP Note 2235581.
 # Set this parameter to `false` if you want to ignore these requirements.
 
+sap_hana_preconfigure_patterns: "{{ __sap_hana_preconfigure_patterns }}"
+# (SUSE specific) The list of the zypper patterns to install.
+# The default for this parameter is set in the vars file which corresponds to the detected OS version.
+
 sap_hana_preconfigure_update: false
 # Set this parameter to `true` to update the system to the latest package levels.
 # By setting the parameter `sap_general_preconfigure_set_minor_release` of the
@@ -181,6 +185,8 @@ sap_hana_preconfigure_saptune_version: ''
 # Available options for HANA are: HANA, NETWEAVER+HANA, S4HANA-APP+DB, S4HANA-DBSERVER
 sap_hana_preconfigure_saptune_solution: 'HANA'
 
+# (SUSE specific) Apply saptune solution regardless if it is already enabled and verified.
+sap_hana_preconfigure_saptune_solution_force: false
 
 sap_hana_preconfigure_saptune_azure: false
 # On Azure, TCP timestamps, reuse and recycle should be disabled (SLES for SAP Applications).

--- a/roles/sap_hana_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_hana_preconfigure/meta/argument_specs.yml
@@ -225,6 +225,15 @@ argument_specs:
         required: false
         type: bool
 
+      sap_hana_preconfigure_patterns:
+        default: "{{ __sap_hana_preconfigure_patterns }}"
+        description:
+          - (SUSE specific) The list of the zypper patterns to install.
+          - The default for this parameter is set in the vars file which corresponds to the detected OS version.
+        required: false
+        type: list
+        elements: str
+
       sap_hana_preconfigure_update:
         default: 'false'
         description:
@@ -382,6 +391,13 @@ argument_specs:
           - 'S4HANA-DBSERVER'
         required: false
         type: str
+
+      sap_hana_preconfigure_saptune_solution_force:
+        default: false
+        description:
+          - (SUSE specific) Apply saptune solution regardless if it is already enabled and verified.
+        required: false
+        type: bool
 
       sap_hana_preconfigure_saptune_azure:
         default: false

--- a/roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml
@@ -1,6 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __sap_hana_preconfigure_register_patterns
+  changed_when: false
+  ignore_errors: true
+
+- name: Assert that all required zypper patterns are installed
+  ansible.builtin.assert:
+    that: "'{{ item }}' in __sap_hana_preconfigure_register_patterns.stdout"
+    fail_msg: "FAIL: Pattern '{{ item }}' is not installed!"
+    success_msg: "PASS: Pattern '{{ item }}' is installed."
+  loop: "{{ sap_hana_preconfigure_patterns }}"
+  ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
+
+
 # Check rpm --whatprovides only if package cannot be found directly.
 - name: Query RPM packages
   ansible.builtin.shell:

--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -24,6 +24,21 @@
     - __sap_hana_preconfigure_use_saptune
 
 
+- name: Get current enabled saptune solution
+  ansible.builtin.command:
+    cmd: "saptune solution enabled"
+  register: __sap_hana_preconfigure_register_solution_enabled
+  changed_when: false
+  failed_when: false
+  when: __sap_hana_preconfigure_use_saptune
+
+# Enabled solution contains newline, which has to be removed
+- name: Cleanup saptune solution enabled output
+  ansible.builtin.set_fact:
+    __sap_hana_preconfigure_register_solution_enabled_trim:
+      "{{ __sap_hana_preconfigure_register_solution_enabled.stdout | trim | replace('\n', '') }}"
+  when: __sap_hana_preconfigure_use_saptune
+
 # Verify SAP Solution before block and revert if found invalid
 - name: Verify saptune solution before changes
   ansible.builtin.command:
@@ -31,13 +46,22 @@
   register: __sap_hana_preconfigure_register_solution_verify_before
   changed_when: false
   failed_when: false
-  when: __sap_hana_preconfigure_use_saptune
+  when:
+    - __sap_hana_preconfigure_use_saptune
+    - __sap_hana_preconfigure_register_solution_enabled_trim == sap_hana_preconfigure_saptune_solution
 
 - name: Apply saptune solution
   when:
     - __sap_hana_preconfigure_use_saptune
-    - __sap_hana_preconfigure_register_solution_verify_before.rc != 0
+    - sap_hana_preconfigure_saptune_solution_force
+      or __sap_hana_preconfigure_register_solution_enabled_trim != sap_hana_preconfigure_saptune_solution
+      or __sap_hana_preconfigure_register_solution_verify_before.rc != 0
   block:
+    - name: Show current enabled saptune solution
+      ansible.builtin.debug:
+        msg: "{{ __sap_hana_preconfigure_register_solution_enabled_trim }}"
+      when: __sap_hana_preconfigure_register_solution_enabled_trim != ''
+
     - name: Revert saptune configuration
       ansible.builtin.command:
         cmd: "saptune revert all"
@@ -61,6 +85,10 @@
           {{ __sap_hana_preconfigure_register_solution_verify_after.stdout_lines }}
           {{ __sap_hana_preconfigure_register_solution_verify_after.stderr_lines }}
       when: __sap_hana_preconfigure_register_solution_verify_after.rc != 0
+
+    - name: Show applied saptune solution
+      ansible.builtin.debug:
+        msg: "{{ sap_hana_preconfigure_saptune_solution }}"
 
 
 - name: Configure - Include configuration actions for required sapnotes

--- a/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -62,29 +62,6 @@
       changed_when: false
 
 
-- name: Check active saptune solution
-  when:
-    - __sap_hana_preconfigure_use_saptune
-    - __sap_hana_preconfigure_register_saptune_check_before.rc == 0
-      or (__sap_hana_preconfigure_register_saptune_check_after.rc == 0)
-  block:
-    - name: Discover active solution
-      ansible.builtin.command:
-        cmd: saptune solution enabled
-      register: __sap_hana_preconfigure_register_saptune_status
-      changed_when: false
-
-    - name: Set fact for active solution
-      ansible.builtin.set_fact:
-        # Capture the first block on none whitespace
-        __sap_hana_preconfigure_register_solution_configured:
-          "{{ (__sap_hana_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
-
-    - name: Show configured solution
-      ansible.builtin.debug:
-        var: __sap_hana_preconfigure_register_solution_configured
-
-
 - name: Enable sapconf
   when: not __sap_hana_preconfigure_use_saptune
   block:

--- a/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
@@ -29,10 +29,21 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+# Pattern installation will run only if pattern is not installed
+# This ensures that command module shows correct changed status
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __sap_hana_preconfigure_register_patterns
+  changed_when: false
+  ignore_errors: true
+
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ sap_hana_preconfigure_patterns }}"
+  when: item not in __sap_hana_preconfigure_register_patterns.stdout
+  changed_when: item not in __sap_hana_preconfigure_register_patterns.stdout
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:

--- a/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
@@ -29,6 +29,11 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+- name: Ensure that the required zypper patterns are installed
+  ansible.builtin.command:
+    cmd: zypper install -y -t pattern {{ item }}
+  loop: "{{ sap_hana_preconfigure_patterns }}"
+
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
     state: present

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
@@ -20,7 +20,7 @@
 
 - name: Apply SAP note 2684254 using saptune
   when:
-    -__sap_hana_preconfigure_use_saptune | d(true)
+    - __sap_hana_preconfigure_use_saptune | d(true)
     - __sap_hana_preconfigure_verify_2684254_before.rc != 0
   block:
     - name: Revert SAP note 2684254

--- a/roles/sap_hana_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_15.yml
@@ -35,10 +35,6 @@ __sap_hana_preconfigure_packages:
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit
 
-  # 2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"
-  # 3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file
-  - libltdl7
-
   # Recommended for System monitoring
   - cpupower
   # - "{{ 'libcpupower0' if ansible_distribution_version.split('.')[1] | int < 6 else 'libcpupower1' }}"

--- a/roles/sap_hana_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_15.yml
@@ -23,10 +23,13 @@ __sap_hana_preconfigure_sapnotes_versions:
   # 1771258 - Linux: User and system resource limits
   # Limits are created by applying saptune solution or predefined in sapconf.
 
+__sap_hana_preconfigure_patterns:
+  - sap_server
+  # sap-hana pattern is not part of SLES, but SLES_SAP
 
 __sap_hana_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-server-enterprise-sap_server
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
@@ -35,10 +35,6 @@ __sap_hana_preconfigure_packages:
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit
 
-  # 2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"
-  # 3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file
-  - libltdl7
-
   # Recommended for System monitoring
   - cpupower
   # - "{{ 'libcpupower0' if ansible_distribution_version.split('.')[1] | int < 6 else 'libcpupower1' }}"

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
@@ -22,11 +22,13 @@ __sap_hana_preconfigure_sapnotes_versions:
   # 1771258 - Linux: User and system resource limits
   # Limits are created by applying saptune solution or predefined in sapconf.
 
+__sap_hana_preconfigure_patterns:
+  - sap_server
+  - sap-hana
 
 __sap_hana_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-server-enterprise-sap_server
-  - patterns-sap-hana
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
@@ -23,10 +23,6 @@ __sap_hana_preconfigure_packages:
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit
 
-  # 2998886 - SAP HANA DB installation fails with "hdbnsutil: error while loading shared libraries"
-  # 3029056 - Error while loading shared libraries: libltdl.so.7: cannot open shared object file
-  - libltdl7
-
   # Recommended for System monitoring
   - cpupower
   - libcpupower1

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
@@ -7,9 +7,13 @@ __sap_hana_preconfigure_sapnotes_versions: []
 
 __sap_hana_preconfigure_min_pkgs:
 
+__sap_hana_preconfigure_patterns:
+  - sles_minimal_sap
+  - sles_sap_DB
+
 __sap_hana_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-sap-DB
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh

--- a/roles/sap_hana_preconfigure/vars/main.yml
+++ b/roles/sap_hana_preconfigure/vars/main.yml
@@ -20,6 +20,7 @@ __sap_hana_preconfigure_req_repos_redhat_8_ppc64le: []
 __sap_hana_preconfigure_req_repos_redhat_9_x86_64: []
 __sap_hana_preconfigure_req_repos_redhat_9_ppc64le: []
 __sap_hana_preconfigure_packages: []
+__sap_hana_preconfigure_patterns: []
 __sap_hana_preconfigure_kernel_parameters_default: []
 __sap_hana_preconfigure_kernel_parameters_default_ppc64le: []
 __sap_hana_preconfigure_ibm_power_repo_url: ''

--- a/roles/sap_netweaver_preconfigure/README.md
+++ b/roles/sap_netweaver_preconfigure/README.md
@@ -122,6 +122,13 @@ This is useful if the role is used for reporting a system's SAP notes compliance
 The list of packages to be installed for SAP NETWEAVER.<br>
 The default for this variable is set in the vars file which corresponds to the detected OS version.<br>
 
+### sap_netweaver_preconfigure_patterns
+- _Type:_ `list` with elements of type `str`
+- _Default:_ (set by platform/environment specific variables)
+
+(SUSE specific) The list of the zypper patterns to install.<br>
+The default for this parameter is set in the vars file which corresponds to the detected OS version.<br>
+
 ### sap_netweaver_preconfigure_min_swap_space_mb
 - _Type:_ `str`
 - _Default:_ `20480`
@@ -163,4 +170,10 @@ Set this parameter to `true` when using Adobe Document Services, to ensure all r
 
 (SUSE specific) Specifies the saptune solution to apply.<br>
 Available values: `NETWEAVER`, `NETWEAVER+HANA`, `S4HANA-APP+DB`, `S4HANA-APPSERVER`, `S4HANA-DBSERVER`
+
+### sap_netweaver_preconfigure_saptune_solution_force
+- _Type:_ `bool`
+- _Default:_ `false`
+
+(SUSE specific) Apply saptune solution regardless if it is already enabled and verified.<br>
 <!-- END Role Variables -->

--- a/roles/sap_netweaver_preconfigure/defaults/main.yml
+++ b/roles/sap_netweaver_preconfigure/defaults/main.yml
@@ -20,6 +20,10 @@ sap_netweaver_preconfigure_packages: "{{ __sap_netweaver_preconfigure_packages }
 # The list of packages to be installed for SAP NETWEAVER.
 # The default for this variable is set in the vars file which corresponds to the detected OS version.
 
+sap_netweaver_preconfigure_patterns: "{{ __sap_netweaver_preconfigure_patterns }}"
+# (SUSE specific) The list of the zypper patterns to install.
+# The default for this parameter is set in the vars file which corresponds to the detected OS version.
+
 # Set this parameter to `true` to update the system to the latest package levels.
 sap_netweaver_preconfigure_update: false
 
@@ -43,3 +47,6 @@ sap_netweaver_preconfigure_saptune_version: ''
 # (SUSE specific) Saptune solution to be applied.
 # Available options for Netweaver are: NETWEAVER, NETWEAVER+HANA, S4HANA-APP+DB, S4HANA-APPSERVER, S4HANA-DBSERVER
 sap_netweaver_preconfigure_saptune_solution: NETWEAVER
+
+# (SUSE specific) Apply saptune solution regardless if it is already enabled and verified.
+sap_netweaver_preconfigure_saptune_solution_force: false

--- a/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_netweaver_preconfigure/meta/argument_specs.yml
@@ -57,6 +57,15 @@ argument_specs:
         type: list
         elements: str
 
+      sap_netweaver_preconfigure_patterns:
+        default: "{{ __sap_netweaver_preconfigure_patterns }}"
+        description:
+          - (SUSE specific) The list of the zypper patterns to install.
+          - The default for this parameter is set in the vars file which corresponds to the detected OS version.
+        required: false
+        type: list
+        elements: str
+
       sap_netweaver_preconfigure_min_swap_space_mb:
         default: '20480'
         description:
@@ -111,3 +120,10 @@ argument_specs:
           - 'S4HANA-DBSERVER'
         required: false
         type: str
+
+      sap_netweaver_preconfigure_saptune_solution_force:
+        default: false
+        description:
+          - (SUSE specific) Apply saptune solution regardless if it is already enabled and verified.
+        required: false
+        type: bool

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml
@@ -1,6 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __sap_netweaver_preconfigure_register_patterns
+  changed_when: false
+  ignore_errors: true
+
+- name: Assert that all required zypper patterns are installed
+  ansible.builtin.assert:
+    that: "'{{ item }}' in __sap_netweaver_preconfigure_register_patterns.stdout"
+    fail_msg: "FAIL: Pattern '{{ item }}' is not installed!"
+    success_msg: "PASS: Pattern '{{ item }}' is installed."
+  loop: "{{ sap_netweaver_preconfigure_patterns }}"
+  ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
+
 # Check rpm --whatprovides only if package cannot be found directly.
 - name: Query RPM packages
   ansible.builtin.shell:

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -1,6 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+- name: Get current enabled saptune solution
+  ansible.builtin.command:
+    cmd: "saptune solution enabled"
+  register: __sap_netweaver_preconfigure_register_solution_enabled
+  changed_when: false
+  failed_when: false
+  when: __sap_netweaver_preconfigure_use_saptune
+
+# Enabled solution contains newline, which has to be removed
+- name: Cleanup saptune solution enabled output
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_register_solution_enabled_trim:
+      "{{ __sap_netweaver_preconfigure_register_solution_enabled.stdout | trim | replace('\n', '') }}"
+  when: __sap_netweaver_preconfigure_use_saptune
+
 # Verify SAP Solution before block and revert if found invalid
 - name: Verify saptune solution before changes
   ansible.builtin.command:
@@ -8,13 +23,22 @@
   register: __sap_netweaver_preconfigure_register_solution_verify_before
   changed_when: false
   failed_when: false
-  when: __sap_netweaver_preconfigure_use_saptune
+  when:
+    - __sap_netweaver_preconfigure_use_saptune
+    - __sap_netweaver_preconfigure_register_solution_enabled_trim == sap_netweaver_preconfigure_saptune_solution
 
 - name: Apply saptune solution
   when:
     - __sap_netweaver_preconfigure_use_saptune
-    - __sap_netweaver_preconfigure_register_solution_verify_before.rc != 0
+    - sap_netweaver_preconfigure_saptune_solution_force
+      or __sap_netweaver_preconfigure_register_solution_enabled_trim != sap_netweaver_preconfigure_saptune_solution
+      or __sap_netweaver_preconfigure_register_solution_verify_before.rc != 0
   block:
+    - name: Show current enabled saptune solution
+      ansible.builtin.debug:
+        msg: "{{ __sap_netweaver_preconfigure_register_solution_enabled_trim }}"
+      when: __sap_netweaver_preconfigure_register_solution_enabled_trim != ''
+
     - name: Revert saptune configuration
       ansible.builtin.command:
         cmd: "saptune revert all"
@@ -38,6 +62,10 @@
           {{ __sap_netweaver_preconfigure_register_solution_verify_after.stdout_lines }}
           {{ __sap_netweaver_preconfigure_register_solution_verify_after.stderr_lines }}
       when: __sap_netweaver_preconfigure_register_solution_verify_after.rc != 0
+
+    - name: Show applied saptune solution
+      ansible.builtin.debug:
+        msg: "{{ sap_netweaver_preconfigure_saptune_solution }}"
 
 
 - name: Warn if not enough swap space is configured

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -62,29 +62,6 @@
       changed_when: false
 
 
-- name: Check active saptune solution
-  when:
-    - __sap_netweaver_preconfigure_use_saptune
-    - __sap_netweaver_preconfigure_register_saptune_check_before.rc == 0
-      or (__sap_netweaver_preconfigure_register_saptune_check_after.rc == 0)
-  block:
-    - name: Discover active solution
-      ansible.builtin.command:
-        cmd: saptune solution enabled
-      register: __sap_netweaver_preconfigure_register_saptune_status
-      changed_when: false
-
-    - name: Set fact for active solution
-      ansible.builtin.set_fact:
-        # Capture the first block on none whitespace
-        __sap_netweaver_preconfigure_register_solution_configured:
-          "{{ (__sap_netweaver_preconfigure_register_saptune_status.stdout | regex_search('(\\S+)', '\\1'))[0] | default('NONE') }}"
-
-    - name: Show configured solution
-      ansible.builtin.debug:
-        var: __sap_netweaver_preconfigure_register_solution_configured
-
-
 - name: Enable sapconf
   when: not __sap_netweaver_preconfigure_use_saptune
   block:

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
@@ -29,10 +29,21 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+# Pattern installation will run only if pattern is not installed
+# This ensures that command module shows correct changed status
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __sap_netweaver_preconfigure_register_patterns
+  changed_when: false
+  ignore_errors: true
+
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ sap_netweaver_preconfigure_patterns }}"
+  when: item not in __sap_netweaver_preconfigure_register_patterns.stdout
+  changed_when: item not in __sap_netweaver_preconfigure_register_patterns.stdout
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
@@ -29,6 +29,11 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+- name: Ensure that the required zypper patterns are installed
+  ansible.builtin.command:
+    cmd: zypper install -y -t pattern {{ item }}
+  loop: "{{ sap_netweaver_preconfigure_patterns }}"
+
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
     state: present

--- a/roles/sap_netweaver_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_netweaver_preconfigure/vars/SLES_15.yml
@@ -20,10 +20,13 @@ __sap_netweaver_preconfigure_sapnotes_versions: []
   # 900929 - Linux: STORAGE_PARAMETERS_WRONG_SET and "mmap() failed"
   # Parameter vm.max_map_count=2147483647 is already default value.
 
+__sap_netweaver_preconfigure_patterns:
+  - sap_server
+  # sap-nw pattern is not part of SLES, but SLES_SAP
 
 __sap_netweaver_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-server-enterprise-sap_server
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh
@@ -42,7 +45,6 @@ __sap_netweaver_preconfigure_packages:
   - nfs-utils
   - bind-utils
   - procmail
-  - libltdl7
 
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_netweaver_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_netweaver_preconfigure/vars/SLES_SAP_15.yml
@@ -20,11 +20,13 @@ __sap_netweaver_preconfigure_sapnotes_versions: []
   # 900929 - Linux: STORAGE_PARAMETERS_WRONG_SET and "mmap() failed"
   # Parameter vm.max_map_count=2147483647 is already default value.
 
+__sap_netweaver_preconfigure_patterns:
+  - sap_server
+  - sap-nw
 
 __sap_netweaver_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-server-enterprise-sap_server
-  - patterns-sap-nw
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh
@@ -43,7 +45,6 @@ __sap_netweaver_preconfigure_packages:
   - nfs-utils
   - bind-utils
   - procmail
-  - libltdl7
 
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_netweaver_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_netweaver_preconfigure/vars/SLES_SAP_16.yml
@@ -5,9 +5,13 @@
 
 __sap_netweaver_preconfigure_sapnotes_versions: []
 
+__sap_netweaver_preconfigure_patterns:
+  - sles_minimal_sap
+  - sles_sap_APP
+
 __sap_netweaver_preconfigure_packages:
-  # Mandatory patterns
-  - patterns-sap-APP
+  # Patterns are not included in package list
+  # Ansible package module skips recommended packages resulting in discrepancies.
 
   # Recommended packages
   - tcsh
@@ -32,7 +36,6 @@ __sap_netweaver_preconfigure_packages:
   - nfs-utils
   - bind-utils
   - procmail
-  - libltdl7
 
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_netweaver_preconfigure/vars/main.yml
+++ b/roles/sap_netweaver_preconfigure/vars/main.yml
@@ -7,3 +7,4 @@
 
 # dummy entry for passing the arg spec validation:
 __sap_netweaver_preconfigure_packages: []
+__sap_netweaver_preconfigure_patterns: []


### PR DESCRIPTION
### Description:
# New features
1. Introduced new variable with zypper patterns, which will be used with `command` instead of `package` module.
   - Reason: `package` module does not run zypper in default mode and it skips `Recommends` packages, resulting in discrepancines.
   - Example: Pattern `sap-hana` recommends packages that install `libltdl7`, but `package` will not install it when using rpm of pattern:  `patterns-sap-hana`
2. Introduced new variables `sap_hana_preconfigure_saptune_solution_force` and `sap_netweaver_preconfigure_saptune_solution_force` that allow forcing application of saptune solution regardless if it is already enabled and verified.
   - This follows recommendation that fresh re-enablement is always correct way to go, but variable is `false` by default.

# Fixes
3. Reverted commit https://github.com/sap-linuxlab/community.sap_install/commit/0dc982c2704b5a5c657c9432d9fb6a779fc73134
4. Fixed typo in saptune variable validation, resulting in skipping block
5. Re-enabled validation using `saptune solution enabled` after finding edge case where NETWEAVER can be successfully verified on host with HANA applied (overlap of parameters)
6. Updated RedHat specific variable comments with `(RedHat specific)` where appropriate: `sap_general_preconfigure_packagegroups`, `sap_general_preconfigure_envgroups`
7. Removed saptune solution enabled check from saptune_takeover as it is not necessary, since it is done in configuration step as well.

### Testing
All preconfigure roles were tested on SLES 15 SP6 and SLES4SAP 15 SP6