### PR TITLE
collection: Adjust roles for ansible-core 2.19 part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ __pycache__/
 
 # vi swap file
 *.swp
+
+# Ignore ansible workspace
+.ansible

--- a/roles/sap_general_preconfigure/handlers/main.yml
+++ b/roles/sap_general_preconfigure/handlers/main.yml
@@ -31,8 +31,9 @@
 
 - name: "Debug grub-mkconfig BIOS mode"
   ansible.builtin.debug:
-    var: __sap_general_preconfigure_register_grub2_mkconfig_bios_mode.stdout_lines,
-         __sap_general_preconfigure_register_grub2_mkconfig_bios_mode.stderr_lines
+    msg: |
+      {{ __sap_general_preconfigure_register_grub2_mkconfig_bios_mode.stdout_lines | d('') }}
+      {{ __sap_general_preconfigure_register_grub2_mkconfig_bios_mode.stderr_lines | d('') }}
   listen: __sap_general_preconfigure_regenerate_grub2_conf_handler
   when:
     - not __sap_general_preconfigure_register_stat_sys_firmware_efi.stat.exists
@@ -65,8 +66,9 @@
 
 - name: "Debug grub-mkconfig UEFI"
   ansible.builtin.debug:
-    var: __sap_general_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines,
-         __sap_general_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines
+    msg: |
+      {{ __sap_general_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines | d('') }}
+      {{ __sap_general_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines | d('') }}
   listen: __sap_general_preconfigure_regenerate_grub2_conf_handler
   when:
     - __sap_general_preconfigure_register_stat_sys_firmware_efi.stat.exists

--- a/roles/sap_general_preconfigure/tasks/sapnote/2369910.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2369910.yml
@@ -17,7 +17,9 @@
       ansible.builtin.command: "localectl set-locale LANG={{ sap_general_preconfigure_default_locale }}"
       changed_when: true
       when:
-        - sap_general_preconfigure_default_locale is defined and sap_general_preconfigure_default_locale
+        - sap_general_preconfigure_default_locale is defined
+        - sap_general_preconfigure_default_locale is string
+        - sap_general_preconfigure_default_locale | length > 0
         - sap_general_preconfigure_default_locale == 'C.UTF-8' or
           sap_general_preconfigure_default_locale == 'C.utf8' or
           sap_general_preconfigure_default_locale.startswith('en_') and

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -178,12 +178,13 @@
     # Block to repeat resource group restart if checks failed.
     # HAGetFailoverConfig with 'HAActive: FALSE' will be caught.
     # HACheckConfig with any line starting with 'ERROR' will be caught.
+    # regex_search is 'NoneType' when string is not found, therefore any type beside NoneType is considered fail.
     - name: "SAP HA Pacemaker - (SAP HA Interface) Block for ASCS ERS restart"
       when:
-        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
-          or __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
-          or __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout | d('') | regex_search('^ERROR,', multiline=True)
-          or __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout | d('') | regex_search('^ERROR,', multiline=True)
+        - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True) is not none
+          or __sap_ha_pacemaker_cluster_register_ers_ha_failover_config.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True) is not none
+          or __sap_ha_pacemaker_cluster_register_ascs_ha_check_config.stdout | d('') | regex_search('^ERROR,', multiline=True) is not none
+          or __sap_ha_pacemaker_cluster_register_ers_ha_check_config.stdout | d('') | regex_search('^ERROR,', multiline=True) is not none
       vars:
         __rsc_ascs: "{{ __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name }}"
         __rsc_ers: "{{ __sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name }}"
@@ -240,7 +241,7 @@
                 /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HAGetFailoverConfig
               changed_when: false
               failed_when:
-                - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
+                - __sap_ha_pacemaker_cluster_register_ascs_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True) is not none
 
             - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ASCS after restart"
               register: __sap_ha_pacemaker_cluster_register_ascs_ha_check_config_restart
@@ -248,7 +249,7 @@
                 /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ascs_instance_nr }} -function HACheckConfig
               changed_when: false
               failed_when:
-                - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config_restart.stdout | d('') | regex_search('^ERROR,', multiline=True)
+                - __sap_ha_pacemaker_cluster_register_ascs_ha_check_config_restart.stdout | d('') | regex_search('^ERROR,', multiline=True) is not none
 
             - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig and HAGetFailoverConfig results for ASCS after restart"
               ansible.builtin.debug:
@@ -275,7 +276,7 @@
                 /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
               changed_when: false
               failed_when:
-                - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True)
+                - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True) is not none 
 
             - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS after restart"
               register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart
@@ -283,7 +284,7 @@
                 /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HACheckConfig
               changed_when: false
               failed_when:
-                - __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart.stdout | d('') | regex_search('^ERROR,', multiline=True)
+                - __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart.stdout | d('') | regex_search('^ERROR,', multiline=True)  is not none
 
             - name: "SAP HA Pacemaker - (SAP HA Interface) Display HACheckConfig and HAGetFailoverConfig results for ERS after restart"
               ansible.builtin.debug:

--- a/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/configure_nwas_abap_ascs_ers_post_install.yml
@@ -276,7 +276,7 @@
                 /usr/sap/hostctrl/exe/sapcontrol -nr {{ __sap_ha_pacemaker_cluster_nwas_ers_instance_nr }} -function HAGetFailoverConfig
               changed_when: false
               failed_when:
-                - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True) is not none 
+                - __sap_ha_pacemaker_cluster_register_ers_ha_failover_config_restart.stdout | d('') | regex_search('^HAActive:\\s+FALSE$', multiline=True) is not none
 
             - name: "SAP HA Pacemaker - (SAP HA Interface) Get HACheckConfig for ERS after restart"
               register: __sap_ha_pacemaker_cluster_register_ers_ha_check_config_restart

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -8,16 +8,18 @@
 # sap_ha_pacemaker_cluster_cluster_name   -> user-defined or default inherited from {{ ha_cluster_cluster_name }}
 - name: "SAP HA Prepare Pacemaker - Set cluster name"
   when:
-    - __sap_ha_pacemaker_cluster_cluster_name is not defined
+    - __sap_ha_pacemaker_cluster_cluster_name is not defined  # TODO: Remove when ha_cluster vars stop taking precedence
     - sap_ha_pacemaker_cluster_cluster_name is defined
+    - sap_ha_pacemaker_cluster_cluster_name | length > 0
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_name: "{{ sap_ha_pacemaker_cluster_cluster_name }}"
 
 # sap_ha_pacemaker_cluster_hacluster_user_password -> user-defined or default inherited from {{ ha_cluster_hacluster_password }}
+# Defined validation is removed as argument_specs file handles that.
 - name: "SAP HA Prepare Pacemaker - Register the 'hacluster' user password"
   when:
-    - __sap_ha_pacemaker_cluster_hacluster_user_password is not defined
-    - sap_ha_pacemaker_cluster_hacluster_user_password
+    - __sap_ha_pacemaker_cluster_hacluster_user_password is not defined  # TODO: Remove when ha_cluster vars stop taking precedence
+    - sap_ha_pacemaker_cluster_hacluster_user_password | length > 0
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_hacluster_user_password: "{{ sap_ha_pacemaker_cluster_hacluster_user_password }}"
   no_log: true  # secure the credential
@@ -25,14 +27,13 @@
 # sap_ha_pacemaker_cluster_ha_cluster   -> user-defined or default inherited from {{ ha_cluster }}
 - name: "SAP HA Prepare Pacemaker - Register sap_ha_pacemaker_cluster_ha_cluster"
   when:
-    - __sap_ha_pacemaker_cluster_ha_cluster is not defined
+    - __sap_ha_pacemaker_cluster_ha_cluster is not defined  # TODO: Remove when ha_cluster vars stop taking precedence
     - sap_ha_pacemaker_cluster_ha_cluster is defined
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_ha_cluster: "{{ sap_ha_pacemaker_cluster_ha_cluster }}"
 
 - name: "SAP HA Prepare Pacemaker - Generate default sap_ha_pacemaker_cluster_ha_cluster"
   when:
-    - not __sap_ha_pacemaker_cluster_ha_cluster is defined
     - not sap_ha_pacemaker_cluster_ha_cluster is defined
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_ha_cluster:

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -206,7 +206,7 @@
 - name: "SAP HA Install Pacemaker - Create cluster configuration parameters file"
   when:
     - sap_ha_pacemaker_cluster_create_config_varfile
-    - sap_ha_pacemaker_cluster_create_config_dest | length
+    - sap_ha_pacemaker_cluster_create_config_dest | length > 0
   ansible.builtin.template:
     backup: true
     dest: "{{ sap_ha_pacemaker_cluster_create_config_dest }}"
@@ -223,7 +223,7 @@
 - name: "SAP HA Install Pacemaker - Display configuration parameters SAVE FILE location"
   when:
     - sap_ha_pacemaker_cluster_create_config_varfile
-    - sap_ha_pacemaker_cluster_create_config_dest | length
+    - sap_ha_pacemaker_cluster_create_config_dest | length > 0
   ansible.builtin.debug:
     msg: |
       The cluster resource configuration parameters have been saved here:
@@ -299,7 +299,7 @@
     - name: "SAP HA Install Pacemaker - Create backup of existing CIB"
       when:
         - __sap_ha_pacemaker_cluster_cib_query.stdout is defined
-        - __sap_ha_pacemaker_cluster_cib_query.stdout|length > 0
+        - __sap_ha_pacemaker_cluster_cib_query.stdout | length > 0
       ansible.builtin.copy: # noqa template-instead-of-copy
         backup: true
         content: "{{ __sap_ha_pacemaker_cluster_cib_query.stdout }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
@@ -56,7 +56,8 @@
       __sap_ha_pacemaker_cluster_register_instance_service.results
       | selectattr('stat.exists')
       | map(attribute='stat.path')
-      | regex_replace('/etc/systemd/system/', '')
+      | map('regex_replace', '/etc/systemd/system/', '')
+      | list
       }}"
 
 - name: "SAP HA Pacemaker - (systemd) Combine instance services from all nodes"

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -142,7 +142,7 @@ sap_hana_install_shared_path: "{{ sap_hana_install_install_path | d(sap_hana_ins
 # Adjust these accordingly for your installation type
 sap_hana_install_system_usage: 'custom'
 sap_hana_install_restrict_max_mem: 'n'
-sap_hana_install_max_mem:
+# sap_hana_install_max_mem: ''
 
 # Starting with SAP HANA 2.0 SPS08, the component LSS (Local Secure Store) will be installed by default
 # when installing SAP HANA. This requires the installation execution mode to be set to 'optimized'.
@@ -151,8 +151,8 @@ sap_hana_install_max_mem:
 sap_hana_install_install_execution_mode: 'optimized'
 
 # hdblcm will use default ids if blank
-sap_hana_install_userid:
-sap_hana_install_groupid:
+# sap_hana_install_userid: ''
+# sap_hana_install_groupid: ''
 
 # Passwords
 # Setting master password to 'y' will use that master password for all passwords - recommended

--- a/roles/sap_hana_preconfigure/handlers/main.yml
+++ b/roles/sap_hana_preconfigure/handlers/main.yml
@@ -65,8 +65,9 @@
 
 - name: "Debug grub-mkconfig UEFI"
   ansible.builtin.debug:
-    var: __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines,
-         __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines
+    msg: |
+      {{ __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines }}
+      {{ __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines }}
   listen: __sap_hana_preconfigure_regenerate_grub2_conf_handler
   when:
     - __sap_hana_preconfigure_register_stat_sys_firmware_efi.stat.exists

--- a/roles/sap_hana_preconfigure/handlers/main.yml
+++ b/roles/sap_hana_preconfigure/handlers/main.yml
@@ -31,8 +31,9 @@
 
 - name: "Debug grub-mkconfig BIOS mode"
   ansible.builtin.debug:
