### PR TITLE
sap_*_preconfigure/SUSE: Add retry attempts to zypper pattern installation 

### DIFF
--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -42,7 +42,7 @@
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ sap_general_preconfigure_patterns }}"
-  # Retry added to handle post scripts problems like RC 107 
+  # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10
   when: item not in __sap_general_preconfigure_register_patterns.stdout

--- a/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
@@ -42,7 +42,7 @@
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ sap_hana_preconfigure_patterns }}"
-  # Retry added to handle post scripts problems like RC 107 
+  # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10
   when: item not in __sap_hana_preconfigure_register_patterns.stdout

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
@@ -42,7 +42,7 @@
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ sap_netweaver_preconfigure_patterns }}"
-  # Retry added to handle post scripts problems like RC 107 
+  # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10
   when: item not in __sap_netweaver_preconfigure_register_patterns.stdout


### PR DESCRIPTION
## Description

Add 2 more attempts to `zypper -t pattern` installation to resolve issues with some pattern installations, in particular `sap-nw` for `sap_netweaver_preconfigure` role.