### PR TITLE
sap_ha_pacemaker_cluster: SLES16 support, new vars for ha_cluster for corosync and zypper patterns

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -10,7 +10,7 @@ The Ansible Role `sap_ha_pacemaker_cluster` is used to install and configure Lin
 
 <!-- BEGIN Dependencies -->
 ## Dependencies
-- `fedora.linux_system_roles`
+- `fedora.linux_system_roles`, commonly referenced as `LSR`.
     - Roles:
         - `ha_cluster`
 
@@ -1167,5 +1167,10 @@ Name of the NetWeaver SCS resource group.<br>
 - _Default:_ `rsc_vip_<SID>_SCS<SCS-instance-number>`<br>
 
 Name of the Virtual IP resource for NetWeaver Central Services (SCS).<br>
+
+### sap_ha_pacemaker_cluster_zypper_patterns
+- _Type:_ `list`<br>
+
+(SUSE Specific) Additional zypper patterns to be installed.<br>
 
 <!-- END Role Variables -->

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -73,6 +73,10 @@ sap_ha_pacemaker_cluster_cluster_properties:
 # score is dynamic and automatically increased for groups
 sap_ha_pacemaker_cluster_constraint_colo_base_score: 2000
 
+### Corosync variables
+sap_ha_pacemaker_cluster_corosync_totem: {}
+sap_ha_pacemaker_cluster_corosync_transport: {}
+
 ################################################################################
 # Inherit from 'ha_cluster' Linux System Role parameters when defined
 ################################################################################
@@ -86,6 +90,9 @@ sap_ha_pacemaker_cluster_extra_packages: []
 
 # Optional: additional fence agent packages. This is combined with the above "minimal" list.
 sap_ha_pacemaker_cluster_fence_agent_packages: []
+
+# (SUSE Specific) Optional list of zypper patterns to install.
+sap_ha_pacemaker_cluster_zypper_patterns: []
 
 # Mandatory.
 # Either inherit from the 'ha_cluster' LSR variable when defined, but do not set a default.

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -310,6 +310,37 @@ argument_specs:
             stonith-timeout: 900
             concurrent-fencing: true
 
+      sap_ha_pacemaker_cluster_corosync_totem:
+        type: dict
+        default: Specified in Operating System and Platform variables.
+        description:
+          - Define dictionary of options for corosync totem configuration.
+
+        example:
+          sap_ha_pacemaker_cluster_corosync_totem:
+            options:
+              token: 5000
+              token_retransmits_before_loss_const: 10
+              join: 60
+              consensus: 6000
+              max_messages: 20
+
+      sap_ha_pacemaker_cluster_corosync_transport:
+        type: dict
+        default: Specified in Operating System variables.
+        description:
+          - Define dictionary of options for corosync transport configuration.
+          - Available options are defined in (LSR `ha_cluster` documentation)[https://github.com/linux-system-roles/ha_cluster/blob/main/README.md].
+
+        example:
+          sap_ha_pacemaker_cluster_corosync_transport:
+            type: knet
+            crypto:
+              - name: crypto_hash
+                value: sha256
+              - name: crypto_cipher
+                value: aes256
+
 
       ##########################################################################
       # Parameters that are optionally imported from 'ha_cluster' LSR parameters
@@ -353,6 +384,11 @@ argument_specs:
           - "This is automatically combined with default packages in:"
           - "`__sap_ha_pacemaker_cluster_fence_agent_packages_minimal`"
           - "`__sap_ha_pacemaker_cluster_fence_agent_packages_platform`"
+
+      sap_ha_pacemaker_cluster_zypper_patterns:
+        type: list
+        description:
+          - (SUSE Specific) Additional zypper patterns to be installed.
 
       sap_ha_pacemaker_cluster_hacluster_user_password:
         description:

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_hana_scaleup.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/post_steps_hana_scaleup.yml
@@ -13,12 +13,12 @@
      else __sap_ha_pacemaker_cluster_hanacontroller_resource_name }}
   changed_when: true
 
