### PR TITLE
sap_hana_install: Add opt-out for setting sidadm to noexpire 

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -433,6 +433,14 @@ Available values: `none`, `size`, `sha256`, `ima`.
 Set to `False` to install SAP HANA even if the `sidadm` user exists.</br>
 Default is `True`, in which case the installation will not be performed if the `sidadm` user exists.
 
+### sap_hana_install_set_sidadm_noexpire
+
+- _Type:_ `bool`
+- _Default:_ `true`
+
+Set to `true` to ensure the SAP system user `{{ sap_hana_install_sid | lower }}adm` is configured with a non-expiring password.
+Set to `false` to skip this step — typically done when the user is managed by a central identity provider (e.g. Active Directory or LDAP).
+
 ### sap_hana_install_new_system
 
 - _Type:_ `bool`

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -113,10 +113,6 @@ sap_hana_install_check_sidadm_user: true
 # an existing HANA system.
 sap_hana_install_new_system: true
 
-# Set to `true` to ensure the SAP system user '{{ sid | lower }}adm' is non-expiring.
-# Set to `false` to skip this step — typically used when the user is domain-managed.
-sap_hana_install_set_sidadm_noexpire: true
-
 # The first tenant database is using a port range not within the range of the ports of additional tenant databases.
 # In case this is not desired, you can set the following parameter to `true` to recreate the initial tenant database.
 sap_hana_install_recreate_tenant_database: false
@@ -218,6 +214,10 @@ sap_hana_install_certificates_hostmap:
 
 # If the following variable is set to `y`, the role will start SAP HANA after each system boot.
 sap_hana_install_system_restart: 'n'
+
+# Set to `true` to ensure the SAP system user '{{ sid | lower }}adm' is non-expiring.
+# Set to `false` to skip this step — typically used when the user is domain-managed.
+sap_hana_install_set_sidadm_noexpire: true
 
 # If the following variable is undefined or set to `y`, the role will create an initial tenant database.
 # corresponding entry in the hdblcm configfile:

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -113,6 +113,10 @@ sap_hana_install_check_sidadm_user: true
 # an existing HANA system.
 sap_hana_install_new_system: true
 
+# Set to `true` to ensure the SAP system user '{{ sid | lower }}adm' is non-expiring.
+# Set to `false` to skip this step — typically used when the user is domain-managed.
+sap_hana_install_set_sidadm_noexpire: true
+
 # The first tenant database is using a port range not within the range of the ports of additional tenant databases.
 # In case this is not desired, you can set the following parameter to `true` to recreate the initial tenant database.
 sap_hana_install_recreate_tenant_database: false

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -25,6 +25,7 @@
       become: true
       register: __sap_hana_install_post_install_register_sidadm_noexpire
       changed_when: __sap_hana_install_post_install_register_sidadm_noexpire.rc == 0
+      when: sap_hana_install_set_sidadm_noexpire | default(true)
 
     - name: SAP HANA Post Install - Recreate the initial tenant database
       ansible.builtin.include_tasks: post_install/recreate_tenant_database.yml


### PR DESCRIPTION
I have some central managed users and I'm not able to change them. This option would allow the playbook not to fail in this step.