### PR TITLE
Collection: ansible core 2.19 part 2

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -95,7 +95,7 @@
 # Reason for noqa: A double brace might also occur in an awk command sequence.
 - name: Check RHEL 7 package groups
   when:
-    - sap_general_preconfigure_packagegroups | d([])
+    - sap_general_preconfigure_packagegroups | length > 0
     - ansible_distribution_major_version == '7'
   block:
 
@@ -124,7 +124,7 @@
 # Reason for noqa: A double brace might also occur in an awk command sequence.
 - name: Check RHEL 8 environment groups
   when:
-    - sap_general_preconfigure_envgroups | d([])
+    - sap_general_preconfigure_envgroups | length > 0
     - ansible_distribution_major_version == '8'
   block:
 
@@ -252,7 +252,7 @@
   ansible.builtin.debug:
     msg: "INFO: No minimum required package version defined (variable __sap_general_preconfigure_min_pkgs)."
   ignore_errors: true
-  when: not __sap_general_preconfigure_min_pkgs | d([])
+  when: not __sap_general_preconfigure_min_pkgs | length > 0
 
 # Reason for noqa: The yum module appears to not support the check-update option
 - name: Get info about possible package updates # noqa command-instead-of-module

--- a/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/configuration.yml
@@ -58,7 +58,7 @@
 - name: Configure - Include configuration actions for required sapnotes
   ansible.builtin.include_tasks:
     file: "sapnote/{{ sap_note_line_item.number }}.yml"
-  with_items: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"
+  loop: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) | flatten(levels=1) }}"
   loop_control:
     loop_var: sap_note_line_item
   tags:

--- a/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-tmpfs.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/generic/assert-tmpfs.yml
@@ -16,7 +16,7 @@
 
 - name: Assert that the size of tmpfs is large enough as per /etc/fstab
   ansible.builtin.assert:
-    that: (sap_general_preconfigure_size_of_tmpfs_gb + 'G') in __sap_general_preconfigure_register_fstab_tmpfs_size_gb_assert.stdout
+    that: (sap_general_preconfigure_size_of_tmpfs_gb | string + 'G') in __sap_general_preconfigure_register_fstab_tmpfs_size_gb_assert.stdout
     fail_msg: "FAIL: The size of tmpfs in /etc/fstab is '{{ __sap_general_preconfigure_register_fstab_tmpfs_size_gb_assert.stdout }}'
                but the expected size is '{{ sap_general_preconfigure_size_of_tmpfs_gb }}G'!"
     success_msg: "PASS: The size of tmpfs in /etc/fstab is '{{ __sap_general_preconfigure_register_fstab_tmpfs_size_gb_assert.stdout }}'."
@@ -31,7 +31,7 @@
 
 - name: Assert that the current size of tmpfs is large enough as per df output
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_df_shm_assert.stdout == (sap_general_preconfigure_size_of_tmpfs_gb + 'G')
+    that: __sap_general_preconfigure_register_df_shm_assert.stdout == (sap_general_preconfigure_size_of_tmpfs_gb | string + 'G')
     fail_msg: "FAIL: The current size of tmpfs is '{{ __sap_general_preconfigure_register_df_shm_assert.stdout }}'
                but the expected size is '{{ sap_general_preconfigure_size_of_tmpfs_gb }}G'!"
     success_msg: "PASS: The current size of tmpfs is '{{ __sap_general_preconfigure_register_df_shm_assert.stdout }}'."

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -173,7 +173,7 @@
 - name: Ensure that the minimum required package versions are installed
   when:
     - sap_general_preconfigure_min_package_check | bool
-    - __sap_general_preconfigure_min_pkgs | d([])
+    - __sap_general_preconfigure_min_pkgs | length > 0
   block:
 
 # Reason for noqa: We can safely fail at the last command in the pipeline.

--- a/roles/sap_general_preconfigure/vars/main.yml
+++ b/roles/sap_general_preconfigure/vars/main.yml
@@ -6,5 +6,6 @@ __sap_general_preconfigure_packagegroups: ''
 __sap_general_preconfigure_envgroups: ''
 __sap_general_preconfigure_patterns: []
 __sap_general_preconfigure_packages: []
+__sap_general_preconfigure_min_pkgs: []
 __sap_general_preconfigure_size_of_tmpfs_gb: ''
 __sap_general_preconfigure_kernel_parameters_default: []

--- a/roles/sap_hana_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/configuration.yml
@@ -47,13 +47,13 @@
 
 - name: Configure - Include configuration actions for required sapnotes
   ansible.builtin.include_tasks: "sapnote/{{ sap_note_line_item.number }}.yml"