-- name: "SAP HA Install Pacemaker - SAPHana clone crm resource refresh"
-  ansible.builtin.command:
-    cmd: crm resource refresh {{ __sap_ha_pacemaker_cluster_hana_resource_clone_name
-     if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
-     else __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}
-  changed_when: true
+# - name: "SAP HA Install Pacemaker - SAPHana clone crm resource refresh"
+#   ansible.builtin.command:
+#     cmd: crm resource refresh {{ __sap_ha_pacemaker_cluster_hana_resource_clone_name
+#      if not __sap_ha_pacemaker_cluster_saphanasr_angi_available
+#      else __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}
+#   changed_when: true
 
 - name: "SAP HA Install Pacemaker - Wait for SAP HANA to become idle"
   ansible.builtin.command:

--- a/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/Suse/pre_steps_hana.yml
@@ -6,9 +6,13 @@
 # This is destructive step if executed on running cluster
 # without proper migration from SAPHanaSR to SAPHanaSR-angi!
 
+# SLES_SAP 16 includes only SAPHanaSR-angi and SAPHanaSR tasks are skipped.
+
 
 - name: "SAP HA Prepare Pacemaker - Block for preparation of SAPHanaSR-angi HANA cluster"
-  when: (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
+  when:
+    - sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool
+    - ansible_distribution_major_version | int < 16
   block:
     - name: Query package SAPHanaSR  # noqa command-instead-of-module
       ansible.builtin.command:
@@ -38,8 +42,6 @@
         - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
         - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
         - __sap_ha_pacemaker_cluster_rpm_query_saphanasr.rc == 0
-        # SAPHanaSR (Classic) is not available on SLES 16
-        - ansible_distribution_major_version | int < 16
 
     - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
       ansible.builtin.set_fact:
@@ -52,7 +54,6 @@
 - name: "SAP HA Prepare Pacemaker - Block for preparation of Classic HANA cluster"
   when:
     - not (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
-    # SAPHanaSR (Classic) is not available on SLES 16
     - ansible_distribution_major_version | int < 16
   block:
     - name: Query package SAPHanaSR-angi  # noqa command-instead-of-module

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
@@ -86,6 +86,11 @@
   ansible.builtin.set_fact:
     ha_cluster_extra_packages: "{{ __sap_ha_pacemaker_cluster_extra_packages }}"
 
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_zypper_patterns'"
+  when: __sap_ha_pacemaker_cluster_zypper_patterns is defined and ansible_os_family == 'Suse'
+  ansible.builtin.set_fact:
+    ha_cluster_zypper_patterns: "{{ __sap_ha_pacemaker_cluster_zypper_patterns }}"
+
 - name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_fence_agent_packages'"
   when: __sap_ha_pacemaker_cluster_fence_agent_packages is defined
   ansible.builtin.set_fact:
@@ -122,6 +127,11 @@
   when: __sap_ha_pacemaker_cluster_corosync_totem is defined
   ansible.builtin.set_fact:
     ha_cluster_totem: "{{ __sap_ha_pacemaker_cluster_corosync_totem }}"
+
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_transport'"
+  when: __sap_ha_pacemaker_cluster_corosync_transport is defined
+  ansible.builtin.set_fact:
+    ha_cluster_transport: "{{ __sap_ha_pacemaker_cluster_corosync_transport }}"
 
 - name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_options'"
   when: __sap_ha_pacemaker_cluster_sbd_options is defined

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -54,6 +54,13 @@
       | unique | select() }}"
   # remove duplicates and empty elements
 
+- name: "SAP HA Prepare Pacemaker - Combine zypper patterns"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_zypper_patterns: "{{
+      (sap_ha_pacemaker_cluster_zypper_patterns
+      + __sap_ha_pacemaker_cluster_sap_zypper_patterns)
+      | unique | select() }}"
+  when: ansible_os_family == 'Suse'
 
 # Combine following fence packages together:
 # __sap_ha_pacemaker_cluster_fence_agent_packages_minimal -> os default
@@ -120,5 +127,17 @@
           }]) -%}
       {%- endfor %}
       {{ new_opts }}
+
+
+# Prepare corosync transport variable with either:
+# - User provided sap_ha_pacemaker_cluster_corosync_transport if present
+# - Default __sap_ha_pacemaker_cluster_corosync_transport_default from OS variables
+- name: "SAP HA Prepare Pacemaker - Prepare corosync transport settings"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_corosync_transport:
+      "{{ sap_ha_pacemaker_cluster_corosync_transport
+        if sap_ha_pacemaker_cluster_corosync_transport is defined and sap_ha_pacemaker_cluster_corosync_transport | length > 0
+        else __sap_ha_pacemaker_cluster_corosync_transport_default | d({}) }}"
+
 
 # TODO: Add support for ha_cluster_quorum

--- a/roles/sap_ha_pacemaker_cluster/vars/SLES_15.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/SLES_15.yml
@@ -6,8 +6,6 @@
 
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
   minimal:
-    # Pattern contains all required cluster packages
-    - patterns-ha-ha_sles
     - ClusterTools2
   hana_scaleout:
     - SAPHanaSR-ScaleOut
@@ -18,3 +16,11 @@ __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
   nwas:
     - sap-suse-cluster-connector
     - sapstartsrv-resource-agents
+
+# Dictionary with zypper patterns for specific scenarios
+__sap_ha_pacemaker_cluster_sap_zypper_patterns_dict:
+  minimal:
+    - ha_sles
+  hana_scaleout: []
+  hana_scaleup: []
+  nwas: []

--- a/roles/sap_ha_pacemaker_cluster/vars/SLES_16.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/SLES_16.yml
@@ -5,15 +5,24 @@
 # - SUSE Linux Enterprise Server 16
 
 # Dictionary with additional cluster packages for specific scenarios
+# All packages are included in patterns
 __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
