### PR TITLE
sap_ha_install_hana_hsr: Fix linter failures

### DIFF
--- a/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
@@ -20,8 +20,8 @@
     -sr_enable --name="{{ item.hana_site }}"
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
-  register: enablesr
-  changed_when: "'successfully enabled system as system replication source site' in enablesr.stdout"
+  register: __sap_ha_install_hana_hsr_enablesr
+  changed_when: "'successfully enabled system as system replication source site' in __sap_ha_install_hana_hsr_enablesr.stdout"
   when:
     - __sap_ha_install_hana_hsr_node_name == item.node_name.split('.')[0]
     - item.node_role is defined and item.node_role == 'primary'
@@ -43,7 +43,7 @@
     --online
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
-  register: registersr
+  register: __sap_ha_install_hana_hsr_registersr
   when:
     - __sap_ha_install_hana_hsr_node_name == item.node_name.split('.')[0]
     - item.node_role is not defined or item.node_role == 'secondary'
@@ -60,8 +60,8 @@
     -nr {{ sap_ha_install_hana_hsr_instance_number }} -function StartSystem
   become: true
   become_user: "{{ sap_ha_install_hana_hsr_sid | lower }}adm"
-  register: startinstance
-  changed_when: "'StartSystem' in startinstance.stdout"
+  register: __sap_ha_install_hana_hsr_startinstance
+  changed_when: "'StartSystem' in __sap_ha_install_hana_hsr_startinstance.stdout"
   when:
     - __sap_ha_install_hana_hsr_node_name != __sap_ha_install_hana_hsr_primary_node_name
     - __sap_ha_install_hana_hsr_node_name not in __sap_ha_install_hana_hsr_srstate.stdout

--- a/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/run_backup.yml
@@ -186,5 +186,5 @@
   ansible.builtin.debug:
     msg: |
       Database backup was successfully completed.
-      Location: {{ __sap_ha_install_hana_hsr_backup_path_final}}
+      Location: {{ __sap_ha_install_hana_hsr_backup_path_final }}
       File prefix: {{ __sap_ha_install_hana_hsr_backup_prefix }}

--- a/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/update_etchosts.yml
@@ -5,9 +5,9 @@
     awk '(/{{ "( |\t)" + item.node_name + "($| |\t)" }}/ && !/^{{ item.node_ip + "( |\t)" }}/) \
     || (/^{{ item.node_ip + "( |\t)" }}/ \
     && !/{{ "( |\t)" + item.node_name + "($| |\t)" }}/)' /etc/hosts
-  register: etchosts_conflict
+  register: __sap_ha_install_hana_hsr_etchosts_conflict
   changed_when: false
-  failed_when: etchosts_conflict.stdout != ''
+  failed_when: __sap_ha_install_hana_hsr_etchosts_conflict.stdout != ''
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "Check if {{ item.node_ip }} exists for hosts other than {{ item.node_name }}"


### PR DESCRIPTION
- var-naming[no-role-prefix]
- jinja[spacing]

Tested with `ansible-lint 25.8.1`.