-  with_items: "{{ __sap_hana_preconfigure_sapnotes_versions | difference(['']) }}"
+  loop: "{{ __sap_hana_preconfigure_sapnotes_versions | difference(['']) | flatten(levels=1) }}"
   loop_control:
     loop_var: sap_note_line_item
 
 - name: Configure - Initiate GRUB update if necessary
   ansible.builtin.include_tasks:
-    file: "generic/set-boot-kernel-args.yml"
+    file: "RedHat/generic/set-boot-kernel-args.yml"
     apply:
       tags:
         - grubconfig

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-thp.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-thp.yml
@@ -26,6 +26,7 @@
     - name: Set fact for THP, RHEL up to RHEL 9.1
       ansible.builtin.set_fact:
         __sap_hana_preconfigure_fact_thp: 'never'
+        __sap_hana_preconfigure_fact_thp_boot_command_line_arg: "transparent_hugepage=never"
       when:
         - sap_hana_preconfigure_thp is undefined or sap_hana_preconfigure_thp | length == 0
         - ansible_distribution_major_version == '7' or
@@ -36,6 +37,7 @@
     - name: Set fact for THP, RHEL 9.2 and later
       ansible.builtin.set_fact:
         __sap_hana_preconfigure_fact_thp: 'madvise'
+        __sap_hana_preconfigure_fact_thp_boot_command_line_arg: "transparent_hugepage=madvise"
       when:
         - sap_hana_preconfigure_thp is undefined or sap_hana_preconfigure_thp | length == 0
         - ansible_distribution_major_version | int >= 10 or
@@ -47,28 +49,39 @@
     - name: Set fact for THP if 'sap_hana_preconfigure_thp' is defined
       ansible.builtin.set_fact:
         __sap_hana_preconfigure_fact_thp: "{{ sap_hana_preconfigure_thp }}"
+        __sap_hana_preconfigure_fact_thp_boot_command_line_arg: "transparent_hugepage={{ sap_hana_preconfigure_thp }}"
+        __sap_hana_preconfigure_fact_thp_fail_msg_grub: "FAIL: 'transparent_hugepage={{ sap_hana_preconfigure_thp }}' is not in GRUB_CMDLINE_LINUX in /etc/default/grub!"
+        __sap_hana_preconfigure_fact_thp_success_msg_grub: "PASS: 'transparent_hugepage={{ sap_hana_preconfigure_thp }}' is in GRUB_CMDLINE_LINUX in /etc/default/grub."
+        __sap_hana_preconfigure_fact_thp_fail_msg_proc_cmdline: "FAIL: 'transparent_hugepage={{ sap_hana_preconfigure_thp }}' is not in /proc/cmdline!"
+        __sap_hana_preconfigure_fact_thp_success_msg_proc_cmdline: "PASS: 'transparent_hugepage={{ sap_hana_preconfigure_thp }}' is in /proc/cmdline."
+        __sap_hana_preconfigure_fact_thp_fail_msg_cur: "FAIL: THP is currently configured with the status of '{{ __sap_hana_preconfigure_register_sys_kernel_thp_assert.stdout.split('[')[1].split(']')[0] }}' but it needs to be '{{ __sap_hana_preconfigure_fact_thp }}'!"
+        __sap_hana_preconfigure_fact_thp_success_msg_cur: "PASS: THP is currently configured with the correct status of '{{ __sap_hana_preconfigure_fact_thp }}'."
       when:
         - sap_hana_preconfigure_thp is defined
         - sap_hana_preconfigure_thp is string
         - sap_hana_preconfigure_thp | length > 0
 
+    - name: Display __sap_hana_preconfigure_fact_thp_boot_command_line_arg
+      ansible.builtin.debug:
+        msg: "__sap_hana_preconfigure_fact_thp_boot_command_line_arg = >{{ __sap_hana_preconfigure_fact_thp_boot_command_line_arg }}"
+
     - name: Assert that 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is in GRUB_CMDLINE_LINUX in /etc/default/grub
       ansible.builtin.assert:
-        that: "'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' in __sap_hana_preconfigure_register_default_grub_cmdline_thp_assert.stdout"
-        fail_msg: "FAIL: 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is not in GRUB_CMDLINE_LINUX in /etc/default/grub!"
-        success_msg: "PASS: 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is in GRUB_CMDLINE_LINUX in /etc/default/grub."
+        that: __sap_hana_preconfigure_fact_thp_boot_command_line_arg in __sap_hana_preconfigure_register_default_grub_cmdline_thp_assert.stdout
+        fail_msg: __sap_hana_preconfigure_fact_thp_fail_msg_grub
+        success_msg: __sap_hana_preconfigure_fact_thp_success_msg_grub
       ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
 
     - name: Assert that 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is in /proc/cmdline
       ansible.builtin.assert:
