### PR TITLE
sap_ha_install_hana_hsr: Add backup location detection and user variable

### DIFF
--- a/roles/sap_ha_install_hana_hsr/defaults/main.yml
+++ b/roles/sap_ha_install_hana_hsr/defaults/main.yml
@@ -1,13 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-sap_ha_install_hana_hsr_sid: "{{ sap_hana_sid }}"
+# SAP HANA Database SID in capital letters (String). Example: 'H02'
+sap_ha_install_hana_hsr_sid: "{{ sap_hana_sid | upper }}"
+
+# SAP HANA Database Instance Number (String). Example: '90'
 sap_ha_install_hana_hsr_instance_number: "{{ sap_hana_instance_number }}"
+
+# Dictionary with cluster nodes. Same dictionary is used by LSR ha_cluster.
+# sap_hana_cluster_nodes:
+#   - node_name: "hana0"
+#     node_ip: "10.0.0.1"
+#     node_role: primary
+#     hana_site: DC01
+#   - node_name: "hana1"
+#     node_ip: "10.0.0.2"
+#     node_role: secondary
+#     hana_site: DC02
 sap_ha_install_hana_hsr_cluster_nodes: "{{ sap_hana_cluster_nodes }}"
 
+# Name of database user for backups (String).
 sap_ha_install_hana_hsr_hdbuserstore_system_backup_user: HDB_SYSTEMDB
+
+# Master password for database (String).
 sap_ha_install_hana_hsr_db_system_password: "{{ sap_hana_install_master_password }}"
+
+# Fully qualified domain name (String).
 sap_ha_install_hana_hsr_fqdn: "{{ sap_domain }}"
+
+# HSR Replication mode (String).
 sap_ha_install_hana_hsr_rep_mode: sync
+
+# HSR Operation mode (String).
 sap_ha_install_hana_hsr_oper_mode: logreplay
 
+# Set to true to update /etc/hosts (Boolean).
 sap_ha_install_hana_hsr_update_etchosts: true
+
+# Define the directory path where database backup will be created (String).
+# Required sub-directories will be created in this path: SYSTEMDB and DB_<SID>.
+# Default: /usr/sap/<SID>/HDB<INST_NR>/backup/data/
+# Backup will be created with name: <SID>_PRE_HSR_<TIMESTAMP> (e.g. H02_PRE_HSR_20250729_1426)
+# sap_ha_install_hana_hsr_backup_path: ''

--- a/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/log_mode.yml
@@ -12,6 +12,7 @@
   changed_when: false
 
 # CHECK, if ansible_hostname needs to be replaced with interface name
+# This task will fail when HSR is already configured, because secondary node nameserver is not running with port 3XX13.
 - name: "SAP HSR - Set log_mode to normal"
   tags: hsr_logmode
   become: true

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -32,13 +32,14 @@
     that:
       - sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'primary') | length == 1
       - sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_role', '==', 'secondary') | length >= 1
-    fail_msg: "Node roles not valid. There must be 1 primary and at least 1 node defined with the secondary role."
+    fail_msg: "Node roles are not valid. There must be 1 primary and at least 1 node defined with the secondary role."
 
 - name: SAP HSR - Check that hsr interface is configured on host
   ansible.builtin.assert:
     that:
       - __sap_ha_install_hana_hsr_connection.node_ip is defined
       - __sap_ha_install_hana_hsr_connection.node_ip != ""
+      - __sap_ha_install_hana_hsr_connection.node_ip in ansible_all_ipv4_addresses
     fail_msg: "The IP address configured for HSR does not exist on this host"
     success_msg: "The IP address for HSR is configured on this host"
   tags: always

