### PR TITLE
sap_hana_install: Enhance SAPCAR detection functionality and handling of multiple files

### DIFF
--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -174,6 +174,7 @@
       register: __sap_hana_install_register_find_directory_sap_hana_database_initial
       when: __sap_hana_install_register_stat_software_extract_directory.stat.exists
 
+    # All SAPCAR and SAR files pre_install steps will be skipped if role `sap_install_media_detect` successfully extracts software.
     - name: SAP HANA Pre Install - Set directory of 'hdblcm' from successful find result
       when:
         - __sap_hana_install_register_stat_software_extract_directory.stat.exists

--- a/roles/sap_hana_install/tasks/pre_install/prepare_sapcar.yml
+++ b/roles/sap_hana_install/tasks/pre_install/prepare_sapcar.yml
@@ -16,9 +16,9 @@
         msg: "FAIL: The SAPCAR EXE file '{{ __sap_hana_install_fact_software_directory }}/{{ sap_hana_install_sapcar_filename }}' does not exist!"
       when: not __sap_hana_install_register_sapcar_stat.stat.exists
 
-# We cannot always use the SAPCAR executable in __sap_hana_install_fact_software_directory because there are
-# some configurations in which executing files in this directory is not possible. So we always copy SAPCAR
-# to directory 'sapcar' in sap_hana_install_software_extract_directory. We do not copy the SAPCAR checksum file.
+    # We cannot always use the SAPCAR executable in __sap_hana_install_fact_software_directory because there are
+    # some configurations in which executing files in this directory is not possible. So we always copy SAPCAR
+    # to directory 'sapcar' in sap_hana_install_software_extract_directory. We do not copy the SAPCAR checksum file.
     - name: SAP HANA hdblcm prepare - SAPCAR defined - Copy the SAPCAR executable to '{{ sap_hana_install_software_extract_directory }}/sapcar'
       ansible.builtin.copy:
         src: "{{ __sap_hana_install_fact_software_directory }}/{{ sap_hana_install_sapcar_filename }}"
@@ -63,59 +63,73 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_selected_sapcar_filename: "{{ sap_hana_install_sapcar_filename }}"
 
-- name: SAP HANA hdblcm prepare - SAPCAR autodetection - Prepare the SAPCAR executable if 'sap_hana_install_sapcar_filename' is not defined
+- name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Prepare the SAPCAR executable if 'sap_hana_install_sapcar_filename' is not defined
   when: sap_hana_install_sapcar_filename is not defined
   block:
 
-# We need the 'file' package for the 'file' command, which we need in the next task.
-# RHEL: The 'file' package is contained in the Base software group, which should be installed already.
+    # Package 'file' is present in Base system, but this task ensures next task does not fail on hardened images.
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Ensure file package is present
+      ansible.builtin.package:
+        name: file
+        state: present
 
-# In the first step, we execute the file command for each of the SAPCAR EXE files. It displays the
-# hardware architecture in the second output field, using a string which is different from the output
-# of the 'uname -m' command. So we replace those strings by the "correct" ones. For ppc64 and ppc64le,
-# the second output field is identical. So in this case, we also look at the third and forth output field,
-# to handle cases where a ppc64 SAPCAR executable is present in the software directory.
-# After selecting the SAPCAR EXE files for the current architecture, we copy them to a temporary
-# directory sapcar_tmp in the software extract directory and then perform a checksum verification
-# for these files if the corresponding variable is set.
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Create directory '{{ sap_hana_install_software_extract_directory }}/sapcar_tmp'
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Create directory '{{ sap_hana_install_software_extract_directory }}/sapcar_tmp'
       ansible.builtin.file:
         path: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp"
         state: directory
         mode: '0755'
 
