### PR TITLE
sap_storage_setup: Allow /software NFS mount

### DIFF
--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
@@ -83,6 +83,14 @@
           }
         ]) %}
 
+      {%- elif nfs_item.mountpoint | regex_replace('/$', '') == '/software' -%}
+        {%- set add_software = mount_list.extend([
+          {
+            'mount_src': nfs_item.nfs_path | regex_replace('/$', ''),
+            'mountpoint': nfs_item.mountpoint | regex_replace('/$', ''),
+          }
+        ]) %}
+
       {%- endif %}
       {{ mount_list }}
 


### PR DESCRIPTION
## Description
We are using `/software` as preferred software location in playbooks and most of our roles, so it makes sense to actually allow its mounting using role.

This will allow following simple adjustment to mount software without downloading:
```yaml
storage_definition:
  - name: software
    mountpoint: /software
    nfs_path: ''
    nfs_server: "{{ sap_vm_provision_nfs_mount_point | default('') }}"
    nfs_filesystem_type: "{{ sap_vm_provision_nfs_mount_point_type | default('') }}"
    nfs_mount_options: "{{ sap_vm_provision_nfs_mount_point_opts | default('') }}"
```

### nfs_path
This parameter results in behavior that does not align well with using NFS mount as source as it would create unnecessary subfolder. Keeping it empty will result in desired behavior.