-        that: "'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' in __sap_hana_preconfigure_register_proc_cmdline_thp_assert.stdout"
-        fail_msg: "FAIL: 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is not in /proc/cmdline!"
-        success_msg: "PASS: 'transparent_hugepage={{ __sap_hana_preconfigure_fact_thp }}' is in /proc/cmdline."
+        that: __sap_hana_preconfigure_fact_thp_boot_command_line_arg in __sap_hana_preconfigure_register_proc_cmdline_thp_assert.stdout
+        fail_msg: __sap_hana_preconfigure_fact_thp_fail_msg_proc_cmdline
+        success_msg: __sap_hana_preconfigure_fact_thp_success_msg_proc_cmdline
       ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
 
     - name: Assert that THP currently has the correct status
       ansible.builtin.assert:
         that: __sap_hana_preconfigure_register_sys_kernel_thp_assert.stdout.split('[')[1].split(']')[0] == '{{ __sap_hana_preconfigure_fact_thp }}'
-        fail_msg: "FAIL: THP is currently configured with the status of '{{ __sap_hana_preconfigure_register_sys_kernel_thp_assert.stdout.split('[')[1].split(']')[0] }}' but it needs to be '{{ __sap_hana_preconfigure_fact_thp }}'!"
-        success_msg: "PASS: THP is currently configured with the correct status of '{{ __sap_hana_preconfigure_fact_thp }}'!"
+        fail_msg: __sap_hana_preconfigure_fact_thp_fail_msg_cur
+        success_msg: __sap_hana_preconfigure_fact_thp_success_msg_cur
       ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-tuned.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/assert-tuned.yml
@@ -81,8 +81,9 @@
 
 - name: Assert - Display the output of the tuned-adm active command
   ansible.builtin.debug:
-    var: __sap_hana_preconfigure_register_current_tuned_profile_assert.stdout_lines,
-         __sap_hana_preconfigure_register_current_tuned_profile_assert.stderr_lines
+    msg: |
+      {{ __sap_hana_preconfigure_register_current_tuned_profile_assert.stdout_lines | d('') }}
+      {{ __sap_hana_preconfigure_register_current_tuned_profile_assert.stderr_lines | d('') }}
   ignore_errors: yes
   when: sap_hana_preconfigure_use_tuned or
         sap_hana_preconfigure_assert_all_config

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-thp.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-thp.yml
@@ -57,4 +57,6 @@
 
     - name: Display the status of THP
       ansible.builtin.debug:
-        var: __sap_hana_preconfigure_register_thp_status.stdout_lines, __sap_hana_preconfigure_register_thp_status.stderr_lines
+        msg: |
+          {{ __sap_hana_preconfigure_register_thp_status.stdout_lines | d('') }}
+          {{ __sap_hana_preconfigure_register_thp_status.stderr_lines | d('') }}

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-tuned.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/configure-tuned.yml
@@ -43,7 +43,9 @@
 
     - name: Display the output of the tuned-adm active command
       ansible.builtin.debug:
-        var: __sap_hana_preconfigure_register_current_tuned_profile.stdout_lines, __sap_hana_preconfigure_register_current_tuned_profile.stderr_lines
+        msg: |
+          {{ __sap_hana_preconfigure_register_current_tuned_profile.stdout_lines | d('') }}
+          {{ __sap_hana_preconfigure_register_current_tuned_profile.stderr_lines | d('') }}
 
     - name: Switch to tuned profile '{{ sap_hana_preconfigure_tuned_profile }}' if not currently active
       when: __sap_hana_preconfigure_register_current_tuned_profile.stdout != sap_hana_preconfigure_tuned_profile
@@ -61,4 +63,6 @@
 
         - name: Display the output of the tuned-adm active command after switching to profile '{{ sap_hana_preconfigure_tuned_profile }}'
           ansible.builtin.debug:
-            var: __sap_hana_preconfigure_register_new_tuned_profile.stdout_lines, __sap_hana_preconfigure_register_new_tuned_profile.stderr_lines
+            msg: |
+              {{ __sap_hana_preconfigure_register_new_tuned_profile.stdout_lines | d('') }}
+              {{ __sap_hana_preconfigure_register_new_tuned_profile.stderr_lines | d('') }}

--- a/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-ksm.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/generic/disable-ksm.yml
@@ -39,4 +39,6 @@
 
 - name: Display the status of KSM
   ansible.builtin.debug:
-    var: __sap_hana_preconfigure_register_ksm_status.stdout_lines, __sap_hana_preconfigure_register_ksm_status.stderr_lines
+    msg: |
+      {{ __sap_hana_preconfigure_register_ksm_status.stdout_lines | d('') }}
+      {{ __sap_hana_preconfigure_register_ksm_status.stderr_lines | d('') }}