--- a/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
@@ -1,31 +1,189 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Define default path to backups that will be either used or validated against.
+# Backups are not stored there directly, but in sub-directories.
+# Example: /usr/sap/H02/HDB90/backup/data
+- name: "SAP HSR - Set the default backup location path"
+  ansible.builtin.set_fact:
+    __sap_ha_install_hana_hsr_basepath_databackup_default:
+      "{{ '/usr/sap/' ~ sap_ha_install_hana_hsr_sid ~ '/HDB' ~ sap_ha_install_hana_hsr_instance_number ~ '/backup/data' }}"
+
+
+# Ensure that we create same folder structure inside of user provided path.
+- name: "SAP HSR - Create sub-directories in provided {{ sap_ha_install_hana_hsr_backup_path }}"
+  ansible.builtin.file:
+    path: "{{ sap_ha_install_hana_hsr_backup_path | regex_replace('/$', '') ~ '/' ~ item }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
+    group: sapsys
+  loop:
+    - SYSTEMDB
+    - "{{ 'DB_' ~ sap_ha_install_hana_hsr_sid }}"
+  when:
+    - sap_ha_install_hana_hsr_backup_path is defined
+    - sap_ha_install_hana_hsr_backup_path | string | length > 0
+
+
+- name: Block to find basepath_databackup
+  when:
+    - sap_ha_install_hana_hsr_backup_path is not defined
+      or sap_ha_install_hana_hsr_backup_path | string | length == 0
+  block:
+
+    # Getting data from global.ini file is not accurate and we will get it from database.
+    # The value is stored either in 'SYSTEM' layer or 'DEFAULT' layer. It will default to "NONE" if nothing was found.
+    - name: "SAP HSR - Get value of the 'basepath_databackup' parameter from database"
+      become: true
+      become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
+      ansible.builtin.shell:
+        cmd: |
+          /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+          -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+          -m -a -quiet \
+          -c ';' \
+          <<EOF
+          SELECT COALESCE(
+            (SELECT VALUE FROM M_INIFILE_CONTENTS WHERE LAYER_NAME = 'SYSTEM' AND SECTION = 'persistence' AND KEY = 'basepath_databackup'),
+            (SELECT VALUE FROM M_INIFILE_CONTENTS WHERE LAYER_NAME = 'DEFAULT' AND SECTION = 'persistence' AND KEY = 'basepath_databackup'),
+            'NONE'
+          ) FROM DUMMY;
+          EOF
+      register: __sap_ha_install_hana_hsr_register_basepath_databackup
+      changed_when: false
+      ignore_errors: true
+
+
+    # Proceed with preparation of command output only when valid.
+    # Default path '$(DIR_INSTANCE)/backup/data' requires expansion of $DIR_INSTANCE variable.
+    - name: "SAP HSR - Block to process obtained 'basepath_databackup'"
+      when:
+        - not __sap_ha_install_hana_hsr_register_basepath_databackup.failed
+        - not __sap_ha_install_hana_hsr_register_basepath_databackup.stdout_lines[0] == '"NONE"'
+      vars:
+        # Remove double quotes around query result.
+        __basepath_databackup_trimmed:
+          "{{ __sap_ha_install_hana_hsr_register_basepath_databackup.stdout_lines[0] | replace('\"', '') }}"
+        # Identify if ENV variable is present by searching for $.
+        __basepath_databackup_expansion_needed:
+          "{{ __basepath_databackup_trimmed is search('\\$\\(') }}"
+        # Finds text inside parentheses and then strips them.
+        __basepath_databackup_expand_var:
+          "{{ __basepath_databackup_trimmed | regex_search('\\((.*?)\\)') | regex_replace('\\(|\\)', '') | d('') }}"
+
+      block:
+        # Ansible become is not enough to load ENV so we have to use source.
+        - name: "SAP HSR - Get value of the expanded variable {{ __basepath_databackup_expand_var }}"
+          become: true
+          become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
+          ansible.builtin.shell:
+            cmd: |
+              source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.profile && \
+              echo ${{ __basepath_databackup_expand_var }}
+            executable: /bin/bash
+          register: __sap_ha_install_hana_hsr_register_expansion_result
+          changed_when: false
+          check_mode: false
+          ignore_errors: true
+          when: __basepath_databackup_expansion_needed
+
+        # Either expand variable or fall back to value, as it does not contain ENV variable.
+        - name: "SAP HSR - Create full path of 'basepath_databackup' directory"
+          ansible.builtin.set_fact:
+            __sap_ha_install_hana_hsr_basepath_databackup_expanded:
+              "{{ __basepath_databackup_trimmed | replace('$(' + __basepath_databackup_expand_var + ')', __sap_ha_install_hana_hsr_register_expansion_result.stdout)
+                if __basepath_databackup_expansion_needed and not __sap_ha_install_hana_hsr_register_expansion_result.failed
+                else __basepath_databackup_trimmed }}"
+
+        # Identify if path is same as default and set fact only if it is different.
+        - name: "SAP HSR - Set fact 'basepath_databackup' when different from default path"
+          ansible.builtin.set_fact:
+            __sap_ha_install_hana_hsr_basepath_databackup: "{{ __sap_ha_install_hana_hsr_basepath_databackup_expanded }}"
+          when: (__sap_ha_install_hana_hsr_basepath_databackup_expanded | regex_replace('/$', '')) != __sap_ha_install_hana_hsr_basepath_databackup_default
+
+
+# Combine final path to backup directory in order:
+# 1. User defined 'sap_ha_install_hana_hsr_backup_path' if defined and not empty.
+# 2. Generated '__sap_ha_install_hana_hsr_basepath_databackup' or empty.
+- name: "SAP HSR - Set variable with path to backup directory"
+  ansible.builtin.set_fact:
+    __sap_ha_install_hana_hsr_backup_path:
+      "{{ sap_ha_install_hana_hsr_backup_path
+        if sap_ha_install_hana_hsr_backup_path is defined and sap_ha_install_hana_hsr_backup_path | string | length > 0
+        else __sap_ha_install_hana_hsr_basepath_databackup | d('') }}"
+
+- name: "SAP HSR - Set variable with backup file prefix"
+  ansible.builtin.set_fact:
+    # Prepare backup name as <SID>_PRE_HSR_<TIMESTAMP>. Example: H02_PRE_HSR_20250729_1444
+    __sap_ha_install_hana_hsr_backup_prefix:
+      "{{ (sap_ha_install_hana_hsr_sid | upper) ~ '_PRE_HSR_' ~ now(utc=False).strftime('%Y%m%d_%H%M') }}"
+
+
+# 'USING FILE' parameter accepts range of inputs:
+# - ('name') - Backup 'name' will be created in default basepath_databackup.
+# - ('','name') - Backup 'name' will be created in default basepath_databackup.
+# - ('/backup/name') - Backup 'name' will be created in /backup/ folder, but it has to exist with correct permissions.
+# - ('/backup/','name') - Backup 'name' will be created in /backup/ folder, but it has to exist with correct permissions.
+# Using full path requires us to specify sub-directories to avoid mixing up SYSTEMDB and TENANTDB backups.
 - name: "SAP HSR - Run backup for SYSTEMDB"
