### PR TITLE
sap_swpm: Remove selinux role dependency from README.md

### DIFF
--- a/roles/sap_swpm/README.md
+++ b/roles/sap_swpm/README.md
@@ -9,12 +9,6 @@ The Ansible role `sap_swpm` installs various SAP Systems installable by SAP Soft
 <!-- END Description -->
 
 <!-- BEGIN Dependencies -->
-## Dependencies
-- `fedora.linux_system_roles`
-    - Roles:
-        - `selinux`
-
-Install required collections by `ansible-galaxy collection install -vv -r meta/collection-requirements.yml`.
 <!-- END Dependencies -->
 
 ## Prerequisites


### PR DESCRIPTION
The selinux role is not called from sap_swpm, so the Dependencies section in README.md needs to be empty.