--- a/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
@@ -135,7 +135,8 @@
 - name: Ensure that the minimum required package versions are installed
   when:
     - sap_hana_preconfigure_min_package_check | bool
-    - __sap_hana_preconfigure_min_pkgs | d([])
+    - __sap_hana_preconfigure_min_pkgs is defined
+    - __sap_hana_preconfigure_min_pkgs | length > 0
   block:
 
 # Reason for noqa: We can safely fail at the last command in the pipeline.

--- a/roles/sap_hana_preconfigure/tasks/main.yml
+++ b/roles/sap_hana_preconfigure/tasks/main.yml
@@ -90,7 +90,7 @@
 
 - name: Display the content of sap_general_preconfigure_fact_reboot_required
   ansible.builtin.debug:
-    var: sap_general_preconfigure_fact_reboot_required
+    msg: "{{ sap_general_preconfigure_fact_reboot_required | d('') }}"
 
 - name: Include installation.yml
   ansible.builtin.include_tasks: '{{ item }}/{{ assert_prefix }}installation.yml'

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -180,9 +180,9 @@
 
 - name: Display the output of the hosts file completeness check
   ansible.builtin.debug:
-    var:
-      __sap_maintain_etc_hosts_register_ipv4_fqdn_sap_hostname_once_check.stdout_lines,
-      __sap_maintain_etc_hosts_register_ipv4_fqdn_sap_hostname_once_check.stderr_lines
+    msg: |
+      {{ __sap_maintain_etc_hosts_register_ipv4_fqdn_sap_hostname_once_check.stdout_lines | d('') }}
+      {{ __sap_maintain_etc_hosts_register_ipv4_fqdn_sap_hostname_once_check.stderr_lines | d('') }}
 
 - name: Display the expected output of the hosts file completeness check
   ansible.builtin.debug:

--- a/roles/sap_netweaver_preconfigure/tasks/RedHat/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/RedHat/configuration.yml
@@ -7,7 +7,7 @@
 
 - name: Include configuration actions for required sapnotes
   ansible.builtin.include_tasks: "sapnote/{{ sap_note_line_item.number }}.yml"
-  with_items: "{{ __sap_netweaver_preconfigure_sapnotes_versions | difference(['']) }}"
+  loop: "{{ __sap_netweaver_preconfigure_sapnotes_versions | difference(['']) | flatten(levels=1) }}"
   loop_control:
     loop_var: sap_note_line_item
   when: __sap_netweaver_preconfigure_sapnotes_versions is defined

--- a/roles/sap_netweaver_preconfigure/tasks/sapnote/2526952.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/sapnote/2526952.yml
@@ -25,11 +25,9 @@
 
 - name: Display the output of the tuned-adm active command
   ansible.builtin.debug:
-    var: __sap_netweaver_preconfigure_register_current_tuned_profile.stdout_lines, __sap_netweaver_preconfigure_register_current_tuned_profile.stderr_lines
-
-#- name: Set a variable which contains the name of the currently active tuned profile
-#  set_fact:
-#    __sap_netweaver_preconfigure_register_active_tuned_profile: "{{ __sap_netweaver_preconfigure_register_current_tuned_profile.stdout }}"
+    msg: |
+      {{ __sap_netweaver_preconfigure_register_current_tuned_profile.stdout_lines | d('') }}
+      {{ __sap_netweaver_preconfigure_register_current_tuned_profile.stderr_lines | d('') }}
 
 - name: Switch to tuned profile sap-netweaver if not currently active
   when: __sap_netweaver_preconfigure_register_current_tuned_profile.stdout != 'sap-netweaver'
@@ -47,8 +45,6 @@
 
     - name: Display the output of the tuned-adm active command after switching to profile sap-netweaver
       ansible.builtin.debug:
-        var: __sap_netweaver_preconfigure_register_new_tuned_profile.stdout_lines, __sap_netweaver_preconfigure_register_new_tuned_profile.stderr_lines
-
-#    - name: Set a variable which contains the name of the now active tuned profile
-#      set_fact:
-#        __sap_netweaver_preconfigure_register_active_tuned_profile: "{{ __sap_netweaver_preconfigure_register_new_tuned_profile.stdout }}"
+        msg: |
+          {{ __sap_netweaver_preconfigure_register_new_tuned_profile.stdout_lines | d('') }}
+          {{ __sap_netweaver_preconfigure_register_new_tuned_profile.stderr_lines | d('') }}


### PR DESCRIPTION
preconfigure roles and sap_maintain_etc_hosts Ansible 2.19 readiness for RHEL managed nodes

Plus 3 x `with_items` -> `loop`

Relates to #1101 and #1102.