-# Reason for noqa: There are pipe symbols - as part of an or statement - in an awk command sequence.
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Identify matching SAR executables in '{{ __sap_hana_install_fact_software_directory }}' # noqa jinja[spacing]
-      ansible.builtin.shell: |
-          set -o pipefail &&
-          for sapcar_any in SAPCAR*EXE; do
-             file ${sapcar_any} | awk '{
-                split ($0, a, ":"); split (a[2], b, ","); sub ("^ ", "", b[2]);
-                sub ("x86-64", "x86_64", b[2]);
-                if (index (b[2], "64-bit PowerPC") > 0) {
-                   if ((index (b[3], "GNU/Linux") > 0)||(index (b[4], "GNU/Linux") > 0)) {sub ("64-bit PowerPC", "ppc64le", b[2])};
-                   if ((index (b[3], "SYSV") > 0)||(index (b[4], "SYSV") > 0)) {sub ("64-bit PowerPC", "ppc64", b[2])};
-                }
-                sub ("IBM S/390", "s390x", b[2]);
-                printf ("%s %s %s\n", a[1], b[2], b[3])}'
-             done | awk '$2=="{{ ansible_architecture }}"{printf ("%s\n", $1)}'
+    # In the first step, we execute the file command for each of the SAPCAR EXE files. It displays the
+    # hardware architecture in the second output field, using a string which is different from the output
+    # of the 'uname -m' command.
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Find matching SAR executables in '{{ __sap_hana_install_fact_software_directory }}'  # noqa risky-shell-pipe
+      ansible.builtin.shell:
+        cmd: find . -name 'SAPCAR*EXE' -exec file {} + | sed 's|^\./||'
       args:
         chdir: "{{ __sap_hana_install_fact_software_directory }}"