-    var: __sap_hana_preconfigure_register_grub2_mkconfig_bios_mode.stdout_lines,
-         __sap_hana_preconfigure_register_grub2_mkconfig_bios_mode.stderr_lines
+    msg: |
+      {{ __sap_hana_preconfigure_register_grub2_mkconfig_bios_mode.stdout_lines | d('') }}
+      {{ __sap_hana_preconfigure_register_grub2_mkconfig_bios_mode.stderr_lines | d('') }}
   listen: __sap_hana_preconfigure_regenerate_grub2_conf_handler
   when:
     - not __sap_hana_preconfigure_register_stat_sys_firmware_efi.stat.exists
@@ -66,8 +67,8 @@
 - name: "Debug grub-mkconfig UEFI"
   ansible.builtin.debug:
     msg: |
-      {{ __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines }}
-      {{ __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines }}
+      {{ __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines | d('') }}
+      {{ __sap_hana_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines | d('') }}
   listen: __sap_hana_preconfigure_regenerate_grub2_conf_handler
   when:
     - __sap_hana_preconfigure_register_stat_sys_firmware_efi.stat.exists

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-thp.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-thp.yml
@@ -42,11 +42,15 @@
           (ansible_distribution_major_version == '9' and
             __sap_hana_preconfigure_fact_ansible_distribution_minor_version | int >= 2)
 
+    # TODO: Replace with full validations for accepted values ['always', 'madvise', 'never']
+    # and implement block for followup tasks.
     - name: Set fact for THP if 'sap_hana_preconfigure_thp' is defined
       ansible.builtin.set_fact:
         __sap_hana_preconfigure_fact_thp: "{{ sap_hana_preconfigure_thp }}"
       when:
-        - sap_hana_preconfigure_thp is defined and sap_hana_preconfigure_thp
+        - sap_hana_preconfigure_thp is defined
+        - sap_hana_preconfigure_thp is string
+        - sap_hana_preconfigure_thp | length > 0
 
     - name: Assert that 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is in GRUB_CMDLINE_LINUX in /etc/default/grub
       ansible.builtin.assert:

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-thp.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-thp.yml
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+# TODO: Replace with full validations for accepted values ['always', 'madvise', 'never']
+# and implement block for followup tasks.
 - name: Set fact for THP if 'sap_hana_preconfigure_thp' is defined
   ansible.builtin.set_fact:
     __sap_hana_preconfigure_fact_thp: "{{ sap_hana_preconfigure_thp }}"
   when:
     - sap_hana_preconfigure_thp is defined
+    - sap_hana_preconfigure_thp is string
     - sap_hana_preconfigure_thp | length > 0
 
 - name: Set fact for THP if 'sap_hana_preconfigure_thp' is undefined
@@ -14,11 +17,13 @@
   when:
     - __sap_hana_preconfigure_boot_command_line_args['thp']['arch'] is defined
     - ansible_architecture in __sap_hana_preconfigure_boot_command_line_args['thp']['arch']
-    - sap_hana_preconfigure_thp is undefined or sap_hana_preconfigure_thp | length == 0
+    - sap_hana_preconfigure_thp is undefined
+      or not sap_hana_preconfigure_thp is string
+      or sap_hana_preconfigure_thp | length == 0
 
 - name: Add boot command line args for configuring THP if applicable
   when:
-    - (sap_hana_preconfigure_thp is defined and sap_hana_preconfigure_thp | length > 0)
+    - (sap_hana_preconfigure_thp is defined and sap_hana_preconfigure_thp is string and sap_hana_preconfigure_thp | length > 0)
       or
       (
         __sap_hana_preconfigure_boot_command_line_args['thp']['arch'] is defined and

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_absent.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_absent.yml
@@ -3,10 +3,10 @@
 - name: Verify that variable node_ip is in the correct format
   ansible.builtin.assert:
     that:
-      - (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) is not none
-          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) | length > 0)
-        or (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) is not none
-          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) | length > 0)
+      - (thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) is not none
+          and thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) | length > 0)
+        or (thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) is not none
+          and thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) | length > 0)
     msg: |
       "The IP address of this host does not have a correct format.
        Configure the IP address appropriately in of the following variables:

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_absent.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_absent.yml
@@ -2,8 +2,11 @@
 ---
 - name: Verify that variable node_ip is in the correct format
   ansible.builtin.assert:
-    that: thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) or
-          thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6)
+    that:
+      - (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) is not none
+          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) | length > 0)
+        or (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) is not none
+          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) | length > 0)
     msg: |
       "The IP address of this host does not have a correct format.
        Configure the IP address appropriately in of the following variables:

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -11,8 +11,11 @@
 
 - name: Verify that variable node_ip is using the correct IP address format
   ansible.builtin.assert:
-    that: thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) or
-          thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6)
+    that:
+      - (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) is not none
+          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) | length > 0)
+        or (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) is not none
+          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) | length > 0)
     msg: |
       "The IP address of this host does not have a correct format.
        Configure the IP address appropriately in of the following variables:

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -12,10 +12,10 @@
 - name: Verify that variable node_ip is using the correct IP address format
   ansible.builtin.assert:
     that:
-      - (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) is not none
-          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) | length > 0)
-        or (node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) is not none
-          and node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) | length > 0)
+      - (thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) is not none
+          and thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv4) | length > 0)
+        or (thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) is not none
+          and thishost.node_ip | regex_search(sap_maintain_etc_hosts_regexp_ipv6) | length > 0)
     msg: |
       "The IP address of this host does not have a correct format.
        Configure the IP address appropriately in of the following variables:

--- a/roles/sap_netweaver_preconfigure/handlers/main.yml
+++ b/roles/sap_netweaver_preconfigure/handlers/main.yml
@@ -31,8 +31,9 @@
 
 - name: "Debug grub-mkconfig BIOS mode"
   ansible.builtin.debug:
-    var: __sap_netweaver_preconfigure_register_grub2_mkconfig_bios_mode.stdout_lines,
-         __sap_netweaver_preconfigure_register_grub2_mkconfig_bios_mode.stderr_lines
+    msg: |
+      {{ __sap_netweaver_preconfigure_register_grub2_mkconfig_bios_mode.stdout_lines | d('') }}
+      {{ __sap_netweaver_preconfigure_register_grub2_mkconfig_bios_mode.stderr_lines | d('') }}
   listen: __sap_netweaver_preconfigure_regenerate_grub2_conf_handler
   when:
     - not __sap_netweaver_preconfigure_register_stat_sys_firmware_efi.stat.exists
@@ -65,8 +66,9 @@
 
 - name: "Debug grub-mkconfig UEFI"
   ansible.builtin.debug:
-    var: __sap_netweaver_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines,
-         __sap_netweaver_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines
+    msg: |
+      {{ __sap_netweaver_preconfigure_register_grub2_mkconfig_uefi_mode.stdout_lines | d('') }}
+      {{ __sap_netweaver_preconfigure_register_grub2_mkconfig_uefi_mode.stderr_lines | d('') }}
   listen: __sap_netweaver_preconfigure_regenerate_grub2_conf_handler
   when:
     - __sap_netweaver_preconfigure_register_stat_sys_firmware_efi.stat.exists

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
@@ -113,12 +113,6 @@
   # Stop execution of tasks after this block for any host, if one host
   # failed a task in this block.
   any_errors_fatal: true
-  vars:
-    attach_item: |
-      {{ sap_storage_setup_definition
-        | selectattr('name', 'eq', nfs_item.name)
-        | join('')
-      }} # convert this single element list to a simple dict
   block:
 
     - name: SAP Storage Setup - ({{ nfs_item.name }}) Create directory as temporary mountpoint