-  minimal: []  # All minimal packages are part of patterns
+  minimal: []
+  hana_scaleout: []
+  hana_scaleup: []
+  hana_angi: []
+  nwas: []
+
+# Dictionary with zypper patterns for specific scenarios
+__sap_ha_pacemaker_cluster_sap_zypper_patterns_dict:
+  minimal:
+    - ha_sles
   hana_scaleout:
-    - patterns-sap-HADB
+    - sles_sap_HADB
   hana_scaleup:
-    - patterns-sap-HADB
-  hana_angi: []  # SAPHanaSR-angi package is part of patterns-sap-HADB
+    - sles_sap_HADB
   nwas:
-    - patterns-sap-HAAPP
+    - sles_sap_HAAPP
 
 # Package list was simplified because of new patterns below:
 
@@ -33,3 +42,12 @@ __sap_ha_pacemaker_cluster_sap_extra_packages_dict:
 # - ClusterTools2
 # - supportutils-plugin-ha-sap
 # - socat
+
+# Default corosync transport options
+__sap_ha_pacemaker_cluster_corosync_transport_default:
+  type: knet
+  crypto:
+    - name: crypto_hash
+      value: sha256
+    - name: crypto_cipher
+      value: aes256

--- a/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
@@ -27,6 +27,10 @@ __sap_ha_pacemaker_cluster_corosync_totem_default:
     consensus: 6000
     max_messages: 20
 
+# Default corosync transport options
+__sap_ha_pacemaker_cluster_corosync_transport_default:
+  type: udpu
+
 # Make sure that there is always the minimal default fed into the included role.
 # This is combined with the custom list 'sap_ha_pacemaker_cluster_fence_agent_packages'.
 __sap_ha_pacemaker_cluster_fence_agent_packages_minimal:
@@ -51,8 +55,11 @@ __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
 
 # Dictionary with additional cluster packages for specific scenarios
 # All packages are defined in SLES_15 and SLES_16 var files.
-__sap_ha_pacemaker_cluster_sap_extra_packages_dict:
-  {}
+__sap_ha_pacemaker_cluster_sap_extra_packages_dict: {}
+
+# Dictionary with zypper patterns for specific scenarios
+# All zypper patterns are defined in SLES_15 and SLES_16 var files.
+__sap_ha_pacemaker_cluster_sap_zypper_patterns_dict: {}
 
 # Dictionary with preferred platform specific VIP method that differs from default
 __sap_ha_pacemaker_cluster_vip_method_dict:

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_perf.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleout_perf.yml
@@ -13,4 +13,9 @@ __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
     if __sap_ha_pacemaker_cluster_saphanasr_angi_available
     else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_scaleout) }}"
 
+# SUSE Specific: Combine list of zypper patterns
+__sap_ha_pacemaker_cluster_sap_zypper_patterns: "{{
+  __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict.minimal | d([])
+  + __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict.hana_scaleout | d([]) }}"
+
 sap_ha_pacemaker_cluster_hadr_provider_name: SAPHanaSR

--- a/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/hana_scaleup_perf.yml
@@ -13,6 +13,11 @@ __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
     if __sap_ha_pacemaker_cluster_saphanasr_angi_available
     else __sap_ha_pacemaker_cluster_sap_extra_packages_dict.hana_scaleup) }}"
 
+# SUSE Specific: Combine list of zypper patterns
+__sap_ha_pacemaker_cluster_sap_zypper_patterns: "{{
+  __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict.minimal | d([])
+  + __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict.hana_scaleup | d([]) }}"
+
 # Set variable with dictionary name based on angi availability
 __sap_ha_pacemaker_cluster_hana_hook_dictionary:
   "{{ '__sap_ha_pacemaker_cluster_hook_'

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -94,6 +94,7 @@ __sap_ha_pacemaker_cluster_pcmk_host_map: ''
 __sap_ha_pacemaker_cluster_sap_extra_packages: []
 __sap_ha_pacemaker_cluster_platform_extra_packages: []
 __sap_ha_pacemaker_cluster_fence_agent_packages_platform: []
+__sap_ha_pacemaker_cluster_sap_zypper_patterns: []
 
 __sap_ha_pacemaker_cluster_cluster_properties: []
 __sap_ha_pacemaker_cluster_resource_defaults:

--- a/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/nwas_common.yml
@@ -11,3 +11,8 @@
 __sap_ha_pacemaker_cluster_sap_extra_packages: "{{
   __sap_ha_pacemaker_cluster_sap_extra_packages_dict.minimal | d([])
   + __sap_ha_pacemaker_cluster_sap_extra_packages_dict.nwas | unique }}"
+
+# SUSE Specific: Combine list of zypper patterns
+__sap_ha_pacemaker_cluster_sap_zypper_patterns: "{{
+  __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict.minimal | d([])
+  + __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict.nwas | d([]) }}"


### PR DESCRIPTION
## Changes
- SLES 16 variables
- New corosync variables for `ha_cluster` added
- New zypper pattern variables for `ha_cluster` added

## Tested
Changes were tested on SLES4SAP 15 SP6 and 16 for both SAP HANA HA and SAP ASCS/ERS clusters.