### PR TITLE
sap_*_preconfigure/SUSE: Update SLES16 pattern names and add packages for hardened images

### DIFF
--- a/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -2,6 +2,7 @@
 ---
 # 1275776 - Linux: Preparing SLES for SAP environments
 
+# saptune_check fails if 'saptune service takeover' was not executed.
 - name: Execute saptune_check - before takeover
   ansible.builtin.command:
     cmd: saptune_check
@@ -10,10 +11,12 @@
   changed_when: false
   failed_when: false
 
-- name: Takeover and enable saptune
+- name: Takeover saptune
   when:
     - __sap_general_preconfigure_use_saptune
     - __sap_general_preconfigure_register_saptune_check_before.rc != 0
+    # sapconf is not present on SLES 16 and takeover is not required.
+    - ansible_distribution_major_version | int < 16
   block:
     - name: Check saptune version  # noqa: command-instead-of-module
       ansible.builtin.command:
@@ -27,7 +30,7 @@
         name: sapconf
         state: stopped
         enabled: false
-      when: __sap_general_preconfigure_register_sapconf
+      when: __sap_general_preconfigure_register_sapconf.rc == 0
 
     - name: Make sure that sapconf and tuned are stopped and disabled
       ansible.builtin.command:
@@ -42,13 +45,21 @@
       register: __sap_general_preconfigure_register_sapconf_failed
       changed_when: false
       ignore_errors: true
+      when: __sap_general_preconfigure_register_sapconf.rc == 0
 
     - name: Execute systemctl reset-failed sapconf.service  # noqa command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl reset-failed sapconf.service
-      when: __sap_general_preconfigure_register_sapconf_failed.rc == 0
+      when:
+        - __sap_general_preconfigure_register_sapconf.rc == 0
+        - __sap_general_preconfigure_register_sapconf_failed.rc == 0
       changed_when: true
 
+
+- name: Enable saptune service
+  when:
+    - __sap_general_preconfigure_use_saptune
+  block:
     - name: Ensure saptune is running and enabled
       ansible.builtin.systemd:
         name: saptune

--- a/roles/sap_general_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_15.yml
@@ -23,6 +23,9 @@ __sap_general_preconfigure_packages:
   - bind-utils
   - hostname
 
+  # Required for zypper ps
+  - lsof
+
 # Packages specific for SAP Note 2578899
 # Their services are enabled using __sap_general_preconfigure_services_2578899
 __sap_general_preconfigure_packages_2578899:

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
@@ -24,6 +24,9 @@ __sap_general_preconfigure_packages:
   - nfs-utils
   - bind-utils
 
+  # Required for zypper ps
+  - lsof
+
 # Packages specific for SAP Note 2578899
 # Their services are enabled using __sap_general_preconfigure_services_2578899
 __sap_general_preconfigure_packages_2578899:

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
@@ -6,7 +6,7 @@
 __sap_general_preconfigure_sapnotes_versions: []
 
 __sap_general_preconfigure_patterns:
-  - sles_minimal_sap
+  - sles_sap_minimal_sap
 
 __sap_general_preconfigure_packages:
   # Patterns are not included in package list

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
@@ -25,6 +25,8 @@ __sap_general_preconfigure_packages:
   - nfs-utils
   - bind-utils
 
+  # Required for zypper ps
+  - lsof
 
 __sap_general_preconfigure_min_pkgs: []
 __sap_general_preconfigure_packagegroups:

--- a/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -10,10 +10,12 @@
   changed_when: false
   failed_when: false
 
-- name: Takeover and enable saptune
+- name: Takeover saptune
   when:
     - __sap_hana_preconfigure_use_saptune
     - __sap_hana_preconfigure_register_saptune_check_before.rc != 0
+    # sapconf is not present on SLES 16 and takeover is not required.
+    - ansible_distribution_major_version | int < 16
   block:
     - name: Check saptune version  # noqa: command-instead-of-module
       ansible.builtin.command:
@@ -27,7 +29,7 @@
         name: sapconf
         state: stopped
         enabled: false
