### PR TITLE
sap_swpm: remove duplicate section `credentials_anydb_ibmdb2`

### DIFF
--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -258,17 +258,6 @@ ora.SystemPassword = {{ sap_swpm_db_system_password }}
 #  END  section credentials_anydb_oracledb                        #
 ###################################################################
 {% endif %}
-{% if 'credentials_anydb_ibmdb2' in sap_swpm_inifile_sections_list %}
-
-###################################################################
-# BEGIN section credentials_anydb_ibmdb2                          #
-#                                                                 #
-nwUsers.db6.db2sidPassword = {{ sap_swpm_sap_sidadm_password }}
-# nwUsers.db6.db2sidUid =
-#                                                                 #
-#  END  section credentials_anydb_ibmdb2                          #
-###################################################################
-{% endif %}
 {% if 'credentials_anydb_sapase' in sap_swpm_inifile_sections_list %}
 
 ###################################################################


### PR DESCRIPTION
... from `templates/inifile_params.j2`

Solves #985. See also PR #982.