### PR TITLE
sap_ha_pacemaker_cluster: Remove NIC parameter from IPaddr2 resource agents

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -1098,6 +1098,8 @@ For RHEL System Roles for SAP, or Red Hat Automation Hub, use 'redhat.rhel_syste
 
 OS device name of the network interface to use for the Virtual IP configuration.<br>
 When there is only one interface on the system, its name will be used by default.<br>
+Ensure that same network interface is present on all cluster nodes.<br>
+IPaddr2 resource agent does not require network interface defined (except Google Cloud).<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_primary_ip_address
 - _Type:_ `string`<br>

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -154,6 +154,8 @@ argument_specs:
         description:
           - OS device name of the network interface to use for the Virtual IP configuration.
           - When there is only one interface on the system, its name will be used by default.
+          - Ensure that same network interface is present on all cluster nodes.
+          - IPaddr2 resource agent does not require network interface defined (except Google Cloud).
 
       sap_ha_pacemaker_cluster_stonith_custom:
         type: list

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_resources_default.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_vip_resources_default.yml
@@ -13,15 +13,22 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_vip] }}"
   vars:
+    __ipaddr_ip:
+      - name: ip
+        value: "{{ vip_list_item.value | quote }}"
+    # Create separate list for nic parameter only when it is defined and not empty.
+    __ipaddr_nic:
+      - name: nic
+        value: "{{ sap_ha_pacemaker_cluster_vip_client_interface | d('') }}"
+
     __resource_vip:
       id: "{{ vip_list_item.key }}"
       agent: "{{ __sap_ha_pacemaker_cluster_available_vip_agents['ipaddr'].agent }}"
       instance_attrs:
-        - attrs:
-            - name: ip
-              value: "{{ vip_list_item.value | quote }}"
-            - name: nic
-              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
+        # Combine both lists if sap_ha_pacemaker_cluster_vip_client_interface is defined and not empty.
+        - attrs: "{{ __ipaddr_ip + __ipaddr_nic
+            if sap_ha_pacemaker_cluster_vip_client_interface is defined and sap_ha_pacemaker_cluster_vip_client_interface | length > 0
+            else __ipaddr_ip }}"
   when:
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - sap_ha_pacemaker_cluster_vip_method == 'ipaddr' or

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_common.yml
@@ -8,21 +8,14 @@
   ansible.builtin.setup:
     gather_subset: hardware,interfaces
 
-# Multi-NIC:
-# Find out if there is more than one interface present, this will
-# be used for determining the target NIC for VIP configurations.
-# Assumption: The local loopback "lo" is always in the list.
-- name: "SAP HA Prepare Pacemaker - Set multi-NIC when more than one interface is found"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_nic_multi_bool: true
-  when:
-    - ansible_interfaces | length > 2
 
-- name: "SAP HA Prepare Pacemaker - Set interface name when only one interface is present"
+# Use default ipv4 interface when one interface is detected.
+# Assumption: The local loopback "lo" is always in the list.
+- name: "SAP HA Prepare Pacemaker - Set network interface name when only one interface is present"
   ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_vip_client_interface: "{{ ansible_default_ipv4.interface }}"
+    __sap_ha_pacemaker_cluster_vip_client_interface: "{{ ansible_default_ipv4.interface }}"
   when:
-    - not __sap_ha_pacemaker_cluster_nic_multi_bool
+    - ansible_interfaces | length <= 2
     - sap_ha_pacemaker_cluster_vip_client_interface == ''
 
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_aws_ec2_vs.yml
@@ -58,7 +58,7 @@
             - name: ip
               value: "{{ vip_list_item.value }}"
             - name: interface
-              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
+              value: "{{ __sap_ha_pacemaker_cluster_vip_client_interface | d(sap_ha_pacemaker_cluster_vip_client_interface) }}"
             - name: routing_table
               value: "{{ sap_ha_pacemaker_cluster_aws_vip_update_rt }}"
   when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_gcp_ce_vm.yml
@@ -22,8 +22,9 @@
               value: "{{ vip_list_item.value }}"
             - name: cidr_netmask
               value: 32
+            # IPaddr2 does not require 'nic' parameter, but GCP documentation includes it.
             - name: nic
-              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
+              value: "{{ __sap_ha_pacemaker_cluster_vip_client_interface | d(sap_ha_pacemaker_cluster_vip_client_interface) }}"
       operations:
         - action: monitor
           attrs:

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_cloud_ibmcloud_powervs.yml
@@ -6,17 +6,24 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_vip] }}"
   vars:
+    __ipaddr_ip_cidr:
+      - name: ip
+        value: "{{ vip_list_item.value | quote }}"
+      - name: cidr_netmask
+        value: "{{ __sap_ha_pacemaker_cluster_vip_client_interface_subnet_cidr.stdout | int }}"
+    # Create separate list for nic parameter only when it is defined and not empty.
+    __ipaddr_nic:
+      - name: nic
+        value: "{{ sap_ha_pacemaker_cluster_vip_client_interface | d('') }}"
+
     __resource_vip:
       id: "{{ vip_list_item.key }}"
       agent: "{{ __sap_ha_pacemaker_cluster_available_vip_agents[sap_ha_pacemaker_cluster_vip_method].agent }}"
       instance_attrs:
