### PR TITLE
sap_maintain_etc_hosts: Fix domain set_fact logic which never triggered

### DIFF
--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -30,7 +30,9 @@
 
 - name: Ensure node_domain is set
   ansible.builtin.set_fact:
-    __sap_maintain_etc_hosts_domain: "{{ thishost.node_domain | default(sap_domain) | default(ansible_domain) }}"
+    __sap_maintain_etc_hosts_domain:
+      "{{ thishost.node_domain if thishost.node_domain is defined and thishost.node_domain != ''
+        else (sap_domain if sap_domain is defined and sap_domain != '' else ansible_domain | d('')) }}"
 
 - name: Verify that variable domain_name is set
   ansible.builtin.assert:


### PR DESCRIPTION
## Issue
`ansible_domain` is never undefined and when server does not have `/etc/hosts` in place, it will be `ansible_domain: ''`, therefore all those `d()` never triggered.

## Solution
Replace with IF/ELSE logic to check for `not defined and not empty` before using `sap_domain`