### PR TITLE
Collection: fix documentation link in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -58,7 +58,7 @@ dependencies: {}
 repository: https://github.com/sap-linuxlab/community.sap_install
 
 # The URL to any online docs
-documentation: https://github.com/sap-linuxlab/sap-linuxlab.github.io/blob/master/README.md
+documentation: https://github.com/sap-linuxlab/community.sap_install/blob/main/README.md
 
 # The URL to the homepage of the collection/project
 homepage: https://sap-linuxlab.github.io


### PR DESCRIPTION
### Description
Fix for link https://github.com/sap-linuxlab/sap-linuxlab.github.io/blob/master/README.md in galaxy documentation, which does not contain any documentation.

Correct link: https://github.com/sap-linuxlab/community.sap_install/blob/main/README.md