### PR TITLE
sap_hana_preconfigure: Implement SAP note 3108302 v.13

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -6,6 +6,7 @@ __sap_hana_preconfigure_supported_rhel_minor_releases:
   - "9.0"
   - "9.2"
   - "9.4"
+  - "9.6"
 
 # required repos for RHEL 9:
 __sap_hana_preconfigure_req_repos_redhat_9_0_x86_64:
@@ -126,7 +127,7 @@ __sap_hana_preconfigure_sapnotes_versions_x86_64:
 
 __sap_hana_preconfigure_sapnotes_versions_ppc64le:
   - { number: '2055470', version: '90' }
-  - { number: '3108302', version: '11' }
+  - { number: '3108302', version: '13' }
   - { number: '2382421', version: '47' }
   - { number: '3024346', version: '11' }
 
@@ -170,8 +171,11 @@ __sap_hana_preconfigure_min_packages_9_5_x86_64:
 __sap_hana_preconfigure_min_packages_9_5_ppc64le:
 
 __sap_hana_preconfigure_min_packages_9_6_x86_64:
+  - [ 'kernel', '5.14.0-570.17.1.el9_6' ]
 
 __sap_hana_preconfigure_min_packages_9_6_ppc64le:
+  - [ 'kernel', '5.14.0-570.17.1.el9_6' ]
+  - [ 'glibc', '2.34-168.el9_6.20' ]
 
 __sap_hana_preconfigure_min_packages_9_7_x86_64:
 


### PR DESCRIPTION
... for installing the minimum required package versions for running HANA on RHEL 9.6 on x86_64 and ppc64le.

Solves issue #1088.