### PR TITLE
sap_ha_pacemaker_cluster: Enhance handling of cluster properties and improve ASCS ERS post steps

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -243,17 +243,17 @@ sap_ha_pacemaker_cluster_cluster_nodes:
 ```
 ### sap_ha_pacemaker_cluster_cluster_properties
 - _Type:_ `dict`<br>
-- _Default:_ `{'concurrent-fencing': True, 'stonith-enabled': True, 'stonith-timeout': 900}`<br>
 
 Standard pacemaker cluster properties are configured with recommended settings for cluster node fencing.<br>
 When no STONITH resource is defined, STONITH will be disabled and a warning displayed.<br>
+Default values are predefined by OS and Platform if the variable is not defined.<br>
+Some mandatory properties are appended, if not defined.<br>
 
 Example:
 ```yaml
 sap_ha_pacemaker_cluster_cluster_properties:
-  concurrent-fencing: true
   stonith-enabled: true
-  stonith-timeout: 900
+  stonith-timeout: 150
 ```
 ### sap_ha_pacemaker_cluster_corosync_totem
 - _Type:_ `dict`<br>

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -53,21 +53,23 @@ sap_ha_pacemaker_cluster_host_type: "{{ sap_host_type | d(['hana_scaleup_perf'])
 ### VIP resource default patterns
 sap_ha_pacemaker_cluster_vip_client_interface: ''
 
-## A custom stonith definition that takes precedence over platform defaults.
+### STONITH
+## Recommended fencing methods are defined only for platforms, where applicable.
+## It is not recommended to configure cluster without fencing resources (e.g. SBD).
+## You can define custom stonith resource using variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+## NOTE: Not providing stonith resource will result in cluster property 'stonith-enabled: false'.
 # sap_ha_pacemaker_cluster_stonith_custom:
 #   - name: ""
 #     agent: "stonith:"
 #     options:
 #       pcmk_host_list: ""
 
-# sap_ha_pacemaker_cluster_stonith_custom: []
-
-# Simpler definition format here which gets transformed into the 'ha_cluster' LSR native
-# 'ha_cluster_cluster_properties' parameter.
-sap_ha_pacemaker_cluster_cluster_properties:
-  stonith-enabled: true
-  stonith-timeout: 900
-  concurrent-fencing: true
+## The variable 'sap_ha_pacemaker_cluster_cluster_properties' is used to configure cluster properties (e.g. cib-bootstrap-options).
+# NOTE: Default values are defined by Operating System and Platforms, if the variable is not defined.
+# Simpler definition format here which gets transformed into the 'ha_cluster' LSR native 'ha_cluster_cluster_properties' parameter.
+# sap_ha_pacemaker_cluster_cluster_properties:
+#   stonith-enabled: true
+#   stonith-timeout: 150  # Default value 150 is for SBD method.
 
 ### Constraints:
 # score is dynamic and automatically increased for groups

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -297,20 +297,17 @@ argument_specs:
 
       sap_ha_pacemaker_cluster_cluster_properties:
         type: dict
-        default:
-          stonith-enabled: true
-          stonith-timeout: 900
-          concurrent-fencing: true
         description:
           - Standard pacemaker cluster properties are configured with recommended settings for
             cluster node fencing.
           - When no STONITH resource is defined, STONITH will be disabled and a warning displayed.
+          - Default values are predefined by OS and Platform if the variable is not defined.
+          - Some mandatory properties are appended, if not defined.
 
         example:
           sap_ha_pacemaker_cluster_cluster_properties:
             stonith-enabled: true
-            stonith-timeout: 900
-            concurrent-fencing: true
+            stonith-timeout: 150
 
       sap_ha_pacemaker_cluster_corosync_totem:
         type: dict

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -71,9 +71,10 @@
     # Resource restart is initiated from one node.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS and ERS resource groups"
       ansible.builtin.shell: |
-        {{ __sap_ha_pacemaker_cluster_command.resource_restart }} \
-        {{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }} \
-        {{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}
+        {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ item }}
+      loop:
+        - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+        - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
       run_once: true
       changed_when: true
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -190,9 +190,10 @@
       block:
         - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS and ERS resource groups"
           ansible.builtin.shell: |
-            {{ __sap_ha_pacemaker_cluster_command.resource_restart }} \
-            {{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }} \
-            {{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}
+            {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ item }}
+          loop:
+            - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }}"
+            - "{{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}"
           run_once: true
           changed_when: true
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -52,153 +52,156 @@
       delay: "{{ 1 if ansible_check_mode else 10 }}"
       ignore_errors: "{{ ansible_check_mode }}"
 
-    # Sleep added to resolve issue with WaitforStarted finishing before resources are available.
+    # Sleep is required to ensure that Sapstarsrv process is available before checking with WaitforStarted.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS and ERS to be up and running"
+      become: true
+      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+      ansible.builtin.shell: |
+        sleep 20
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 5
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 5
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
+
+
+    # Existing steps were modified to align with best practices.
+    # Cluster connector requires restart of Sapstartsrv resources, but complete group restart is recommended.
+    # Resource restart is initiated from one node.
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS and ERS resource groups"
+      ansible.builtin.shell: |
+        {{ __sap_ha_pacemaker_cluster_command.resource_restart }} \
+        {{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }} \
+        {{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}
+      run_once: true
+      changed_when: true
+
+    # Wait for resources to come up after group restart.
+    # Register value is used to determine where resource is started, while unmanaged by cluster.
+    # Sleep is required to ensure that Sapstarsrv process is available before checking with WaitforStarted.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ascs
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
+        sleep 20
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 5
       changed_when: false
       failed_when: false
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ERS to be up and running"
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
       register: __sap_ha_pacemaker_cluster_register_where_ers
       ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 30
+        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function WaitforStarted 600 5
       changed_when: false
       failed_when: false
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
 
-    # NOTE: RestartService can cause fencing lockup and hang forever,
-    # it might be good to remove them in future and leave reload to "ASCS ERS restart" block.
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ASCS service"
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Block to get HAGetFailoverConfig and HACheckConfig for ASCS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_restart_ascs
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function RestartService
-      changed_when: __sap_ha_pacemaker_cluster_register_restart_ascs.rc == 0
+      check_mode: false
+      ignore_errors: "{{ ansible_check_mode }}"
+      block:
+        # HAGetFailoverConfig function checks live status of High Availability.
+        # Empty output and 'HAActive: FALSE' can be caused by Sapstartsrv not using cluster connector yet.
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
+          register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
+          changed_when: false
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Restart the ERS service"
+        # HACheckConfig function checks SAP System configuration for High Availability
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
+          register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
+          changed_when: false
+          failed_when: false
+
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig and HAGetFailoverConfig results for ASCS"
+          ansible.builtin.debug:
+            msg: |
+              HAGetFailoverConfig:
+              {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+
+              HACheckConfig:
+              {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
+
+
+    - name: "SAP HA Pacemaker - (SAP HA Interface) Block to get HAGetFailoverConfig and HACheckConfig for ERS"
       when:
         - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
         - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
       become: true
       become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_restart_ers
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function RestartService
-      changed_when: __sap_ha_pacemaker_cluster_register_restart_ers.rc == 0
-
-
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
-      ansible.builtin.shell: |
-        sleep 10
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
-      changed_when: false
       check_mode: false
       ignore_errors: "{{ ansible_check_mode }}"
+      block:
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
+          register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
+          changed_when: false
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
-      changed_when: false
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
+          register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
+          ansible.builtin.shell: |
+            /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
+          changed_when: false
+          failed_when: false
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
-      ansible.builtin.debug:
-        msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig and HAGetFailoverConfig results for ERS"
+          ansible.builtin.debug:
+            msg: |
+              HAGetFailoverConfig:
+              {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
 
-
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
-      changed_when: false
-      failed_when: false
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
-
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
-      ansible.builtin.debug:
-        msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
+              HACheckConfig:
+              {{ __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout_lines }}
 
 
-    # Ensure there are no errors before resources get restarted
+    # Ensure there are no errors before resources get restarted.
     - name: "SAP HA Install Pacemaker - Cluster resource cleanup before restart"
       ansible.builtin.shell: |
         {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
       changed_when: true
 
-    # Block to restart cluster resources if RestartService is not enough.
-    # This is required for SUSE, where SAP needs full restart to load HAlib.
+
+    # Block to repeat resource group restart if checks failed.
+    # HAGetFailoverConfig with 'HAActive: FALSE' will be caught.
+    # HACheckConfig with any line starting with 'ERROR' will be caught.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
       when:
-        - "(__sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
-           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout)
-          or (__sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
-           and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout)
-          or (__sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout is defined
-           and 'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout)"
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
+          or __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
+          or __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout | d('') | regex_search('^ERROR,', multiline=True)
+          or __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout | d('') | regex_search('^ERROR,', multiline=True)
       vars:
         __rsc_ascs: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
         __rsc_ers: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
       block:
-        - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS ERS resources"
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Restart ASCS and ERS resource groups"
           ansible.builtin.shell: |
-            {{ __sap_ha_pacemaker_cluster_command.resource_restart }} {{ restart_item }}
-          loop:
-            - "{{ __rsc_ascs }}"
-            - "{{ __rsc_ers }}"
-          loop_control:
-            loop_var: restart_item
-          when:
-            - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-            - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
+            {{ __sap_ha_pacemaker_cluster_command.resource_restart }} \
+            {{ __sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name }} \
+            {{ __sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name }}
+          run_once: true
           changed_when: true
 
+        # Sleep is required to ensure that Sapstarsrv process is available before checking with WaitforStarted.
         - name: "SAP HA Pacemaker - (SAP HA Interface) Wait for ASCS to be up and running"
           become: true
           become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
           register: __sap_ha_pacemaker_cluster_register_where_ascs_restart
           ansible.builtin.shell: |
+            sleep 20
             /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function WaitforStarted 600 30
           changed_when: false
           failed_when: false
@@ -218,106 +221,77 @@
             {{ __sap_ha_pacemaker_cluster_command.resource_cleanup }}
           changed_when: true
 
-    ### END of BLOCK for instance restarts.
+
+        # Repeat checks after resource groups were restarted second time.
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Block to get HAGetFailoverConfig and HACheckConfig for ASCS after restart"
+          when:
+            - __sap_ha_pacemaker_cluster_register_where_ascs_restart.rc is defined
+            - __sap_ha_pacemaker_cluster_register_where_ascs_restart.rc == 0
+          become: true
+          become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+          check_mode: false
+          ignore_errors: "{{ ansible_check_mode }}"
+          block:
+            - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS after restart"
+              register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config_restart
+              ansible.builtin.shell: |
+                /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
+              changed_when: false
+              failed_when:
+                - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
+
+            - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS after restart"
+              register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config_restart
+              ansible.builtin.shell: |
+                /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
+              changed_when: false
+              failed_when:
+                - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config_restart.stdout | d('') | regex_search('^ERROR,', multiline=True)
+
+            - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig and HAGetFailoverConfig results for ASCS after restart"
+              ansible.builtin.debug:
+                msg: |
+                  HAGetFailoverConfig:
+                  {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config_restart.stdout_lines }}
+
+                  HACheckConfig:
+                  {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config_restart.stdout_lines }}
 
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config
-      ansible.builtin.shell: |
-        sleep 30
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
-      changed_when: false
-      failed_when:
-        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout"
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
+        - name: "SAP HA Pacemaker - (SAP HA Interface) Block to get HAGetFailoverConfig and HACheckConfig for ERS after restart"
+          when:
+            - __sap_ha_pacemaker_cluster_register_where_ers_restart.rc is defined
+            - __sap_ha_pacemaker_cluster_register_where_ers_restart.rc == 0
+          become: true
+          become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
+          check_mode: false
+          ignore_errors: "{{ ansible_check_mode }}"
+          block:
+            - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS after restart"
+              register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart
+              ansible.builtin.shell: |
+                /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
+              changed_when: false
+              failed_when:
+                - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
-      changed_when: false
-      failed_when:
-        - "'ERROR' in __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout"
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
+            - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS after restart"
+              register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart
+              ansible.builtin.shell: |
+                /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
+              changed_when: false
+              failed_when:
+                - __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart.stdout | d('') | regex_search('^ERROR,', multiline=True)
 
+            - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig and HAGetFailoverConfig results for ERS after restart"
+              ansible.builtin.debug:
+                msg: |
+                  HAGetFailoverConfig:
+                  {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart.stdout_lines }}
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ASCS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
-      changed_when: false
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
-      # failed_when:
-      #   - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout is defined
-      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout
+                  HACheckConfig:
+                  {{ __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart.stdout_lines }}
 
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Get HAGetFailoverConfig for ERS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-      become: true
-      become_user: "{{ __sap_ha_pacemaker_cluster_nwas_sid | lower }}adm"
-      register: __sap_ha_pacemaker_cluster_register_ers_ha_failover_config
-      ansible.builtin.shell: |
-        /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
-      changed_when: false
-      check_mode: false
-      ignore_errors: "{{ ansible_check_mode }}"
-      # failed_when:
-      #   - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout is defined
-      #      and 'FALSE' in __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout
-
-
-    # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ASCS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines is defined
-      ansible.builtin.debug:
-        msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout_lines }}
-
-
-    # HAGetFailoverConfig is not consistent and it can show FALSE on one of nodes
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HAGetFailoverConfig results on ERS"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ers.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines is defined
-      ansible.builtin.debug:
-        msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout_lines }}
-
-    # HACheckConfig shows same statues on both nodes, therefore only ASCS is shown
-    - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig results"
-      when:
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc is defined
-        - __sap_ha_pacemaker_cluster_register_where_ascs.rc == 0
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines is defined
-      ansible.builtin.debug:
-        msg: |
-          {{ __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout_lines }}
-
-
-    # TODO: verification checks that the instances are running and HA Interface is enabled
+    ### END of BLOCK for resource group restarts after failed checks.
 
 ### END of BLOCK for sap_cluster_connector.

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -88,8 +88,23 @@
         else __sap_ha_pacemaker_cluster_fence_agent_packages_minimal }}"
 
 
+# Prepare cluster properties variable with either:
+# - User provided 'sap_ha_pacemaker_cluster_cluster_properties' if defined and not empty.
+# - Platform specific defaults, if defined.
+# - OS specific defaults.
+# If the variable 'ha_cluster_properties' is defined, it will append only missing keys.
+- name: "SAP HA Prepare Pacemaker - Prepare cluster properties variable"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_cluster_properties:
+      "{{ sap_ha_pacemaker_cluster_cluster_properties
+        if sap_ha_pacemaker_cluster_cluster_properties is defined and sap_ha_pacemaker_cluster_cluster_properties | length > 0
+        else (__sap_ha_pacemaker_cluster_cluster_properties_platform
+          if __sap_ha_pacemaker_cluster_cluster_properties_platform is defined
+          else __sap_ha_pacemaker_cluster_cluster_properties_default) }}"
+
+
 # Prepare corosync totem variable with either:
-# - User provided sap_ha_pacemaker_cluster_corosync_totem if present
+# - User provided 'sap_ha_pacemaker_cluster_corosync_totem' if present
 # - Combine corosync totem from OS variables and Platform variables if present
 # - Use default corosync totem from OS variables if Platform variable is not present
 - name: "SAP HA Prepare Pacemaker - Prepare corosync totem settings"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_nwas_abap_ascs_ers_simple_mount.yml
@@ -74,6 +74,8 @@
         - attrs:
             - name: resource-stickiness
               value: "{{ __sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness }}"
+            - name: priority
+              value: 100
       operations:
         # TODO: Add values for start and stop when they are published.
         - action: monitor

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -35,10 +35,13 @@
       )
   block:
 
+    # Ensure that property 'stonith-enabled' is set to 'false' if no Stonith resources are defined.
+    # NOTE: We cannot allow user set 'stonith-enabled' 'true' if there are no fencing resources.
     - name: "SAP HA Prepare Pacemaker - (STONITH) Set to disabled when no fencing resource is defined"
+      when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
       ansible.builtin.set_fact:
-        sap_ha_pacemaker_cluster_cluster_properties:
-          "{{ sap_ha_pacemaker_cluster_cluster_properties | combine({'stonith-enabled': false}) }}"
+        __sap_ha_pacemaker_cluster_cluster_properties:
+          "{{ __sap_ha_pacemaker_cluster_cluster_properties | combine({'stonith-enabled': false}) }}"
 
     - name: "SAP HA Prepare Pacemaker - Warn that there is no STONITH configured"
       ansible.builtin.pause:
@@ -53,38 +56,64 @@
 
 # END of block for disabling stonith
 
-# Add additional stonith properties to sap_ha_pacemaker_cluster_cluster_properties
-# Checks if pcmk_delay_max is defined and non zero, then multiples it by 2.
-- name: "SAP HA Prepare Pacemaker - (STONITH) Add priority-fencing-delay property"
-  ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_cluster_properties:
-      "{{ sap_ha_pacemaker_cluster_cluster_properties | combine({'priority-fencing-delay':
-          __sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max | int * 2})
-        if __sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max is defined
-        and __sap_ha_pacemaker_cluster_stonith_default.options.pcmk_delay_max | int != 0
-        else sap_ha_pacemaker_cluster_cluster_properties }}"
+# Stonith cluster properties
+# Property 'concurrent-fencing' is 'false' by default, but Scale-Out requires 'true'.
+# NOTE: Reversed combine ensures that user defined values are retained.
+# TODO: Enable during implementation of Scale-Out.
+# - name: "SAP HA Prepare Pacemaker - Disable concurrent-fencing in properties"
+#   when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+#   ansible.builtin.set_fact:
+#     __sap_ha_pacemaker_cluster_cluster_properties:
+#       "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
+#   when:
+#     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleout') | length > 0
 
-- name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
-  when:
-    - sap_ha_pacemaker_cluster_cluster_properties is defined
-    - sap_ha_pacemaker_cluster_cluster_properties is iterable
-    - sap_ha_pacemaker_cluster_cluster_properties | length > 0
+
+# Property 'priority-fencing-delay' is required to ensure proper fencing order.
+# The value is based on 'pcmk_delay_max', if it is defined in '__sap_ha_pacemaker_cluster_stonith_default'.
+# This task will not change property if it is already defined.
+# NOTE: Reversed combine ensures that user defined values are retained.
+- name: "SAP HA Prepare Pacemaker - (STONITH) Add priority-fencing-delay property"
+  when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_cluster_properties: "{{ __sap_ha_pacemaker_cluster_cluster_properties | d([]) + __stonith_properties }}"
+    __sap_ha_pacemaker_cluster_cluster_properties:
+      "{{ {'priority-fencing-delay': (__pcmk_delay_max | int * 2
+          if __pcmk_delay_max is defined and __pcmk_delay_max | int != 0
+          else 30)} | combine(__sap_ha_pacemaker_cluster_cluster_properties)
+        if __sap_ha_pacemaker_cluster_cluster_properties['priority-fencing-delay'] is not defined
+        else __sap_ha_pacemaker_cluster_cluster_properties }}"
   vars:
-    __stonith_properties:
+    __pcmk_delay_max:
+      "{{ (__sap_ha_pacemaker_cluster_stonith_default['instance_attrs'][0]['attrs']
+        | selectattr('name', 'equalto', 'pcmk_delay_max') | first).value }}"
+
+# Ensure that property 'concurrent-fencing' is set to 'true' for Azure.
+# Source: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#create-a-fencing-device-on-the-pacemaker-cluster
+# NOTE: Reversed combine ensures that user defined values are retained.
+- name: "SAP HA Prepare Pacemaker - (STONITH) - MSAZURE VM - Add cluster property 'concurrent-fencing'"
+  when:
+    - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+    - __sap_ha_pacemaker_cluster_platform == "cloud_msazure_vm"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_cluster_properties:
+      "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
+
+
+# Prepare structure compatible with the variable 'ha_cluster_cluster_properties'.
+- name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
+  # This task is skipped if 'ha_cluster_cluster_properties' is defined, as both structures are different.
+  when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_cluster_properties:
       - attrs: |-
-          {% set attrs = __sap_ha_pacemaker_cluster_cluster_properties | map(attribute='attrs') | flatten -%}
-          {%- for default_cluster_properties in (sap_ha_pacemaker_cluster_cluster_properties | dict2items) -%}
-            {% if default_cluster_properties.key not in
-            (__sap_ha_pacemaker_cluster_cluster_properties | map(attribute='attrs') | flatten | map(attribute='name')) -%}
-              {% set role_attrs = attrs.extend([
-                {
-                  'name': default_cluster_properties.key,
-                  'value': default_cluster_properties.value
-                }
-              ]) -%}
-            {%- endif %}
+          {% set attrs = [] -%}
+          {%- for default_cluster_properties in (__sap_ha_pacemaker_cluster_cluster_properties | dict2items) -%}
+            {% set role_attrs = attrs.extend([
+              {
+                'name': default_cluster_properties.key,
+                'value': default_cluster_properties.value
+              }
+            ]) -%}
           {%- endfor %}
           {{ attrs }}
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars_hana.yml
@@ -23,18 +23,6 @@
     - "(role_path + '/vars/' + include_item + '.yml') is file"
 
 
-# Disable concurrent-fencing for Scale-up scenario.
-# This assignment cannot be in scaleup var file, because it results in nested error.
-- name: "SAP HA Prepare Pacemaker - Disable concurrent-fencing in properties"
-  ansible.builtin.set_fact:
-    sap_ha_pacemaker_cluster_cluster_properties:
-      "{{ sap_ha_pacemaker_cluster_cluster_properties | combine({'concurrent-fencing': false})
-      if sap_ha_pacemaker_cluster_cluster_properties['concurrent-fencing'] is defined
-      else sap_ha_pacemaker_cluster_cluster_properties }}"
-  when:
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
-
-
 # Private variables are assigned following logic:
 # 1. Use backwards compatible var if new var is empty
 # 2. Use user input if new var is not empty

--- a/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
@@ -55,6 +55,11 @@ __sap_ha_pacemaker_cluster_command:
   resource_restart: "pcs resource restart"
   resource_cleanup: "pcs resource cleanup"
 
+# Dictionary with default cluster properties
+__sap_ha_pacemaker_cluster_cluster_properties_default:
+  stonith-enabled: true
+  stonith-timeout: 150  # Default value 150 is for SBD method.
+
 # Default corosync options - OS specific
 __sap_ha_pacemaker_cluster_corosync_totem_default:
   options: {}

--- a/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
@@ -12,11 +12,17 @@ __sap_ha_pacemaker_cluster_connector_config_lines:
   - "service/halib_cluster_connector = /usr/bin/sap_suse_cluster_connector"
 
 # Cluster commands to manage resources - crmsh commands in SUSE OS family.
+# --force is required only for resource restart and maintenance on/off.
 __sap_ha_pacemaker_cluster_command:
   resource_stop: "crm resource stop"
   resource_start: "crm resource start"
-  resource_restart: "crm resource restart"
+  resource_restart: "crm --force resource restart"
   resource_cleanup: "crm resource cleanup"
+
+# Dictionary with default cluster properties
+__sap_ha_pacemaker_cluster_cluster_properties_default:
+  stonith-enabled: true
+  stonith-timeout: 150  # Default value 150 is for SBD method.
 
 # Default corosync options - OS specific
 __sap_ha_pacemaker_cluster_corosync_totem_default:

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -218,6 +218,22 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
    else __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_nwas'] }}"
 
 
+# Dictionary with default platform specific cluster properties
+__sap_ha_pacemaker_cluster_cluster_properties_platform_dict:
+  hana:
+    stonith-enabled: true
+    stonith-timeout: 600
+
+  nwas:
+    stonith-enabled: true
+    stonith-timeout: 300
+
+__sap_ha_pacemaker_cluster_cluster_properties_platform:
+  "{{ __sap_ha_pacemaker_cluster_cluster_properties_platform_dict['hana']
+    if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
+   else __sap_ha_pacemaker_cluster_cluster_properties_platform_dict['nwas'] }}"
+
+
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_aws_ec2_vs | d('aws_vpc_move_ip') }}"
 sap_ha_pacemaker_cluster_vip_group_prefix: ''  # the default supported VIP agent is a single resource only

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -90,6 +90,12 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
   "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower] }}"
 
 
+# Dictionary with default platform specific cluster properties
+__sap_ha_pacemaker_cluster_cluster_properties_platform:
+  stonith-enabled: true
+  stonith-timeout: 300
+
+
 # GCP needs haproxy and ports defined
 sap_ha_pacemaker_cluster_healthcheck_hana_primary_port: "620{{ __sap_ha_pacemaker_cluster_hana_instance_nr }}"
 sap_ha_pacemaker_cluster_healthcheck_hana_secondary_port: >-

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -117,6 +117,12 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform:
   "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower] }}"
 
 
+# Dictionary with default platform specific cluster properties
+__sap_ha_pacemaker_cluster_cluster_properties_platform:
+  stonith-enabled: true
+  stonith-timeout: 900
+
+
 # Platform specific VIP handling
 sap_ha_pacemaker_cluster_vip_method: "{{ __sap_ha_pacemaker_cluster_vip_method_dict.cloud_msazure_vm | d('azure_lb') }}"
 


### PR DESCRIPTION
## Reason for changes
1. Post steps for ASCS/ERS were not restarting correct cluster resources, resulting in empty output of `HAGetFailoverConfig` because Sapstartsrv was not loaded with cluster connector.
2. Cluster properties for stonith were not correct and ASCS parameter was missing.

## Changes
- ASCS/ERS Post tasks
  - Reorganize existing tasks (@ja9fuchs This will cause some mess with git diff, so please check it directly in fork)
  - Replace restart Sapstartsrv with restart of resource group so it can manage all resources
  - Add blocks around tasks with same parameters to simplify code
- Cluster properties
  - Remove default variable `sap_ha_pacemaker_cluster_cluster_properties` to enable proper loading of user defined versus predefined.
  - Remove defaults for `concurrent-fencing` because it is used only by HANA Scaleout and Azure HA (separate tasks).
  - Fix jinja for `priority-fencing-delay` which was incorrectly pointing towards previous structure of `__sap_ha_pacemaker_cluster_stonith_default`
  - Add OS specific `__sap_ha_pacemaker_cluster_cluster_properties_default` and platform specific `__sap_ha_pacemaker_cluster_cluster_properties_platform` definition of cluster properties. All `stonith-timeout` values are defined based on documentations we could find.
- ASCS SAPInstance meta property `priority: 100` was added to align with `priority-fencing-delay`

## Tested
Changes were tested on:
- SLES_SAP 15 SP6 on AWS and Azure
- SLES_SAP 16 RC2 on Harvester cluster

**NOTE: We have agreed with @ja9fuchs  that load order for `ha_cluster` variables have to be changed in future, to ensure that `sap_ha_pacemaker_cluster` variables take precedence over them, but this PR was done in alignment with current state (Although comments were added for future reference).**