-      when: __sap_hana_preconfigure_register_sapconf
+      when: __sap_hana_preconfigure_register_sapconf.rc == 0
 
     - name: Make sure that sapconf and tuned are stopped and disabled
       ansible.builtin.command:
@@ -49,6 +51,11 @@
       when: __sap_hana_preconfigure_register_sapconf_failed.rc == 0
       changed_when: true
 
+
+- name: Enable saptune service
+  when:
+    - __sap_hana_preconfigure_use_saptune
+  block:
     - name: Ensure saptune is running and enabled
       ansible.builtin.systemd:
         name: saptune

--- a/roles/sap_hana_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_15.yml
@@ -92,6 +92,7 @@ __sap_hana_preconfigure_packages_2684254:
   - libssh2-1
   - libopenssl1_1
   - insserv-compat
+  - libltdl7
 
 __sap_hana_preconfigure_min_pkgs:
 

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
@@ -58,6 +58,7 @@ __sap_hana_preconfigure_packages_2684254:
   - libssh2-1
   - libopenssl1_1
   - insserv-compat
+  - libltdl7
 
 
 __sap_hana_preconfigure_min_pkgs:

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
@@ -4,11 +4,13 @@
 # - SUSE Linux Enterprise Server for SAP Applications 16
 
 __sap_hana_preconfigure_sapnotes_versions: []
+  # 3577842 - - SAP HANA DB: Recommended OS settings for SLES 16 / SLES for SAP Applications 16
+  # - { number: '3577842', version: '1' }
 
 __sap_hana_preconfigure_min_pkgs:
 
 __sap_hana_preconfigure_patterns:
-  - sles_minimal_sap
+  - sles_sap_minimal_sap
   - sles_sap_DB
 
 __sap_hana_preconfigure_packages:
@@ -23,6 +25,9 @@ __sap_hana_preconfigure_packages:
   - uuidd
   - sysstat
   - sysctl-logger
+
+  # 3577842
+  - libltdl7
 
   # 3139184 - Linux: systemd integration for sapstartsrv and SAP Host Agent
   - polkit

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -10,10 +10,12 @@
   changed_when: false
   failed_when: false
 
-- name: Takeover and enable saptune
+- name: Takeover saptune
   when:
     - __sap_netweaver_preconfigure_use_saptune
     - __sap_netweaver_preconfigure_register_saptune_check_before.rc != 0
+    # sapconf is not present on SLES 16 and takeover is not required.
+    - ansible_distribution_major_version | int < 16
   block:
     - name: Check saptune version  # noqa: command-instead-of-module
       ansible.builtin.command:
@@ -27,7 +29,7 @@
         name: sapconf
         state: stopped
         enabled: false
-      when: __sap_netweaver_preconfigure_register_sapconf
+      when: __sap_netweaver_preconfigure_register_sapconf.rc == 0
 
     - name: Make sure that sapconf and tuned are stopped and disabled
       ansible.builtin.command:
@@ -49,6 +51,11 @@
       when: __sap_netweaver_preconfigure_register_sapconf_failed.rc == 0
       changed_when: true
 
+
+- name: Enable saptune service
+  when:
+    - __sap_netweaver_preconfigure_use_saptune
+  block:
     - name: Ensure saptune is running and enabled
       ansible.builtin.systemd:
         name: saptune

--- a/roles/sap_netweaver_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_netweaver_preconfigure/vars/SLES_SAP_16.yml
@@ -6,7 +6,7 @@
 __sap_netweaver_preconfigure_sapnotes_versions: []
 
 __sap_netweaver_preconfigure_patterns:
-  - sles_minimal_sap
+  - sles_sap_minimal_sap
   - sles_sap_APP
 
 __sap_netweaver_preconfigure_packages:


### PR DESCRIPTION
## Changes
- Update SLES 16 pattern name
- Add `lsof` and `libltdl7` into dependencies for hardened images.
- Update saptune takeover steps to skip for SLES16, where sapconf is not present.