-  ansible.builtin.shell: |
-    /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql -quiet \
-    -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
-    -m <<EOF
-    BACKUP DATA FOR SYSTEMDB USING FILE ('data_bck');
-    EOF
+  ansible.builtin.shell:
+    cmd: |
+      /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql -quiet \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      BACKUP DATA FOR SYSTEMDB USING FILE ('{{ __systemdb_path }}','{{ __sap_ha_install_hana_hsr_backup_prefix }}');
+      EOF
   changed_when: true
+  vars:
+    # Ensure that backup goes into sub-directory, when path is not default.
+    __systemdb_path:
+      "{{ __sap_ha_install_hana_hsr_backup_path | regex_replace('/$', '') ~ '/SYSTEMDB/'
+        if __sap_ha_install_hana_hsr_backup_path != ''
+        else '' }}"
 
 - name: "SAP HSR - Run backup in TENANTDB {{ sap_ha_install_hana_hsr_sid }}"
-  ansible.builtin.shell: |
-    /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql -quiet \
-    -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
-    -m <<EOF
-    BACKUP DATA FOR {{ sap_ha_install_hana_hsr_sid }} USING FILE ('data_bck');
-    EOF
+  ansible.builtin.shell:
+    cmd: |
+      /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql -quiet \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      BACKUP DATA FOR {{ sap_ha_install_hana_hsr_sid }} USING FILE ('{{ __tenantdb_path }}','{{ __sap_ha_install_hana_hsr_backup_prefix }}');
+      EOF
   changed_when: true
+  vars:
+    # Ensure that backup goes into sub-directory, when path is not default.
+    __tenantdb_path:
+      "{{ __sap_ha_install_hana_hsr_backup_path | regex_replace('/$', '') ~ '/DB_' ~ sap_ha_install_hana_hsr_sid ~ '/'
+        if __sap_ha_install_hana_hsr_backup_path != ''
+        else '' }}"
+
+
+# This is final configuration of backup path, because find command cannot proceed with
+# empty string '' like hdbsql.
+- name: "SAP HSR - Set variable with final path to backup directory"
+  ansible.builtin.set_fact:
+    __sap_ha_install_hana_hsr_backup_path_final:
+      "{{ __sap_ha_install_hana_hsr_backup_path
+         if __sap_ha_install_hana_hsr_backup_path != ''
+         else __sap_ha_install_hana_hsr_basepath_databackup_default }}"
 
 - name: "SAP HSR - Verify backup files"
-  ansible.builtin.shell: |
-    source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.sapenv.sh && \
-    find /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/HDB{{ sap_ha_install_hana_hsr_instance_number }}/backup/data/ \
-    -type f -name data_bck* \
-    -exec /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbbackupcheck {} \;
+  ansible.builtin.shell:
+    cmd: |
+      source /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/home/.profile && \
+      find {{ __sap_ha_install_hana_hsr_backup_path_final }} \
+      -type f -name {{ __sap_ha_install_hana_hsr_backup_prefix }}* \
+      -exec /usr/sap/{{ sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbbackupcheck {} \;
   register: __sap_ha_install_hana_hsr_verify_backup
   failed_when:
     - __sap_ha_install_hana_hsr_verify_backup.rc == '1' or
       __sap_ha_install_hana_hsr_verify_backup.stderr != ""
   changed_when: false
+
+
+- name: "SAP HSR - Show backup details"
+  ansible.builtin.debug:
+    msg: |
+      Database backup was successfully completed.
+      Location: {{ __sap_ha_install_hana_hsr_backup_path_final}}
+      File prefix: {{ __sap_ha_install_hana_hsr_backup_prefix }}


### PR DESCRIPTION
## Changes
This PR was built with idea from https://github.com/sap-linuxlab/community.sap_install/issues/971

- Add user variable `sap_ha_install_hana_hsr_backup_path` that can be used to define custom backup location.
- Add detection of HANA parameter instead of hardcoded path, but leave fall back default path as variable.
- Add handling of SYSTEMDB and TENANTDB folders when `sap_ha_install_hana_hsr_backup_path` is provided.

## Tests
This PR was tested on SLES 16 HANA HA nodes, with all combinations of variables.

## NOTE
This role will require some refactoring in future in order to catch it up with other roles in repository.