### PR TITLE
sap_swpm: Add opt-out for setting sidadm to noexpire

### DIFF
--- a/roles/sap_swpm/README.md
+++ b/roles/sap_swpm/README.md
@@ -72,6 +72,8 @@ Note: For most scenarios, a database like SAP HANA must be available. Use the ro
 
 - (Optional) Update `/etc/hosts` if `sap_swpm_update_etchosts` is set to `true` (Default: `false`).
 
+- (Optional) Do not disable password expiry if `sap_swpm_set_sidadm_noexpire` is set to `false` (Default: `true`).
+
 - (Optional) Apply firewall rules for SAP HANA if `sap_swpm_setup_firewall` is set to `true` (Default: `false`).
 
 - At this stage, the role is searching for a sapinst inifile on the managed node, or it will create one:

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -441,6 +441,9 @@ sap_swpm_swpm_installation_header: ""
 sap_swpm_swpm_command_virtual_hostname: ""
 sap_swpm_swpm_command_mp_stack: ""
 
+# Set linux user password expiry settings
+sap_swpm_set_sidadm_noexpire: true
+
 # Firewall setup
 sap_swpm_setup_firewall: false
 

--- a/roles/sap_swpm/tasks/post_install.yml
+++ b/roles/sap_swpm/tasks/post_install.yml
@@ -11,6 +11,7 @@
   become: true
   register: __sap_swpm_post_install_register_sidadm_noexpire
   changed_when: __sap_swpm_post_install_register_sidadm_noexpire is succeeded
+  when: sap_swpm_set_sidadm_noexpire | default(true)
 
 # Firewall
 


### PR DESCRIPTION
I've central managed users and the ansible code should be able to not run the changes to the linux users.