### PR TITLE
Add extra when for change user expire setting

### DIFF
--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -25,6 +25,7 @@
       become: true
       register: __sap_hana_install_post_install_register_sidadm_noexpire
       changed_when: __sap_hana_install_post_install_register_sidadm_noexpire.rc == 0
+      when: sap_hana_install_set_sidadm_noexpire | default(true)
 
     - name: SAP HANA Post Install - Recreate the initial tenant database
       ansible.builtin.include_tasks: post_install/recreate_tenant_database.yml


### PR DESCRIPTION
I have some central managed users and I'm not able to change them. This option would allow the playbook not to fail in this step.