-      register: __sap_hana_install_register_sapcar_matching_arch
-      changed_when: no
+      register: __sap_hana_install_register_sapcar_file_contents
+      changed_when: false
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Fail if no matching SAPCAR executable could be found
+    # Loop through found files and compare them against search keywords for ansible_architecture.
+    # Supported combinations are defined in the variable '__sap_hana_install_architecture_matrix' in vars/main.yml file.
+    # Each platform can contain multiple search words. AND operator is achieved by counting all found keywords.
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Compare found files against the variable ansible_architecture
+      ansible.builtin.set_fact:
+        __sap_hana_install_register_sapcar_matching_arch: |
+          {%- set matching_files = [] -%}
+          {%- set rule_sets = __sap_hana_install_architecture_matrix.get(ansible_architecture, []) -%}
+          {%- if rule_sets -%}
+            {%- for line in __sap_hana_install_register_sapcar_file_contents.stdout_lines -%}
+              {%- set parts = line.split(': ', 1) -%}
+              {%- if parts | length > 1 -%}
+                {%- set filename = parts[0] -%}
+                {%- set file_info = parts[1] -%}
+
+                {# Create a list of boolean results for each rule set #}
+                {%- set rule_results = [] -%}
+                {%- for keyword_list in rule_sets -%}
+                  {%- set all_keywords_found = (keyword_list | select('in', file_info) | list | length) == (keyword_list | length) -%}
+                  {%- set _ = rule_results.append(all_keywords_found) -%}
+                {%- endfor -%}
+
+                {%- if true in rule_results -%}
+                  {%- set _ = matching_files.append(filename) -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
+          {%- endif -%}
+          {{- matching_files -}}
+
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Fail if no matching SAPCAR executable could be found
       ansible.builtin.fail:
         msg: "FAIL: No SAPCAR EXE file for architecture '{{ ansible_architecture }}' was found in
               {{ __sap_hana_install_fact_software_directory }}!"
-      when: __sap_hana_install_register_sapcar_matching_arch.stdout | length == 0
+      when: __sap_hana_install_register_sapcar_matching_arch | length == 0
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Create a list of files from SAPCAR executables of the matching architecture
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_sapcar_filenames_matching_arch: "{{ __sap_hana_install_fact_sapcar_filenames_matching_arch | d([]) + [item] }}"
-      loop: "{{ __sap_hana_install_register_sapcar_matching_arch.stdout_lines }}"
-
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Copy matching SAPCAR executables to '{{ sap_hana_install_software_extract_directory }}/sapcar_tmp/'
+    # After selecting the SAPCAR EXE files for the current architecture, we copy them to a temporary
+    # directory sapcar_tmp in the software extract directory and then perform a checksum verification
+    # for these files if the corresponding variable is set.
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Copy matching SAPCAR executables to '{{ sap_hana_install_software_extract_directory }}/sapcar_tmp/'
       ansible.builtin.copy:
         src: "{{ __sap_hana_install_fact_software_directory }}/{{ item }}"
         dest: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp/{{ item }}"
@@ -123,12 +137,12 @@
         owner: 'root'
         group: 'root'
         mode: '0755'
-      with_items: "{{ __sap_hana_install_fact_sapcar_filenames_matching_arch }}"
+      loop: "{{ __sap_hana_install_register_sapcar_matching_arch }}"
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Fill list of dicts containing dir, file, and global checksum file
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Fill list of dicts containing dir, file, and global checksum file
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_dict: "{{ __sap_hana_install_fact_sapcar_dict | d([]) + [__sap_hana_install_tmp_sapcar_dict] }}"
-      with_items: "{{ __sap_hana_install_fact_sapcar_filenames_matching_arch }}"
+      loop: "{{ __sap_hana_install_register_sapcar_matching_arch }}"
       vars:
         __sap_hana_install_tmp_sapcar_dict:
           dir: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp"
@@ -136,10 +150,10 @@
           checksum_file: "{{ sap_hana_install_global_checksum_file }}"
       when: sap_hana_install_global_checksum_file is defined
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Fill list of dicts containing dir, file, and specific checksum file
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Fill list of dicts containing dir, file, and specific checksum file
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_dict: "{{ __sap_hana_install_fact_sapcar_dict | d([]) + [__sap_hana_install_tmp_sapcar_dict] }}"
-      with_items: "{{ __sap_hana_install_fact_sapcar_filenames_matching_arch }}"
+      loop: "{{ __sap_hana_install_register_sapcar_matching_arch }}"
       vars:
         __sap_hana_install_tmp_sapcar_dict:
           dir: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp"
@@ -147,11 +161,7 @@
           checksum_file: "{{ __sap_hana_install_fact_software_directory }}/{{ item }}.sha256"
       when: sap_hana_install_global_checksum_file is not defined
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Display __sap_hana_install_fact_sapcar_dict
-      ansible.builtin.debug:
-        var: __sap_hana_install_fact_sapcar_dict
-
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Verify checksum for SAPCAR executables
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Verify checksum for SAPCAR executables
       ansible.builtin.include_tasks: verify_checksum.yml
       loop: "{{ __sap_hana_install_fact_sapcar_dict }}"
       loop_control:
@@ -160,31 +170,49 @@
         - __sap_hana_install_fact_sapcar_dict | length > 0
         - sap_hana_install_verify_checksums
 
-# For each file in temporary directory sapcar_tmp in the software extract directory, we run it with option
-# --version and then identify the most recent one, which is then copied to directory sapcar.
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Identify the SAPCAR executable with the latest version
-      ansible.builtin.shell: |
-        set -o pipefail &&
-        for sapcar_matching_arch in "{{ __sap_hana_install_fact_sapcar_filenames_matching_arch | map('quote') | join(' ') }}"; do
-           ( printf "%s " $(basename ${sapcar_matching_arch})
-             {{ sap_hana_install_software_extract_directory }}/sapcar_tmp/$(basename ${sapcar_matching_arch}) --version |
-             awk '/kernel release/{rel=$NF}/patch number/{printf ("%s %s\n", rel, $NF)}'
-           )
-        done | sort -k 2 -nr -k 3 -nr | awk 'NR==1{printf ("%s - SAP kernel: %s; Patch number: %s\n", $1, $2, $3)}'
+
+    # For each file in temporary directory sapcar_tmp in the software extract directory, we run it with option
+    # --version and then identify the most recent one, which is then copied to directory sapcar.
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Get version of all SAPCAR executable files  # noqa command-instead-of-shell
+      ansible.builtin.command:
+        cmd: "./{{ item }} --version"
       args:
         chdir: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp"
-      register: __sap_hana_install_register_latest_sapcar_file
-      changed_when: no
+      loop: "{{ __sap_hana_install_register_sapcar_matching_arch }}"
+      register: __sap_hana_install_register_sapcar_versions
+      ignore_errors: true
+      changed_when: false
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Display SAPCAR executable file name, SAP kernel release, and patch number
-      ansible.builtin.debug:
-        msg: "Using SAPCAR executable: {{ __sap_hana_install_register_latest_sapcar_file.stdout }}"
-
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Set fact for SAPCAR executable from autodetection
+    # Loop through found files and extract kernel and patch values before sorting them in descending order.
+    # Resulting variable is used together with '| trim' to ensure that empty spaces are removed from shell command output.
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Identify the SAPCAR executable with the latest version
       ansible.builtin.set_fact:
-        __sap_hana_install_fact_selected_sapcar_filename: "{{ __sap_hana_install_register_latest_sapcar_file.stdout.split(' ').0 }}"
+        __sap_hana_install_register_latest_sapcar_file: |
+          {%- set files_with_versions = [] -%}
+          {%- for result in __sap_hana_install_register_sapcar_versions.results -%}
+            {%- if not result.failed -%}
+              {# Use regex to find the kernel and patch numbers, defaulting to 0 if not found #}
+              {%- set kernel = result.stdout | regex_search('kernel release\s+(\d+)', '\\1') | first | default(0) | int -%}
+              {%- set patch = result.stdout | regex_search('patch number\s+(\d+)', '\\1') | first | default(0) | int -%}
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Copy the autodetected SAPCAR executable to '{{ sap_hana_install_software_extract_directory }}/sapcar'
+              {# Append the structured data to our list #}
+              {%- set _ = files_with_versions.append({'kernel': kernel, 'patch': patch, 'filename': result.item}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+
+          {# Sort by patch (secondary) then by kernel (primary) in descending order and return first one #}
+          {%- set sorted_files = files_with_versions | sort(attribute='patch', reverse=true) | sort(attribute='kernel', reverse=true) -%}
+          {{- sorted_files[0].filename if sorted_files else 'none' -}}
+
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Set fact for SAPCAR executable from auto-detection
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_selected_sapcar_filename: "{{ __sap_hana_install_register_latest_sapcar_file | trim }}"
+
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Display SAPCAR executable file name
+      ansible.builtin.debug:
+        msg: "Using SAPCAR executable: {{ __sap_hana_install_fact_selected_sapcar_filename }}"
+
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Copy the autodetected SAPCAR executable to '{{ sap_hana_install_software_extract_directory }}/sapcar'
       ansible.builtin.copy:
         src: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp/{{ __sap_hana_install_fact_selected_sapcar_filename }}"
         dest: "{{ sap_hana_install_software_extract_directory }}/sapcar/{{ __sap_hana_install_fact_selected_sapcar_filename }}"
@@ -194,7 +222,7 @@
         mode: '0755'
       when: not ansible_check_mode
 
-    - name: SAP HANA hdblcm prepare - SAPCAR autodetection - Remove directory '{{ sap_hana_install_software_extract_directory }}/sapcar_tmp'
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Remove directory '{{ sap_hana_install_software_extract_directory }}/sapcar_tmp'
       ansible.builtin.file:
         path: "{{ sap_hana_install_software_extract_directory }}/sapcar_tmp"
         state: absent

--- a/roles/sap_hana_install/tasks/pre_install/prepare_sarfiles.yml
+++ b/roles/sap_hana_install/tasks/pre_install/prepare_sarfiles.yml
@@ -8,13 +8,7 @@
 
 - name: SAP HANA hdblcm prepare - Set fact list of SAR files if 'sap_hana_install_sarfiles' is defined
   ansible.builtin.set_fact:
-    __sap_hana_install_fact_sarfiles: "{{ sap_hana_install_sarfiles }}"
-  when: sap_hana_install_sarfiles is defined
-
-- name: Display the resulting list of file names from variable
-  ansible.builtin.debug:
-    var: __sap_hana_install_fact_sarfiles
-  when: sap_hana_install_sarfiles is defined
+    __sap_hana_install_fact_sarfiles: "{{ sap_hana_install_sarfiles | d([]) }}"
 
 - name: SAP HANA hdblcm prepare - Find all SAR files if 'sap_hana_install_sarfiles' is undefined
   when: sap_hana_install_sarfiles is not defined
@@ -32,10 +26,6 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sarfiles: "{{ __sap_hana_install_fact_sarfiles | d([]) + [item.path | basename] }}"
       loop: "{{ __sap_hana_install_register_find_sarfiles.files }}"
-
-    - name: Display the resulting list of file names after find
-      ansible.builtin.debug:
-        var: __sap_hana_install_fact_sarfiles
 
 - name: Copy SAR files to final destination if 'sap_hana_install_copy_sarfiles' is 'true'
   when: sap_hana_install_copy_sarfiles
@@ -60,6 +50,22 @@
     - name: SAP HANA hdblcm prepare - Set fact for final location of SAR files, copy_sarfiles
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sar_dir: "{{ sap_hana_install_software_extract_directory }}/sarfiles"
+
+- name: SAP HANA hdblcm prepare - Fail if no SAR files were found
+  ansible.builtin.fail:
+    msg: |
+      {% if sap_hana_install_sarfiles is defined -%}
+        FAIL: The variable 'sap_hana_install_sarfiles' is defined but empty.
+        Correct this variable in extra vars or remove it from extra vars to enable SAR file search
+        in directory defined in the variable 'sap_hana_install_software_directory'.
+      {% else -%}
+        FAIL: No SAR files were found in directory '{{ sap_hana_install_software_extract_directory }}'.
+      {% endif %}
+  when: __sap_hana_install_fact_sarfiles | list | length == 0
+
+- name: Display the resulting list of SAR file names
+  ansible.builtin.debug:
+    var: __sap_hana_install_fact_sarfiles
 
 - name: SAP HANA hdblcm prepare - Fill list of dicts containing dir, file, and global checksum file
   ansible.builtin.set_fact:

--- a/roles/sap_hana_install/vars/main.yml
+++ b/roles/sap_hana_install/vars/main.yml
@@ -6,3 +6,35 @@
 __sap_hana_install_sid_prohibited: ['ADD', 'ADM', 'ALL', 'AMD', 'AND', 'ANY', 'ARE', 'ASC', 'AUX', 'AVG', 'BIN', 'BIT', 'CDC', 'COM', 'CON', 'DAA', 'DBA', 'DBM', 'DBO', 'DTD', 'ECO', 'END', 'EPS', 'EXE', 'FOR', 'GET', 'GID', 'IBM', 'INT', 'KEY', 'LIB', 'LOG', 'LPT', 'MAP', 'MAX', 'MEM', 'MIG', 'MIN', 'MON', 'NET', 'NIX', 'NOT', 'NUL', 'OFF', 'OLD', 'OMS', 'OUT', 'PAD', 'PRN', 'RAW', 'REF', 'ROW', 'SAP', 'SET', 'SGA', 'SHG', 'SID', 'SQL', 'SUM', 'SYS', 'TMP', 'TOP', 'TRC', 'UID', 'USE', 'USR', 'VAR']
 
 __sap_hana_install_fact_tmp_dirname: ''
+
+# This dictionary defines keyword rules to identify SAP binaries compatible with modern Linux distributions supported by SAP HANA.
+# Each key is a valid `ansible_architecture` value.
+# The value is a list of rule sets, where each rule set is a list of keywords.
+# A file is considered a match if all keywords from any single rule set are found in the `file` command's output.
+__sap_hana_install_architecture_matrix:
+  x86_64:
+    # LINUX ON X86_64 64BIT
+    # Requires 'ELF' and 'Linux' to differentiate from other x86-64 binaries like those for Solaris (also ELF) or Windows (PE format).
+    # Example: SAPCAR_1400-70007716.EXE: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked,
+    # interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.4, BuildID[sha1]=52b9652252273d4c212fa366935ea3152244ead4, not stripped
+    - ['x86-64', 'ELF', 'Linux']
+    # If ELF is UNIX - System V, then check for interpreter linux string.
+    - ['x86-64', 'ELF', 'SYSV', 'linux']
+  ppc64le:
+    # LINUX ON POWER LE 64BIT
+    # 'LSB' (Least Significant Bit) is crucial to identify Little-Endian PowerPC, as opposed to the older Big-Endian 'MSB' (Most Significant Bit) variant.
+    # Example: SAPCAR_1400-70007726.EXE: ELF 64-bit LSB shared object, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI, version 1 (GNU/Linux), dynamically linked,
+    # interpreter /lib64/ld64.so.2, for GNU/Linux 3.0.0, BuildID[sha1]=52ce4823a8d2273a2bc15d7c8161a24d65b4223f, not stripped
+    - ['PowerPC', 'LSB']
+  s390x:
+    # LINUX ON ZSERIES 64BIT
+    # Identifies binaries for Linux on IBM Z & LinuxONE systems.
+    # Example: SAPCAR_1400-70007722.EXE: ELF 64-bit MSB shared object, IBM S/390, version 1 (SYSV), dynamically linked,
+    # interpreter /lib/ld64.so.1, for GNU/Linux 2.6.4, BuildID[sha1]=a31118ae8d69bf9422b86930012a6c5776cbc82d, not stripped
+    - ['IBM S/390']
+  aarch64:
+    # LINUX ON ARM 64BIT
+    # Identifies binaries for the 64-bit Arm architecture.
+    # Example: SAPCAR_1400-80008313.EXE: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked,
+    # interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=f40042b59e928aacfff753e59686be4d6e242998, for GNU/Linux 3.7.0, not stripped
+    - ['aarch64']


### PR DESCRIPTION
## Changes
- Replace existing complex shell commands for SAPCAR OS Architecture detection and identification of latest SAPCAR:
  - Customizable variable dictionary
  - Jinja2 logic with improved readability
- Added dynamic jinja2 fail messages depending on conditions.
- Added fail check if SAR files were not found.
- Added lot of comments to explain logic behind tasks as well as missing explanations.

## Tested
This code change was tested on SLES_SAP 15 SP6 and SLES_SAP 16 RC2.

**NOTE for testing: Executing role `sap_install_media_detect` beforehand will skip SAPCAR and SAR file tasks, because extracted folder is prepared already.**