### PR TITLE
sap*preconfigure: sysctl checks fail when config file has comments

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-kernel-parameters.yml
@@ -17,7 +17,7 @@
 # in sap_general_preconfigure_etc_sysctl_sap_conf so that the "Reload kernel parameters from file ..." task
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
 - name: Construct the command for getting all current parameters of file '{{ sap_general_preconfigure_etc_sysctl_sap_conf }}'
-  ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}{printf ("%s ", $1)}' "{{ sap_general_preconfigure_etc_sysctl_sap_conf }}"
+  ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' "{{ sap_general_preconfigure_etc_sysctl_sap_conf }}"
   register: __sap_general_preconfigure_register_sap_conf_sysctl_command
   check_mode: false
   changed_when: false

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-kernel-parameters.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/configure-kernel-parameters.yml
@@ -17,7 +17,7 @@
 # in sap_general_preconfigure_etc_sysctl_sap_conf so that the "Reload kernel parameters from file ..." task
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
 - name: Construct the command for getting all current parameters of file '{{ sap_general_preconfigure_etc_sysctl_sap_conf }}'
-  ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' "{{ sap_general_preconfigure_etc_sysctl_sap_conf }}"
+  ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}NF>1&&!/^\s*[#;]/{printf ("%s ", $1)}' "{{ sap_general_preconfigure_etc_sysctl_sap_conf }}"
   register: __sap_general_preconfigure_register_sap_conf_sysctl_command
   check_mode: false
   changed_when: false

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2055470.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2055470.yml
@@ -71,7 +71,7 @@
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
 
     - name: Construct the command for getting all current parameters of file '/etc/sysctl.d/ibm_largesend.conf'
-      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' /etc/sysctl.d/ibm_largesend.conf
+      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}NF>1&&!/^\s*[#;]/{printf ("%s ", $1)}' /etc/sysctl.d/ibm_largesend.conf
       register: __sap_hana_preconfigure_register_ibm_largesend_sysctl_command
       changed_when: false
       when: not ansible_check_mode

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2055470.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2055470.yml
@@ -71,7 +71,7 @@
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
 
     - name: Construct the command for getting all current parameters of file '/etc/sysctl.d/ibm_largesend.conf'
-      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}{printf ("%s ", $1)}' /etc/sysctl.d/ibm_largesend.conf
+      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' /etc/sysctl.d/ibm_largesend.conf
       register: __sap_hana_preconfigure_register_ibm_largesend_sysctl_command
       changed_when: false
       when: not ansible_check_mode

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2382421.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2382421.yml
@@ -71,7 +71,7 @@
 # in __sap_hana_preconfigure_etc_sysctl_saphana_conf so that the "Reload kernel parameters from file ..." task
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
     - name: Construct the command for getting all current parameters of file '{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}'
-      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
+      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
       register: __sap_hana_preconfigure_register_saphana_conf_sysctl_command
       check_mode: false
       changed_when: false

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2382421.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2382421.yml
@@ -71,7 +71,7 @@
 # in __sap_hana_preconfigure_etc_sysctl_saphana_conf so that the "Reload kernel parameters from file ..." task
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
     - name: Construct the command for getting all current parameters of file '{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}'
-      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
+      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}NF>1&&!/^\s*[#;]/{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_saphana_conf }}"
       register: __sap_hana_preconfigure_register_saphana_conf_sysctl_command
       check_mode: false
       changed_when: false

--- a/roles/sap_hana_preconfigure/tasks/sapnote/3024346.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/3024346.yml
@@ -45,7 +45,7 @@
 # in __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf so that the "Reload kernel parameters from file ..." task
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
     - name: Construct the command for getting all current parameters of file '{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}'
-      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}"
+      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}"
       register: __sap_hana_preconfigure_register_netapp_sysctl_command
       changed_when: false
 

--- a/roles/sap_hana_preconfigure/tasks/sapnote/3024346.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/3024346.yml
@@ -45,7 +45,7 @@
 # in __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf so that the "Reload kernel parameters from file ..." task
 # can correctly report its 'changed' state. See also https://github.com/sap-linuxlab/community.sap_install/issues/752 .
     - name: Construct the command for getting all current parameters of file '{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}'
-      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")} !/^#/{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}"
+      ansible.builtin.command: awk 'BEGIN{FS="="; printf ("sysctl ")}NF>1&&!/^\s*[#;]/{printf ("%s ", $1)}' "{{ __sap_hana_preconfigure_etc_sysctl_netapp_hana_conf }}"
       register: __sap_hana_preconfigure_register_netapp_sysctl_command
       changed_when: false
 


### PR DESCRIPTION
Hi @berndfinger,

PR#807 introduced checks of kernel parameters to support indepotency.
However, under very rare circumstances when the sysctl conf files contain comments (#) this check fails as the awk command includes the line with the comments as a kernel parameter to check.
It generates something like:
```sysctl #This is comment net.ipv4.tcp_rmem```

This PR makes a minor change to make awk exclude all lines starting with # (i.e. ^#).

Kudos @James-Allen_nbs.