-        - attrs:
-            - name: ip
-              value: "{{ vip_list_item.value }}"
-            - name: cidr_netmask
-              value: "{{ __sap_ha_pacemaker_cluster_vip_client_interface_subnet_cidr.stdout | int }}"
-            - name: nic
-              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
+        # Combine both lists if sap_ha_pacemaker_cluster_vip_client_interface is defined and not empty.
+        - attrs: "{{ __ipaddr_ip_cidr + __ipaddr_nic
+            if sap_ha_pacemaker_cluster_vip_client_interface is defined and sap_ha_pacemaker_cluster_vip_client_interface | length > 0
+            else __ipaddr_ip_cidr }}"
   when:
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - sap_ha_pacemaker_cluster_vip_method == 'ipaddr_custom' or

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_hyp_ibmpower_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/construct_vars_vip_resources_hyp_ibmpower_vm.yml
@@ -6,15 +6,22 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives + [__resource_vip] }}"
   vars:
+    __ipaddr_ip:
+      - name: ip
+        value: "{{ vip_list_item.value | quote }}"
+    # Create separate list for nic parameter only when it is defined and not empty.
+    __ipaddr_nic:
+      - name: nic
+        value: "{{ sap_ha_pacemaker_cluster_vip_client_interface | d('') }}"
+
     __resource_vip:
       id: "{{ vip_list_item.key }}"
       agent: "{{ __sap_ha_pacemaker_cluster_available_vip_agents[sap_ha_pacemaker_cluster_vip_method].agent }}"
       instance_attrs:
-        - attrs:
-            - name: ip
-              value: "{{ vip_list_item.value }}"
-            - name: nic
-              value: "{{ sap_ha_pacemaker_cluster_vip_client_interface }}"
+        # Combine both lists if sap_ha_pacemaker_cluster_vip_client_interface is defined and not empty.
+        - attrs: "{{ __ipaddr_ip + __ipaddr_nic
+            if sap_ha_pacemaker_cluster_vip_client_interface is defined and sap_ha_pacemaker_cluster_vip_client_interface | length > 0
+            else __ipaddr_ip }}"
   when:
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - (sap_ha_pacemaker_cluster_vip_method == 'ipaddr') or

--- a/roles/sap_ha_pacemaker_cluster/tasks/platform/register_sysinfo_cloud_ibmcloud_powervs.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/platform/register_sysinfo_cloud_ibmcloud_powervs.yml
@@ -22,9 +22,11 @@
 - name: "SAP HA Prepare Pacemaker - IBM Cloud PowerVS - Calculate network interface subnet CIDR"
   ansible.builtin.shell: |
     set -o pipefail && ipcalc --prefix \
-     {{ ansible_facts[sap_ha_pacemaker_cluster_vip_client_interface].ipv4.network
-     + '/' + ansible_facts[sap_ha_pacemaker_cluster_vip_client_interface].ipv4.netmask }} \
+     {{ ansible_facts[__interface].ipv4.network
+     + '/' + ansible_facts[__interface].ipv4.netmask }} \
      | sed 's|PREFIX=||'
   register: __sap_ha_pacemaker_cluster_vip_client_interface_subnet_cidr
   changed_when: false
   check_mode: false
+  vars:
+    __interface: "{{ __sap_ha_pacemaker_cluster_vip_client_interface | d(sap_ha_pacemaker_cluster_vip_client_interface) }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -28,10 +28,6 @@ __sap_ha_pacemaker_cluster_required_facts:
 #  - virtualization_role # subset: virtual
 #  - virtualization_type # subset: virtual
 
-# By default assume non-multi-NIC configuration.
-# This is automatically adjusted during preparation tasks.
-__sap_ha_pacemaker_cluster_nic_multi_bool: false
-
 # By default use the construction of IPaddr2 VIP resources
 # Platforms define different methods out of optional agents, as applicable.
 sap_ha_pacemaker_cluster_vip_method: ipaddr


### PR DESCRIPTION
## Changes
`IPaddr2` resource agent does not require parameter `nic` when cluster node has only 1 network interface (2 if loopback is counted). This means we do not need to populate it unless required.

- Add conditional `attrs` creation, which will include `nic` parameter only if it is user defined.
- Replace default NIC assignment with internal variable `__sap_ha_pacemaker_cluster_vip_client_interface` that will run only if user did not specify `sap_ha_pacemaker_cluster_vip_client_interface`, but it is consumed only when required.
- Remove multi NIC variable `__sap_ha_pacemaker_cluster_nic_multi_bool` as it was not used.
- Update Readme with explanation.

**NOTE:** This change does not affect Google Cloud, as their documentation explicitly mentions `nic` parameter.

## Tested
This change was tested on:
SLES 15 on AWS
```console
primitive rsc_vip_AE1_ASCS00 aws-vpc-move-ip \
        params ip=192.168.2.20 interface=eth0 routing_table=rtb-x
primitive rsc_vip_AE1_ERS10 aws-vpc-move-ip \
        params ip=192.168.2.21 interface=eth0 routing_table=rtb-x
```

SLES 16 on premise
```console
primitive rsc_vip_AE1_ASCS00 IPaddr2 \
        params ip=10.144.75.101
primitive rsc_vip_AE1_ERS10 IPaddr2 \
        params ip=10.144.75.102
```