@@ -131,9 +125,9 @@
       throttle: 1   # avoid NFS request flooding and silent timeout failures (observed on MS Azure Files)
       ansible.posix.mount:
         path: "{{ sap_storage_setup_tmpnfs_register.path }}"
-        src: "{{ attach_item.nfs_server | default(sap_storage_setup_nfs_server) }}"
-        fstype: "{{ attach_item.nfs_filesystem_type | default(sap_storage_setup_nfs_filesystem_type) }}"
-        opts: "{{ attach_item.nfs_mount_options | default(sap_storage_setup_nfs_mount_options) }}"
+        src: "{{ nfs_item.nfs_server | default(sap_storage_setup_nfs_server) }}"
+        fstype: "{{ nfs_item.nfs_filesystem_type | default(sap_storage_setup_nfs_filesystem_type) }}"
+        opts: "{{ nfs_item.nfs_mount_options | default(sap_storage_setup_nfs_mount_options) }}"
         state: mounted
       when:
         - sap_storage_setup_tmpnfs_register.path is defined
@@ -197,7 +191,7 @@
     path: "{{ mount_item.mountpoint }}"
     src: "{{ nfs_server }}/{{ mount_item.mount_src | regex_replace('^/', '') }}"
     fstype: "{{ nfs_item.nfs_filesystem_type | default(sap_storage_setup_nfs_filesystem_type) }}"
-    opts: "{{ attach_item.nfs_mount_options | default(sap_storage_setup_nfs_mount_options) }}"
+    opts: "{{ nfs_item.nfs_mount_options | default(sap_storage_setup_nfs_mount_options) }}"
     state: mounted
   loop: "{{ sap_storage_setup_related_directories }}"
   loop_control:
@@ -206,8 +200,3 @@
   vars:
     nfs_path: "{{ nfs_item.nfs_path | regex_replace('^/', '') | regex_replace('/$', '') }}"
     nfs_server: "{{ nfs_item.nfs_server | default(sap_storage_setup_nfs_server) | regex_replace('/$', '') }}"
-    attach_item: |
-      {{ sap_storage_setup_definition
-        | selectattr('name', 'eq', nfs_item.name)
-        | join('')
-      }} # convert this single element list to a simple dict

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
@@ -10,7 +10,7 @@
       | selectattr("filesystem_type", "defined")
       | selectattr("filesystem_type", "==", "swap")
       | selectattr("swap_path", "defined")
-      | join('')
+      | first
       -}}
 
   # Block conditional
@@ -19,6 +19,7 @@
     | selectattr("swap_path", "defined")
     | selectattr("filesystem_type", "defined")
     | selectattr("filesystem_type", "==", "swap")
+    | length > 0
 
   block:
 
@@ -69,7 +70,7 @@
       | selectattr("filesystem_type", "defined")
       | selectattr("filesystem_type", "==", "swap")
       | selectattr("swap_path", "undefined")
-      | join('')
+      | first
       -}}
 
   # Block conditional
@@ -78,6 +79,7 @@
     | selectattr("swap_path", "undefined")
     | selectattr("filesystem_type", "defined")
     | selectattr("filesystem_type", "==", "swap")
+    | length > 0
 
   block:
 


### PR DESCRIPTION
## Reason
Details about upcoming ansible-core 2.19 are listed in https://github.com/sap-linuxlab/community.sap_install/issues/1101

## Changes
- Add conditionals where truthy was attempted against non-boolean variables
- Add checks for `none` or `type_debug` when required.
- Add condition to all `regex_search` in when checks, because they return `NoneType` which is not truthy (This is not an issue inside of `set_fact`).

**NOTE 1: Dictionary assignments have to be carefully tested because `2.19` now marks them as `string`, invalidating lot of code.**

**NOTE 2: Changes to role `sap_swpm` are prepared and waiting for https://github.com/sap-linuxlab/community.sap_install/pull/1067 to be completed first.**

## Tests
Latest commit was tested on `ansible-core 2.16 2.18 2.19` targeting SLES 15 SP6 on AWS and SLES 16 on premise.
