### PR TITLE
sap_swpm: extensive variable input validation

### DIFF
--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -169,24 +169,24 @@ sap_swpm_software_use_media: false
 sap_swpm_inifile_directory: '/software/sap_swpm/inifiles'
 
 # SWPM1 - paths that this role will look for CD Media software
-sap_swpm_cd_export_pt1_path:
-sap_swpm_cd_export_pt2_path:
-sap_swpm_cd_language_path:
-sap_swpm_cd_java_path:
-sap_swpm_cd_rdbms_path:
-sap_swpm_cd_export_path:
-sap_swpm_cd_ibmdb2_path:
-sap_swpm_cd_ibmdb2_client_path:
-sap_swpm_cd_oracle121_path:
-sap_swpm_cd_oracle121_client_path:
-sap_swpm_cd_sapase_path:
-sap_swpm_cd_sapmaxdb_path:
+sap_swpm_cd_export_pt1_path: ''
+sap_swpm_cd_export_pt2_path: ''
+sap_swpm_cd_language_path: ''
+sap_swpm_cd_java_path: ''
+sap_swpm_cd_rdbms_path: ''
+sap_swpm_cd_export_path: ''
+sap_swpm_cd_ibmdb2_path: ''
+sap_swpm_cd_ibmdb2_client_path: ''
+sap_swpm_cd_oracle121_path: ''
+sap_swpm_cd_oracle121_client_path: ''
+sap_swpm_cd_sapase_path: ''
+sap_swpm_cd_sapmaxdb_path: ''
 sap_swpm_ibmdb2_unpack_path: "/db2/db2{{ sap_swpm_db_sid | lower }}/db2_software"
 
 # --- Experimental --- #
 # MP Stack
-sap_swpm_mp_stack_path:
-sap_swpm_mp_stack_file_name:
+sap_swpm_mp_stack_path: ''
+sap_swpm_mp_stack_file_name: ''
 # SUM
 sap_swpm_sum_prepare: false
 sap_swpm_sum_start: false
@@ -195,17 +195,20 @@ sap_swpm_spam_update: false
 sap_swpm_spam_update_sar:
 sap_swpm_configure_tms: true
 sap_swpm_tmsadm_password: ''
-sap_swpm_tms_tr_files_path:
+sap_swpm_tms_tr_files_path: ''
 # --- Experimental --- #
 
 # --- Experimental - SWPM Observer mode --- #
 # Enables observer mode of SWPM - TO BE USED for debugging/troubleshooting mainly
 # This allows user to watch the installation progress from a browser (on standard port 4237) and possibly interact with it
-# Note: Interaction can impact the automated installation and may result in the need for further manual actions in order to complete the installation
+# Note: Interaction can impact the automated installation and may result in the need for further manual actions
+# in order to complete the installation
 sap_swpm_swpm_observer_mode: false
-# Allows to specify a different remote access user (e.g. when root's password is unknown). Default SWPM behaviour is to use root. This may not be desirable as
-# root's password may not be available for security reasons. The remote access user must exist before SWPM is executed (i.e. <sid>adm can't be used if it doesn't exist yet).
-sap_swpm_swpm_remote_access_user:
+# Allows to specify a different remote access user (e.g. when root's password is unknown).
+# Default SWPM behaviour is to use root. This may not be desirable as the password of the root user
+# may not be available for security reasons. The remote access user must exist before SWPM is executed
+# (i.e. <sid>adm can't be used if it doesn't exist yet).
+sap_swpm_swpm_remote_access_user: ''
 # --- Experimental - SWPM Observer mode --- #
 
 sap_swpm_install_saphostagent: true
@@ -306,11 +309,11 @@ sap_swpm_java_template_id_lookup_dictionary:
 #   - DB Connection (existing SAP HANA)
 ########################################
 
-sap_swpm_db_ip:
-sap_swpm_db_fqdn:
-sap_swpm_db_host:
-sap_swpm_db_sid:
-sap_swpm_db_instance_nr:
+sap_swpm_db_ip: ''
+sap_swpm_db_fqdn: ''
+sap_swpm_db_host: ''
+sap_swpm_db_sid: ''
+sap_swpm_db_instance_nr: ''
 
 sap_swpm_db_system_password: ''
 sap_swpm_db_systemdb_password: ''
@@ -323,20 +326,20 @@ sap_swpm_db_schema_abap_password: ''
 
 # New Install - define schema password (Java)
 # Restore - schema details from backup (Java)
-sap_swpm_db_schema_java:
+sap_swpm_db_schema_java: ''
 sap_swpm_db_schema_java_password: ''
 
-sap_swpm_db_schema:
+sap_swpm_db_schema: ''
 sap_swpm_db_schema_password: ''
 
 # JAVA UME
 sap_swpm_ume_client_nr: '000'
-sap_swpm_ume_type:
+sap_swpm_ume_type: ''
 sap_swpm_ume_instance_nr: '{{ sap_swpm_pas_instance_nr }}'
 sap_swpm_ume_j2ee_admin_password: ''
 sap_swpm_ume_j2ee_guest_password: ''
 sap_swpm_ume_sapjsf_password: ''
-sap_swpm_ume_instance_hostname:
+sap_swpm_ume_instance_hostname: ''
 
 
 ########################################
@@ -346,10 +349,10 @@ sap_swpm_ume_instance_hostname:
 ########################################
 
 # Location of the database backup files.
-sap_swpm_backup_location:
+sap_swpm_backup_location: ''
 
 # Backup prefix
-sap_swpm_backup_prefix:
+sap_swpm_backup_prefix: ''
 
 # SYSTEM password of the backup
 sap_swpm_backup_system_password: ''
@@ -364,20 +367,20 @@ sap_swpm_ascs_install_gateway: true
 #   - Web Dispatcher
 ########################################
 
-sap_swpm_wd_instance_nr:
+sap_swpm_wd_instance_nr: ''
 
 sap_swpm_wd_system_connectivity: false
 sap_swpm_wd_activate_icf: false
-sap_swpm_wd_backend_sid:
-sap_swpm_wd_backend_ms_http_port:
-sap_swpm_wd_backend_ms_host:
-sap_swpm_wd_backend_rfc_host:
-sap_swpm_wd_backend_rfc_instance_nr:
+sap_swpm_wd_backend_sid: ''
+sap_swpm_wd_backend_ms_http_port: ''
+sap_swpm_wd_backend_ms_host: ''
+sap_swpm_wd_backend_rfc_host: ''
+sap_swpm_wd_backend_rfc_instance_nr: ''
 sap_swpm_wd_backend_rfc_client_nr: # 000 default
 sap_swpm_wd_backend_rfc_user: # DDIC default
 sap_swpm_wd_backend_rfc_user_password: ''
-sap_swpm_wd_backend_scenario_size:
-sap_swpm_wd_virtual_host:
+sap_swpm_wd_backend_scenario_size: ''
+sap_swpm_wd_virtual_host: ''
 
 
 ########################################
@@ -389,9 +392,9 @@ sap_swpm_wd_virtual_host:
 sap_swpm_sapadm_password: ''
 #sap_swpm_sap_sidadm_password: ''
 
-sap_swpm_sapadm_uid:
-sap_swpm_sapsys_gid:
-sap_swpm_sidadm_uid:
+sap_swpm_sapadm_uid: ''
+sap_swpm_sapsys_gid: ''
+sap_swpm_sidadm_uid: ''
 
 
 ########################################
@@ -409,22 +412,22 @@ sap_swpm_diagnostics_agent_password: ''
 # will follow sap_swpm_software_path
 # alternatively, can be detected and set with sap_install_media_detect Ansible Role
 
-sap_swpm_igs_path:
-sap_swpm_igs_file_name:
-sap_swpm_igs_helper_path:
-sap_swpm_igs_helper_file_name:
-sap_swpm_kernel_dependent_path:
-sap_swpm_kernel_dependent_file_name:
-sap_swpm_kernel_independent_path:
-sap_swpm_kernel_independent_file_name:
-sap_swpm_web_dispatcher_path:
-sap_swpm_web_dispatcher_file_name:
-sap_swpm_fqdn:
+sap_swpm_igs_path: ''
+sap_swpm_igs_file_name: ''
+sap_swpm_igs_helper_path: ''
+sap_swpm_igs_helper_file_name: ''
+sap_swpm_kernel_dependent_path: ''
+sap_swpm_kernel_dependent_file_name: ''
+sap_swpm_kernel_independent_path: ''
+sap_swpm_kernel_independent_file_name: ''
+sap_swpm_web_dispatcher_path: ''
+sap_swpm_web_dispatcher_file_name: ''
+sap_swpm_fqdn: ''
 sap_swpm_set_fqdn: true
 
 # If the template to use already has the passwords and they are encrypted the password file must be in the same path as the parameter file
 sap_swpm_use_password_file: false
-sap_swpm_password_file_path:
+sap_swpm_password_file_path: ''
 
 sap_swpm_use_livecache: false
 sap_swpm_ddic_001_password: ''

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -376,8 +376,8 @@ sap_swpm_wd_backend_ms_http_port: ''
 sap_swpm_wd_backend_ms_host: ''
 sap_swpm_wd_backend_rfc_host: ''
 sap_swpm_wd_backend_rfc_instance_nr: ''
-sap_swpm_wd_backend_rfc_client_nr: # 000 default
-sap_swpm_wd_backend_rfc_user: # DDIC default
+sap_swpm_wd_backend_rfc_client_nr: '' # 000 default
+sap_swpm_wd_backend_rfc_user: '' # DDIC default
 sap_swpm_wd_backend_rfc_user_password: ''
 sap_swpm_wd_backend_scenario_size: ''
 sap_swpm_wd_virtual_host: ''

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -190,9 +190,9 @@ sap_swpm_mp_stack_file_name: ''
 # SUM
 sap_swpm_sum_prepare: false
 sap_swpm_sum_start: false
-sap_swpm_sum_batch_file:
+sap_swpm_sum_batch_file: ''
 sap_swpm_spam_update: false
-sap_swpm_spam_update_sar:
+sap_swpm_spam_update_sar: ''
 sap_swpm_configure_tms: true
 sap_swpm_tmsadm_password: ''
 sap_swpm_tms_tr_files_path: ''

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -52,10 +52,6 @@ sap_swpm_files_non_sapcar_group: root
 # Have the role run the sapinst command with an existing inifile or after creating the inifile:
 sap_swpm_run_sapinst: true
 
-# Inifile Reuse Mode
-sap_swpm_inifile_reuse_source:
-sap_swpm_inifile_reuse_destination:
-
 #sap_swpm_inifile_parameters_dict:
 #  archives.downloadBasket: /software/download_basket
 #  NW_getFQDN.FQDN: poc.cloud
@@ -140,24 +136,10 @@ sap_swpm_inifile_sections_list:
 
 # SAP product that will be installed and passed as argument to the sapinst installer, example 'NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP'
 # Needs to be defined in the playbook or inventory or can be determined from an existing inifile.params file.
-#sap_swpm_product_catalog_id:
-
-# SAPCAR path and file name, only path is mandatory. The script will automatically get file_name
-sap_swpm_sapcar_path:
-sap_swpm_sapcar_file_name:
-
-# SWPM path and file name, only path is mandatory. The script will automatically get file_name
-sap_swpm_swpm_path: # e.g. /software/sap_swpm
-sap_swpm_swpm_sar_file_name:
-sap_swpm_software_extract_directory: # e.g. /software/sap_swpm_extracted
-
-# Note:
-# When using SWPM2 (for modern SAP products such as S/4 B/4), using .SAR files is recommended - param value should be false
-# When using SWPM1 (for older SAP products), using CD Media is the only choice - param value should be true
-sap_swpm_software_use_media: false
+sap_swpm_product_catalog_id: ''
 
 # Main path that this role will look for .SAR files
-#sap_swpm_software_path: /software/sapfiles
+sap_swpm_software_path: '/software/sapfiles'
 ## This directory path should include these files:
 ##   - igs*sar
 ##   - igshelper*sar
@@ -166,9 +148,25 @@ sap_swpm_software_use_media: false
 ##   - IMDB_CLIENT*SAR
 ##   - SAPHOSTAGENT*SAR
 
+# Directory and file name of SAPCAR*EXE. Only path is mandatory. The role will automatically determine file_name
+sap_swpm_sapcar_path: "{{ sap_swpm_software_path }}"
+# sap_swpm_sapcar_file_name:
+
+# Directory and file name of SWPM. Only path is mandatory. The role will automatically determine file_name
+sap_swpm_swpm_path: "{{ sap_swpm_software_path }}"
+# sap_swpm_swpm_sar_file_name:
+#
+# Define your own software extraction directory. If undefined, the role will use './extracted' as a subdirectory
+# of sap_swpm_swpm_path.
+# sap_swpm_software_extract_directory: # e.g. /software/sap_swpm_extracted
+
+# Note:
+# When using SWPM2 (for modern SAP products such as S/4 B/4), using .SAR files is recommended - param value should be false
+# When using SWPM1 (for older SAP products), using CD Media is the only choice - param value should be true
+sap_swpm_software_use_media: false
+
 # Directory in which a sapinst inifile which is to be used by the role can be stored:
 sap_swpm_inifile_directory: '/software/sap_swpm/inifiles'
-#sap_swpm_local_inifile_directory: '/tmp/inifiles'
 
 # SWPM1 - paths that this role will look for CD Media software
 sap_swpm_cd_export_pt1_path:
@@ -196,7 +194,7 @@ sap_swpm_sum_batch_file:
 sap_swpm_spam_update: false
 sap_swpm_spam_update_sar:
 sap_swpm_configure_tms: true
-sap_swpm_tmsadm_password:
+sap_swpm_tmsadm_password: ''
 sap_swpm_tms_tr_files_path:
 # --- Experimental --- #
 
@@ -219,29 +217,29 @@ sap_swpm_install_saphostagent: true
 #   - SAP NetWeaver
 ########################################
 
-sap_swpm_sid: ""
-sap_swpm_ascs_instance_nr: ""
-sap_swpm_ascs_instance_hostname: ""
-sap_swpm_ers_instance_nr: ""
-sap_swpm_ers_instance_hostname: ""
-sap_swpm_pas_instance_nr: ""
-sap_swpm_pas_instance_hostname: ""
-sap_swpm_aas_instance_nr: ""
-sap_swpm_aas_instance_hostname: ""
+sap_swpm_sid: ''
+sap_swpm_ascs_instance_nr: ''
+sap_swpm_ascs_instance_hostname: ''
+sap_swpm_ers_instance_nr: ''
+sap_swpm_ers_instance_hostname: ''
+sap_swpm_pas_instance_nr: ''
+sap_swpm_pas_instance_hostname: ''
+sap_swpm_aas_instance_nr: ''
+sap_swpm_aas_instance_hostname: ''
 
-sap_swpm_java_scs_instance_nr: ""
-sap_swpm_java_scs_instance_hostname: ""
+sap_swpm_java_scs_instance_nr: ''
+sap_swpm_java_scs_instance_hostname: ''
 
 # Password used for all users created during SWPM installation
-sap_swpm_master_password:
+sap_swpm_master_password: ''
 
 # New Install - define DDIC 000 password
 # Restore - DDIC 000 password from backup
-sap_swpm_ddic_000_password:
+sap_swpm_ddic_000_password: ''
 
 # initial = not an HA setup
 # set this in the input file when installing ascs, ers to indicate an HA setup
-sap_swpm_virtual_hostname:
+sap_swpm_virtual_hostname: ''
 
 
 ########################################
@@ -314,30 +312,30 @@ sap_swpm_db_host:
 sap_swpm_db_sid:
 sap_swpm_db_instance_nr:
 
-sap_swpm_db_system_password:
-sap_swpm_db_systemdb_password:
-sap_swpm_db_sidadm_password:
+sap_swpm_db_system_password: ''
+sap_swpm_db_systemdb_password: ''
+sap_swpm_db_sidadm_password: ''
 
 # New Install - define schema (ABAP), e.g. SAP HANA = SAPHANADB, SAP on IBM Db2 = ABAP or SAPABAP1, SAP on Oracle DB = SAPSR3 (6 characters)
 # Restore - schema details from backup (ABAP)
 sap_swpm_db_schema_abap: "SAPHANADB"
-sap_swpm_db_schema_abap_password:
+sap_swpm_db_schema_abap_password: ''
 
 # New Install - define schema password (Java)
 # Restore - schema details from backup (Java)
 sap_swpm_db_schema_java:
-sap_swpm_db_schema_java_password:
+sap_swpm_db_schema_java_password: ''
 
 sap_swpm_db_schema:
-sap_swpm_db_schema_password:
+sap_swpm_db_schema_password: ''
 
 # JAVA UME
 sap_swpm_ume_client_nr: '000'
 sap_swpm_ume_type:
 sap_swpm_ume_instance_nr: '{{ sap_swpm_pas_instance_nr }}'
-sap_swpm_ume_j2ee_admin_password:
-sap_swpm_ume_j2ee_guest_password:
-sap_swpm_ume_sapjsf_password:
+sap_swpm_ume_j2ee_admin_password: ''
+sap_swpm_ume_j2ee_guest_password: ''
+sap_swpm_ume_sapjsf_password: ''
 sap_swpm_ume_instance_hostname:
 
 
@@ -354,7 +352,7 @@ sap_swpm_backup_location:
 sap_swpm_backup_prefix:
 
 # SYSTEM password of the backup
-sap_swpm_backup_system_password:
+sap_swpm_backup_system_password: ''
 
 # ASCS Install Gateway
 sap_swpm_ascs_install_gateway: true
@@ -377,7 +375,7 @@ sap_swpm_wd_backend_rfc_host:
 sap_swpm_wd_backend_rfc_instance_nr:
 sap_swpm_wd_backend_rfc_client_nr: # 000 default
 sap_swpm_wd_backend_rfc_user: # DDIC default
-sap_swpm_wd_backend_rfc_user_password:
+sap_swpm_wd_backend_rfc_user_password: ''
 sap_swpm_wd_backend_scenario_size:
 sap_swpm_wd_virtual_host:
 
@@ -388,8 +386,8 @@ sap_swpm_wd_virtual_host:
 #   - Unix user
 ########################################
 
-sap_swpm_sapadm_password:
-sap_swpm_sap_sidadm_password:
+sap_swpm_sapadm_password: ''
+#sap_swpm_sap_sidadm_password: ''
 
 sap_swpm_sapadm_uid:
 sap_swpm_sapsys_gid:
@@ -404,7 +402,7 @@ sap_swpm_sidadm_uid:
 
 sap_swpm_parallel_jobs_nr: '23'
 
-sap_swpm_diagnostics_agent_password:
+sap_swpm_diagnostics_agent_password: ''
 
 
 ## --- Individual Software Paths --- ##
@@ -429,17 +427,10 @@ sap_swpm_use_password_file: false
 sap_swpm_password_file_path:
 
 sap_swpm_use_livecache: false
-sap_swpm_ddic_001_password:
+sap_swpm_ddic_001_password: ''
 sap_swpm_load_type: 'SAP'
 
-
 sap_swpm_generic: false
-
-# SWPM
-sap_swpm_swpm_installation_type: ""
-sap_swpm_swpm_installation_header: ""
-sap_swpm_swpm_command_virtual_hostname: ""
-sap_swpm_swpm_command_mp_stack: ""
 
 # Set linux user password expiry settings
 sap_swpm_set_sidadm_noexpire: true

--- a/roles/sap_swpm/defaults/main.yml
+++ b/roles/sap_swpm/defaults/main.yml
@@ -390,7 +390,7 @@ sap_swpm_wd_virtual_host: ''
 ########################################
 
 sap_swpm_sapadm_password: ''
-#sap_swpm_sap_sidadm_password: ''
+sap_swpm_sap_sidadm_password: ''
 
 sap_swpm_sapadm_uid: ''
 sap_swpm_sapsys_gid: ''

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -370,14 +370,15 @@
     # If SWPM is running a normal install Ansible Variable sap_swpm_swpm_command_virtual_hostname is blank
     # IF SWPM is running a HA installation, Ansible Variable sap_swpm_swpm_command_virtual_hostname is set and contains "SAPINST_USE_HOSTNAME={{ sap_swpm_virtual_hostname }} IS_HOST_LOCAL_USING_STRING_COMPARE=true"
     # If SWPM is running a MP Stack XML installation, Ansible Variable sap_swpm_swpm_command_mp_stack is set and contains "SAPINST_STACK_XML={{ sap_swpm_mp_stack_path }} + '/' (if needed) + {{ sap_swpm_mp_stack_file_name }}"
-    sap_swpm_swpm_command_extra_args: "SAPINST_SKIP_DIALOGS=true {{ sap_swpm_swpm_command_guiserver }} {{ sap_swpm_swpm_command_observer }} {{ sap_swpm_swpm_command_virtual_hostname }} {{ sap_swpm_swpm_command_mp_stack }}"
+    sap_swpm_swpm_command_extra_args: "SAPINST_SKIP_DIALOGS=true {{ sap_swpm_swpm_command_guiserver }} {{ sap_swpm_swpm_command_observer }} {{ sap_swpm_swpm_command_virtual_hostname | d('') }} {{ sap_swpm_swpm_command_mp_stack | d('') }}"
   tags: sap_swpm_sapinst_commandline
 
 - name: Set fact for the sapinst command line
   ansible.builtin.set_fact:
-    __sap_swpm_sapinst_command: "umask {{ sap_swpm_umask | d('022') }} ; ./sapinst {{ sap_swpm_swpm_command_inifile }}
-    {{ sap_swpm_swpm_command_product_id }}
-    {{ sap_swpm_swpm_command_extra_args }}"
+    __sap_swpm_sapinst_command: >-
+      umask {{ sap_swpm_umask | d('022') }} ; ./sapinst {{ sap_swpm_swpm_command_inifile }}
+      {{ sap_swpm_swpm_command_product_id }}
+      {{ sap_swpm_swpm_command_extra_args }}
   tags: sap_swpm_sapinst_commandline
 
 - name: Display the sapinst command line

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -230,7 +230,7 @@
       ansible.builtin.set_fact:
         __sap_swpm_fact_inifile_vars_validation_failures: |
          {{ (__sap_swpm_register_inifile_vars_validation_test_result.content | b64decode).splitlines()
-            | select('search', 'FAIL')
+            | select('match', '^(?!#).*FAIL.*')
             | unique
             | d([])
          }}

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -236,7 +236,7 @@
       ansible.builtin.set_fact:
         __sap_swpm_fact_inifile_vars_validation_failures: |
          {{ (__sap_swpm_register_inifile_vars_validation_test_result.content | b64decode).splitlines()
-            | select('match', '^(?!#).*FAIL.*')
+            | select('match', '^(?!#).*ERROR:.*')
             | unique
             | d([])
          }}
@@ -245,7 +245,7 @@
       ansible.builtin.fail:
         msg: |
           {% for __sap_swpm_inifile_vars_validation_failure in __sap_swpm_fact_inifile_vars_validation_failures %}
-          {{ __sap_swpm_inifile_vars_validation_failure }}
+          {{ __sap_swpm_inifile_vars_validation_failure | regex_replace('ERROR:', '') | regex_replace('XXX', '\n') }}
           {% endfor %}
       when: __sap_swpm_fact_inifile_vars_validation_failures | length > 0
 

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -15,6 +15,9 @@
 - name: SAP SWPM Pre Install - Define the temporary directory for SWPM
   ansible.builtin.set_fact:
     __sap_swpm_fact_tempdir_from_env: "{{ ansible_env.TEMP | d('/tmp') }}"
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
 
 - name: SAP SWPM Pre Install - Define 'sap_swpm_inifile_sections_list' from 'sap_swpm_inifile_list' if necessary
   ansible.builtin.set_fact:
@@ -133,6 +136,52 @@
     sap_swpm_inifile_sections_list: "{{ sap_swpm_inifile_sections_list | d([]) }}"
     sap_swpm_inifile_parameters_dict: "{{ sap_swpm_inifile_parameters_dict | d({}) }}"
   tags: always
+
+- name: SAP SWPM Pre Install - Validate all vars in sap_swpm_inifile_sections_list
+  when: sap_swpm_inifile_sections_list is defined
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
+  block:
+    - name: SAP SWPM Pre Install - Validate all vars in sap_swpm_inifile_sections_list
+      ansible.builtin.template:
+        src: "{{ role_path }}/templates/inifile_params.j2"
+        dest: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        owner: 'root'
+        group: 'root'
+        mode: '0644'
+      check_mode: false
+      changed_when: false
+
+    - name: SAP SWPM Pre Install - Check for variables with length 0
+      ansible.builtin.slurp:
+        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+      register: __sap_swpm_register_inifile_params_validation_test_result
+#      changed_when: false
+
+#      ansible.builtin.command: "grep FAIL: {{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+#      register: __sap_swpm_register_command_grep_result
+#      changed_when: false
+
+    - name: SAP SWPM Pre Install - Identify FAIL in the validation output
+      ansible.builtin.set_fact:
+        __sap_swpm_register_inifile_params_validation_failures: |
+         {{ (__sap_swpm_register_inifile_params_validation_test_result.content | b64decode).splitlines() | select('search', 'FAIL') }}
+
+    - name: SAP SWPM Pre Install - Display variables which have been defined incorrectly
+      ansible.builtin.fail:
+        msg: |
+          {{ __sap_swpm_register_inifile_params_validation_failures_line_item.split()[2:] | join(' ') }}
+      loop: "{{ __sap_swpm_register_inifile_params_validation_failures }}"
+      loop_control:
+        loop_var: __sap_swpm_register_inifile_params_validation_failures_line_item
+        label: " Related inifile parameter: {{ __sap_swpm_register_inifile_params_validation_failures_line_item.split()[0] }}"
+      when: __sap_swpm_register_inifile_params_validation_failures | length > 0
+
+  rescue:
+    - name: SAP SWPM Pre Install - Template validation failed
+      ansible.builtin.fail:
+        msg: "Template validation failed - please configure your role variables and restart!"
 
 # Assert correct hostname and IP resolution of virtual hostname and IP if:
 # - sapinst is requested to be run, and

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -1,7 +1,62 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: SAP SWPM Pre Install - Assert the number of characters in the hostname, see SAP note 611361
+# Find out early if an inifile already exists:
+- name: SAP SWPM Pre Install - Check if file '{{ sap_swpm_inifile_directory }}/inifile.params' exists on the managed node
+  ansible.builtin.stat:
+    path: "{{ sap_swpm_inifile_directory }}/inifile.params"
+  check_mode: false
+  register: __sap_swpm_register_stat_sapinst_inifile
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
+
+- name: SAP SWPM Pre Install - Notify about the SWPM inifile not being present on the managed node
+  ansible.builtin.debug:
+    msg: |
+      There is no existing SWPM inifile at '{{ sap_swpm_inifile_directory }}/inifile.params'.
+      So the role will create an inifile.
+  when: not __sap_swpm_register_stat_sapinst_inifile.stat.exists
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
+
+- name: SAP SWPM Pre Install - Notify about existing SWPM inifile on the managed node
+  ansible.builtin.debug:
+    msg: "INFO: Using existing SWPM inifile '{{ sap_swpm_inifile_directory }}/inifile.params'."
+  when: __sap_swpm_register_stat_sapinst_inifile.stat.exists
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
+
+- name: SAP SWPM Pre Install - New inifile - Assert that certain important variables are set
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') != 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name) is string
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name) | trim | length > 0
+    success_msg: |
+      PASS: The variable '{{ __sap_swpm_var_name }}' is valid.
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', __sap_swpm_essential_vars_line_item, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') == 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED' %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', __sap_swpm_essential_vars_line_item) is not string %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is not a String.
+      {% else %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is empty.
+      {% endif %}
+  loop:
+    - sap_swpm_software_path
+    - sap_swpm_product_catalog_id
+    - sap_swpm_sid
+    - sap_swpm_fqdn
+  loop_control:
+    loop_var: __sap_swpm_essential_vars_line_item
+  vars:
+    __sap_swpm_var_name: "{{ __sap_swpm_essential_vars_line_item }}"
+  when: not __sap_swpm_register_stat_sapinst_inifile.stat.exists
+
+- name: SAP SWPM Pre Install - Assert the hostname compliance with SAP note 611361
   ansible.builtin.include_tasks:
     file: pre_install/assert_hostname.yml
     apply:
@@ -25,6 +80,7 @@
   when:
     - sap_swpm_inifile_sections_list is undefined
     - sap_swpm_inifile_list is defined
+    - "'sap_swpm_generate_inifile' in ansible_run_tags or (not __sap_swpm_register_stat_sapinst_inifile.stat.exists)"
   tags: always
 
 - name: SAP SWPM Pre Install - Define 'sap_swpm_inifile_parameters_dict' from 'sap_swpm_inifile_custom_values_dictionary' if necessary
@@ -33,11 +89,14 @@
   when:
     - sap_swpm_inifile_parameters_dict is undefined
     - sap_swpm_inifile_custom_values_dictionary is defined
+    - "'sap_swpm_generate_inifile' in ansible_run_tags or (not __sap_swpm_register_stat_sapinst_inifile.stat.exists)"
   tags: always
 
 # Note: Variable definitions in sap_swpm_templates_install_dictionary will overwrite existing top level definitions.
 - name: SAP SWPM Pre Install - Define variables from 'sap_swpm_templates_install_dictionary' if present
-  when: sap_swpm_templates_install_dictionary is defined
+  when:
+    - sap_swpm_templates_install_dictionary is defined
+    - "'sap_swpm_generate_inifile' in ansible_run_tags or (not __sap_swpm_register_stat_sapinst_inifile.stat.exists)"
   tags: always
   block:
 
@@ -137,8 +196,17 @@
     sap_swpm_inifile_parameters_dict: "{{ sap_swpm_inifile_parameters_dict | d({}) }}"
   tags: always
 
+# We are validating all vars which are used in the inifile by templating. The first phase is
+# to fail on any undefined variable, which is the default behavior of the template module.
+# The Jinja2 template also contains validation code which will put lines starting with "FAIL: "
+# into the templating result if any condition is met. By searching for those lines in the
+# templating result, we can reliably identify any further validation error and display a
+# detailed validation error message.
+#
 - name: SAP SWPM Pre Install - Validate all vars in sap_swpm_inifile_sections_list
-  when: sap_swpm_inifile_sections_list is defined
+  when:
+    - sap_swpm_inifile_sections_list is defined
+    - "'sap_swpm_generate_inifile' in ansible_run_tags or (not __sap_swpm_register_stat_sapinst_inifile.stat.exists)"
   tags:
     - sap_swpm_generate_inifile
     - sap_swpm_sapinst_commandline
@@ -156,32 +224,46 @@
     - name: SAP SWPM Pre Install - Check for variables with length 0
       ansible.builtin.slurp:
         path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
-      register: __sap_swpm_register_inifile_params_validation_test_result
-#      changed_when: false
+      register: __sap_swpm_register_inifile_vars_validation_test_result
 
-#      ansible.builtin.command: "grep FAIL: {{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
-#      register: __sap_swpm_register_command_grep_result
-#      changed_when: false
-
-    - name: SAP SWPM Pre Install - Identify FAIL in the validation output
+    - name: SAP SWPM Pre Install - Identify FAIL in the templating output
       ansible.builtin.set_fact:
-        __sap_swpm_register_inifile_params_validation_failures: |
-         {{ (__sap_swpm_register_inifile_params_validation_test_result.content | b64decode).splitlines() | select('search', 'FAIL') }}
+        __sap_swpm_fact_inifile_vars_validation_failures: |
+         {{ (__sap_swpm_register_inifile_vars_validation_test_result.content | b64decode).splitlines()
+            | select('search', 'FAIL')
+            | unique
+            | d([])
+         }}
 
     - name: SAP SWPM Pre Install - Display variables which have been defined incorrectly
       ansible.builtin.fail:
         msg: |
-          {{ __sap_swpm_register_inifile_params_validation_failures_line_item.split()[2:] | join(' ') }}
-      loop: "{{ __sap_swpm_register_inifile_params_validation_failures }}"
-      loop_control:
-        loop_var: __sap_swpm_register_inifile_params_validation_failures_line_item
-        label: " Related inifile parameter: {{ __sap_swpm_register_inifile_params_validation_failures_line_item.split()[0] }}"
-      when: __sap_swpm_register_inifile_params_validation_failures | length > 0
+          {% for __sap_swpm_inifile_vars_validation_failure in __sap_swpm_fact_inifile_vars_validation_failures %}
+          {{ __sap_swpm_inifile_vars_validation_failure }}
+          {% endfor %}
+      when: __sap_swpm_fact_inifile_vars_validation_failures | length > 0
+
+    - name: SAP SWPM Pre Install - Remove the templating result if the validation was successful
+      ansible.builtin.file:
+        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        state: absent
+      when: __sap_swpm_fact_inifile_vars_validation_failures | length == 0
 
   rescue:
-    - name: SAP SWPM Pre Install - Template validation failed
+    - name: SAP SWPM Pre Install - Validation failed - Remove the templating result if run without verbosity
+      ansible.builtin.file:
+        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        state: absent
+      when: ansible_verbosity == 0
+
+    - name: SAP SWPM Pre Install - Validation failed - Notify about keeping the templating result if run with verbosity
+      ansible.builtin.debug:
+        msg: "Keeping file '{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt' for debugging purposes."
+      when: ansible_verbosity != 0
+
+    - name: SAP SWPM Pre Install - Validation failed
       ansible.builtin.fail:
-        msg: "Template validation failed - please configure your role variables and restart!"
+        msg: "Validation failed - Please configure the failed role variables correctly and restart!"
 
 # Assert correct hostname and IP resolution of virtual hostname and IP if:
 # - sapinst is requested to be run, and
@@ -195,7 +277,7 @@
       tags: sap_swpm_update_etchosts
   when:
     - sap_swpm_run_sapinst
-    - sap_swpm_update_etchosts
+    - sap_swpm_update_etchosts | bool
     - sap_swpm_virtual_hostname | type_debug != 'NoneType'
     - sap_swpm_virtual_hostname | length > 0
   tags: sap_swpm_update_etchosts

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -29,44 +29,6 @@
     - sap_swpm_generate_inifile
     - sap_swpm_sapinst_commandline
 
-- name: SAP SWPM Pre Install - New inifile - Assert that certain important variables are set
-  ansible.builtin.assert:
-    that:
-      - lookup('ansible.builtin.vars', __sap_swpm_var_name, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') != 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED'
-      - lookup('ansible.builtin.vars', __sap_swpm_var_name) is string
-      - lookup('ansible.builtin.vars', __sap_swpm_var_name) | trim | length > 0
-    success_msg: |
-      PASS: The variable '{{ __sap_swpm_var_name }}' is valid.
-    fail_msg: |
-      {% if lookup('ansible.builtin.vars', __sap_swpm_essential_vars_line_item, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') == 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED' %}
-        FAIL: The variable '{{ __sap_swpm_var_name }}' is undefined.
-      {% elif lookup('ansible.builtin.vars', __sap_swpm_essential_vars_line_item) is not string %}
-        FAIL: The variable '{{ __sap_swpm_var_name }}' is not a String.
-      {% else %}
-        FAIL: The variable '{{ __sap_swpm_var_name }}' is empty.
-      {% endif %}
-  loop:
-    - sap_swpm_software_path
-    - sap_swpm_product_catalog_id
-    - sap_swpm_sid
-    - sap_swpm_fqdn
-  loop_control:
-    loop_var: __sap_swpm_essential_vars_line_item
-  vars:
-    __sap_swpm_var_name: "{{ __sap_swpm_essential_vars_line_item }}"
-  when: not __sap_swpm_register_stat_sapinst_inifile.stat.exists
-
-- name: SAP SWPM Pre Install - Assert the hostname compliance with SAP note 611361
-  ansible.builtin.include_tasks:
-    file: pre_install/assert_hostname.yml
-    apply:
-      tags:
-        - sap_swpm_generate_inifile
-        - sap_swpm_sapinst_commandline
-  tags:
-    - sap_swpm_generate_inifile
-    - sap_swpm_sapinst_commandline
-
 - name: SAP SWPM Pre Install - Define the temporary directory for SWPM
   ansible.builtin.set_fact:
     __sap_swpm_fact_tempdir_from_env: "{{ ansible_env.TEMP | d('/tmp') }}"
@@ -103,7 +65,7 @@
     - name: SAP SWPM Pre Install - Display 'sap_swpm_templates_product_input'
       ansible.builtin.debug:
         msg:
-          - "sap_swpm_templates_product_input: >{{ sap_swpm_templates_product_input }}<"
+          - "sap_swpm_templates_product_input: '{{ sap_swpm_templates_product_input }}'"
       ignore_errors: true
 
     - name: SAP SWPM Pre Install - Fail if 'sap_swpm_inifile_sections_list' and 'sap_swpm_inifile_list' are both defined in the dict
@@ -129,14 +91,12 @@
 # Unconditionally define sap_swpm_product_catalog_id from low level member.
     - name: SAP SWPM Pre Install - Define 'sap_swpm_product_catalog_id' from low level member with the same name
       ansible.builtin.set_fact:
-#        sap_swpm_product_catalog_id: "{{ sap_swpm_product_catalog_id |
-#          d(sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_product_catalog_id']) }}"
         sap_swpm_product_catalog_id: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_product_catalog_id'] }}"
       when: sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_product_catalog_id'] is defined
 
     - name: SAP SWPM Pre Install - Display 'sap_swpm_product_catalog_id'
       ansible.builtin.debug:
-        msg: "sap_swpm_product_catalog_id: >{{ sap_swpm_product_catalog_id }}<"
+        msg: "sap_swpm_product_catalog_id: '{{ sap_swpm_product_catalog_id }}'"
 
 # Unconditionally define sap_swpm_inifile_sections_list from low level member.
     - name: SAP SWPM Pre Install - Define 'sap_swpm_inifile_sections_list' from low level member
@@ -156,28 +116,33 @@
 
     - name: SAP SWPM Pre Install - Display 'sap_swpm_role_parameters_dict'
       ansible.builtin.debug:
-        msg: "sap_swpm_role_parameters_dict: >{{ sap_swpm_role_parameters_dict }}<"
-      when: sap_swpm_role_parameters_dict is defined and sap_swpm_role_parameters_dict
+        msg: "sap_swpm_role_parameters_dict: '{{ sap_swpm_role_parameters_dict }}'"
+      when:
+        - sap_swpm_role_parameters_dict is defined
+        - sap_swpm_role_parameters_dict | length > 0
       ignore_errors: true
 
 # Define role variables from low level member, looping over 'sap_swpm_role_parameters_dict'.
 # Reason for noqa: We are setting variables from the content of a dict, and the variable names are in the dict keys.
     - name: SAP SWPM Pre Install - Define role variables from low level member, looping over 'sap_swpm_role_parameters_dict' # noqa var-naming[no-jinja]
       ansible.builtin.set_fact:
-        "{{ line_item.key }}": "{{ line_item.value }}"
+        "{{ __sap_swpm_role_parameters_dict_line_item.key }}": "{{ __sap_swpm_role_parameters_dict_line_item.value }}"
       loop: "{{ sap_swpm_role_parameters_dict | dict2items if sap_swpm_role_parameters_dict is mapping else [] }}"
       loop_control:
-        loop_var: line_item
+        loop_var: __sap_swpm_role_parameters_dict_line_item
       when:
-        - sap_swpm_role_parameters_dict is defined and sap_swpm_role_parameters_dict
+        - sap_swpm_role_parameters_dict is defined
+        - sap_swpm_role_parameters_dict | length > 0
 
     - name: SAP SWPM Pre Install - Display all vars and values of 'sap_swpm_role_parameters_dict'
       ansible.builtin.debug:
-        msg: "{{ line_item.key }}: >{{ lookup('vars', line_item.key) }}<"
+        msg: "{{ __sap_swpm_role_parameters_dict_line_item.key }}: '{{ lookup('vars', __sap_swpm_role_parameters_dict_line_item.key) }}'"
       loop: "{{ sap_swpm_role_parameters_dict | dict2items if sap_swpm_role_parameters_dict is mapping else [] }}"
       loop_control:
-        loop_var: line_item
-      when: sap_swpm_role_parameters_dict is defined and sap_swpm_role_parameters_dict
+        loop_var: __sap_swpm_role_parameters_dict_line_item
+      when:
+        - sap_swpm_role_parameters_dict is defined
+        - sap_swpm_role_parameters_dict | length > 0
       ignore_errors: true
 
 # Define sap_swpm_inifile_parameters_dict from low level member, or use top level variable if defined. Low level definition has precedence.
@@ -196,6 +161,47 @@
     sap_swpm_inifile_parameters_dict: "{{ sap_swpm_inifile_parameters_dict | d({}) }}"
   tags: always
 
+- name: SAP SWPM Pre Install - New inifile - Assert that certain important variables are set
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') != 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name) is string
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name) | trim | length > 0
+    success_msg: |
+      PASS: The variable '{{ __sap_swpm_var_name }}' is valid.
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', __sap_swpm_essential_vars_line_item, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') == 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED' %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', __sap_swpm_essential_vars_line_item) is not string %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is not a String.
+      {% else %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is empty.
+      {% endif %}
+  loop:
+    - sap_swpm_software_path
+    - sap_swpm_product_catalog_id
+    - sap_swpm_sid
+    - sap_swpm_fqdn
+  loop_control:
+    loop_var: __sap_swpm_essential_vars_line_item
+  vars:
+    __sap_swpm_var_name: "{{ __sap_swpm_essential_vars_line_item }}"
+  when: not __sap_swpm_register_stat_sapinst_inifile.stat.exists
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
+
+- name: SAP SWPM Pre Install - Assert the hostname compliance with SAP note 611361
+  ansible.builtin.include_tasks:
+    file: pre_install/assert_hostname.yml
+    apply:
+      tags:
+        - sap_swpm_generate_inifile
+        - sap_swpm_sapinst_commandline
+  tags:
+    - sap_swpm_generate_inifile
+    - sap_swpm_sapinst_commandline
+
 # We are validating all vars which are used in the inifile by templating. The first phase is
 # to fail on any undefined variable, which is the default behavior of the template module.
 # The Jinja2 template also contains validation code which will put lines starting with "FAIL: "
@@ -211,10 +217,10 @@
     - sap_swpm_generate_inifile
     - sap_swpm_sapinst_commandline
   block:
-    - name: SAP SWPM Pre Install - Validate all vars in sap_swpm_inifile_sections_list
+    - name: SAP SWPM Pre Install - Validate all vars used for templating the inifile
       ansible.builtin.template:
         src: "{{ role_path }}/templates/inifile_params.j2"
-        dest: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        dest: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile-validation-test.params"
         owner: 'root'
         group: 'root'
         mode: '0644'
@@ -223,7 +229,7 @@
 
     - name: SAP SWPM Pre Install - Check for variables with length 0
       ansible.builtin.slurp:
-        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile-validation-test.params"
       register: __sap_swpm_register_inifile_vars_validation_test_result
 
     - name: SAP SWPM Pre Install - Identify FAIL in the templating output
@@ -245,20 +251,20 @@
 
     - name: SAP SWPM Pre Install - Remove the templating result if the validation was successful
       ansible.builtin.file:
-        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile-validation-test.params"
         state: absent
       when: __sap_swpm_fact_inifile_vars_validation_failures | length == 0
 
   rescue:
     - name: SAP SWPM Pre Install - Validation failed - Remove the templating result if run without verbosity
       ansible.builtin.file:
-        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt"
+        path: "{{ __sap_swpm_fact_tempdir_from_env }}/inifile-validation-test.params"
         state: absent
       when: ansible_verbosity == 0
 
     - name: SAP SWPM Pre Install - Validation failed - Notify about keeping the templating result if run with verbosity
       ansible.builtin.debug:
-        msg: "Keeping file '{{ __sap_swpm_fact_tempdir_from_env }}/inifile.params-validation-test.txt' for debugging purposes."
+        msg: "Keeping file '{{ __sap_swpm_fact_tempdir_from_env }}/inifile-validation-test.params' for debugging purposes."
       when: ansible_verbosity != 0
 
     - name: SAP SWPM Pre Install - Validation failed

--- a/roles/sap_swpm/tasks/pre_install.yml
+++ b/roles/sap_swpm/tasks/pre_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.debug:
     msg: |
       There is no existing SWPM inifile at '{{ sap_swpm_inifile_directory }}/inifile.params'.
-      So the role will create an inifile.
+      The role will create a new inifile.
   when: not __sap_swpm_register_stat_sapinst_inifile.stat.exists
   tags:
     - sap_swpm_generate_inifile
@@ -105,6 +105,7 @@
           d(sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_sections_list']) }}"
       when: sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_list'] is defined or
             sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_sections_list'] is defined
+      no_log: true
 
 # Define sap_swpm_role_parameters_dict from low level member.
     - name: SAP SWPM Pre Install - Define 'sap_swpm_role_parameters_dict' from low level member
@@ -113,10 +114,11 @@
           d(sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_role_parameters_dict']) }}"
       when: sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_dictionary'] is defined or
             sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_role_parameters_dict'] is defined
+      no_log: true
 
     - name: SAP SWPM Pre Install - Display 'sap_swpm_role_parameters_dict'
       ansible.builtin.debug:
-        msg: "sap_swpm_role_parameters_dict: '{{ sap_swpm_role_parameters_dict }}'"
+        msg: "sap_swpm_role_parameters_dict: '{{ sap_swpm_role_parameters_dict | reject('search', '^(__)?sap_swpm_.*_password$') }}'"
       when:
         - sap_swpm_role_parameters_dict is defined
         - sap_swpm_role_parameters_dict | length > 0
@@ -133,17 +135,7 @@
       when:
         - sap_swpm_role_parameters_dict is defined
         - sap_swpm_role_parameters_dict | length > 0
-
-    - name: SAP SWPM Pre Install - Display all vars and values of 'sap_swpm_role_parameters_dict'
-      ansible.builtin.debug:
-        msg: "{{ __sap_swpm_role_parameters_dict_line_item.key }}: '{{ lookup('vars', __sap_swpm_role_parameters_dict_line_item.key) }}'"
-      loop: "{{ sap_swpm_role_parameters_dict | dict2items if sap_swpm_role_parameters_dict is mapping else [] }}"
-      loop_control:
-        loop_var: __sap_swpm_role_parameters_dict_line_item
-      when:
-        - sap_swpm_role_parameters_dict is defined
-        - sap_swpm_role_parameters_dict | length > 0
-      ignore_errors: true
+      no_log: true
 
 # Define sap_swpm_inifile_parameters_dict from low level member, or use top level variable if defined. Low level definition has precedence.
     - name: SAP SWPM Pre Install - Define 'sap_swpm_inifile_parameters_dict' from low level member
@@ -152,6 +144,7 @@
           d(sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_parameters_dict']) }}"
       when: sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_custom_values_dictionary'] is defined or
             sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]['sap_swpm_inifile_parameters_dict'] is defined
+      no_log: true
 
 # The following task ensures that the two main inifile creation parameters are defined.
 # This is necessary when creating the file 'inifile.params'.

--- a/roles/sap_swpm/tasks/pre_install/assert_vars_length_loop_block.yml
+++ b/roles/sap_swpm/tasks/pre_install/assert_vars_length_loop_block.yml
@@ -3,7 +3,7 @@
 
 # loop block for pre_install/assert_inifile_vars.yml
 
-- name: SAP SWPM Pre Install - Assert variable '{{ __sap_swpm_vars_to_be_asserted_for_length_line_item }}' for 'length_greater_zero''
+- name: SAP SWPM Pre Install - Assert variable '{{ __sap_swpm_vars_to_be_asserted_for_length_line_item }}' for 'length_greater_zero'
   ansible.builtin.assert:
     that:
       - lookup('ansible.builtin.vars', __sap_swpm_var_name, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') != 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED'

--- a/roles/sap_swpm/tasks/pre_install/assert_vars_length_loop_block.yml
+++ b/roles/sap_swpm/tasks/pre_install/assert_vars_length_loop_block.yml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# loop block for pre_install/assert_inifile_vars.yml
+
+- name: SAP SWPM Pre Install - Assert variable '{{ __sap_swpm_vars_to_be_asserted_for_length_line_item }}' for 'length_greater_zero''
+  ansible.builtin.assert:
+    that:
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') != 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED'
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name) is string
+      - lookup('ansible.builtin.vars', __sap_swpm_var_name) | trim | length > 0
+    success_msg: |
+      PASS: The variable '{{ __sap_swpm_var_name }}' is valid.
+    fail_msg: |
+      {% if lookup('ansible.builtin.vars', __sap_swpm_var_name, default='SAP_SWPM_UNDEFINED_VARIABLE_DETECTED') == 'SAP_SWPM_UNDEFINED_VARIABLE_DETECTED' %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is undefined.
+      {% elif lookup('ansible.builtin.vars', __sap_swpm_var_name) is not string %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is not a String.
+      {% else %}
+        FAIL: The variable '{{ __sap_swpm_var_name }}' is empty.
+      {% endif %}
+  vars:
+    __sap_swpm_var_name: "{{ __sap_swpm_vars_to_be_asserted_for_length_line_item }}"

--- a/roles/sap_swpm/tasks/pre_install/detect_variables_from_inifile.yml
+++ b/roles/sap_swpm/tasks/pre_install/detect_variables_from_inifile.yml
@@ -14,7 +14,7 @@
   ansible.builtin.debug:
     msg: "NOTE: The Product ID in '{{ __sap_swpm_register_tmpdir.path }}/inifile.params' is different from the role parameter 'sap_swpm_inifile_product_id_detect'."
   when:
-    - sap_swpm_product_catalog_id
+    - sap_swpm_product_catalog_id | length > 0
     - sap_swpm_inifile_product_id_detect.stdout != sap_swpm_product_catalog_id
 
 - name: SAP SWPM Pre Install - Set SAP product ID
@@ -32,7 +32,7 @@
   ansible.builtin.debug:
     msg: "NOTE: The Software Path in '{{ __sap_swpm_register_tmpdir.path }}/inifile.params' is different from the role parameter 'sap_swpm_software_path'."
   when:
-    - sap_swpm_software_path
+    - sap_swpm_software_path | length > 0
     - sap_swpm_inifile_software_path_detect.stdout != sap_swpm_software_path
 
 - name: SAP SWPM Pre Install - Set Software Path
@@ -50,7 +50,7 @@
   ansible.builtin.debug:
     msg: "NOTE: The SID in '{{ __sap_swpm_register_tmpdir.path }}/inifile.params' is different from the role parameter 'sap_swpm_sid'."
   when:
-    - sap_swpm_sid
+    - sap_swpm_sid | length > 0
     - sap_swpm_inifile_sid_detect.stdout != sap_swpm_sid
 
 - name: SAP SWPM Pre Install - Set SID
@@ -68,7 +68,7 @@
   ansible.builtin.debug:
     msg: "NOTE: The FQDN in '{{ __sap_swpm_register_tmpdir.path }}/inifile.params' is different from the role parameter 'sap_swpm_fqdn'."
   when:
-    - sap_swpm_fqdn
+    - sap_swpm_fqdn | length > 0
     - sap_swpm_inifile_sid_detect.stdout != sap_swpm_fqdn
 
 - name: SAP SWPM Pre Install - Set FQDN

--- a/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
+++ b/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
@@ -55,18 +55,17 @@
 # At this point, the following variables need to be set:
 # sap_swpm_product_catalog_id, sap_swpm_software_path, sap_swpm_sid, sap_swpm_fqdn
 - name: SAP SWPM Pre Install - Assert that certain variables are set
-  ansible.builtin.assert:
-    that: "{{ __sap_swpm_vars_line_item }} is defined and {{ __sap_swpm_vars_line_item }}"
-    fail_msg: "FAIL: '{{ __sap_swpm_vars_line_item }}' is either undefined or empty!"
-    success_msg: "PASS: '{{ __sap_swpm_vars_line_item }}' is set."
+  ansible.builtin.include_tasks:
+    file: assert_vars_length_loop_block.yml
+    apply:
+      tags: sap_swpm_generate_inifile
   loop:
     - sap_swpm_product_catalog_id
     - sap_swpm_software_path
     - sap_swpm_sid
     - sap_swpm_fqdn
   loop_control:
-    loop_var: __sap_swpm_vars_line_item
-    label: __sap_swpm_vars_line_item
+    loop_var: __sap_swpm_vars_to_be_asserted_for_length_line_item
   tags: sap_swpm_generate_inifile
 
 - name: SAP SWPM Pre Install - Display these variables

--- a/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
+++ b/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
@@ -44,8 +44,8 @@
     apply:
       tags: sap_swpm_generate_inifile
   loop:
-    - sap_swpm_product_catalog_id
     - sap_swpm_software_path
+    - sap_swpm_product_catalog_id
     - sap_swpm_sid
     - sap_swpm_fqdn
   loop_control:

--- a/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
+++ b/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
@@ -1,30 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-# The following task is used for checking if an inifile exists on the managed node
-- name: SAP SWPM Pre Install - Ensure the sapinst inifile directory '{{ sap_swpm_inifile_directory }}' exists on the managed node
-  ansible.builtin.file:
-    path: "{{ sap_swpm_inifile_directory }}"
-    state: directory
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-
-- name: SAP SWPM Pre Install - Check if file '{{ sap_swpm_inifile_directory }}/inifile.params' exists on the managed node
-  ansible.builtin.stat:
-    path: "{{ sap_swpm_inifile_directory }}/inifile.params"
-  check_mode: false
-  register: __sap_swpm_register_stat_sapinst_inifile
-
 - name: SAP SWPM Pre Install - Try using existing SWPM inifile 'inifile.params'
   when: __sap_swpm_register_stat_sapinst_inifile.stat.exists
   block:
 
     - name: SAP SWPM Pre Install, existing inifile - Notify about existing sapinst inifile on the managed node
       ansible.builtin.debug:
-        msg: "INFO: Using existing sapinst inifile '{{ sap_swpm_inifile_directory }}/inifile.params'."
+        msg: "INFO: Using existing SWPM inifile '{{ sap_swpm_inifile_directory }}/inifile.params'."
 
-#    - name: SAP SWPM Pre Install, existing inifile - Copy 'inifile.params' to the control node
     - name: SAP SWPM Pre Install, existing inifile - Copy 'inifile.params' to __sap_swpm_register_tmpdir
       ansible.builtin.copy:
         src: "{{ sap_swpm_inifile_directory }}/inifile.params"
@@ -45,7 +29,7 @@
       ansible.builtin.fail:
         msg:
           - "Inifile '{{ sap_swpm_inifile_directory }}/inifile.params' cannot be reused because it contains des25 encrypted data."
-          - "See also SAP notes 2609804."
+          - "See also SAP note 2609804."
       when: sap_swpm_inifile_count_des25.stdout != '0'
 
     - name: SAP SWPM Pre Install - Detect Variables
@@ -84,13 +68,6 @@
   when: "'sap_swpm_generate_inifile' in ansible_run_tags or (not __sap_swpm_register_stat_sapinst_inifile.stat.exists)"
   tags: sap_swpm_generate_inifile
   block:
-
-#    - name: SAP SWPM Pre Install - Ensure role parameter 'sap_swpm_product_catalog_id' is defined
-#      ansible.builtin.fail:
-#        msg:
-#          - "Role parameter 'sap_swpm_product_catalog_id' is empty or not defined, so certain inifile entries cannot be determined."
-#          - "Remediation: Define the role parameter 'sap_swpm_product_catalog_id' in your playbook or inventory and re-run the playbook."
-#      when: sap_swpm_product_catalog_id is not defined or not sap_swpm_product_catalog_id
 
 # 3 tasks for setting password Facts, required by the template:
     - name: SAP SWPM Pre Install - Set password facts when ABAP

--- a/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
+++ b/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
@@ -75,12 +75,14 @@
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
       when: "'ABAP' in sap_swpm_product_catalog_id | string"
+      no_log: true
 
     - name: SAP SWPM Pre Install - Set password facts when Java
       ansible.builtin.set_fact:
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_java }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_java_password }}"
       when: "'Java' in sap_swpm_product_catalog_id | string"
+      no_log: true
 
 # If the individual passwords are set to a non empty string, use those:
     - name: SAP SWPM Pre Install - Set other user passwords using master password
@@ -94,6 +96,7 @@
         sap_swpm_diagnostics_agent_password: "{{ sap_swpm_master_password
           if sap_swpm_master_password | d('') and not sap_swpm_diagnostics_agent_password | d('')
           else sap_swpm_diagnostics_agent_password | d('') }}"
+      no_log: true
 
 # Generate inifile.params, step 1: Process SWPM Configfile template locally for creating inifile.params
     - name: SAP SWPM Pre Install, create inifile - Process SWPM inifile template for creating 'inifile.params'

--- a/roles/sap_swpm/tasks/pre_install/install_type.yml
+++ b/roles/sap_swpm/tasks/pre_install/install_type.yml
@@ -36,7 +36,9 @@
     sap_swpm_swpm_installation_type: "maint_plan_stack"
     sap_swpm_swpm_installation_header: "Installing using SAP Maintenance Planner Stack XML"
   when:
-    - sap_swpm_mp_stack_path is defined and not sap_swpm_mp_stack_path is none
+    - sap_swpm_mp_stack_path is defined
+    - sap_swpm_mp_stack_path is string
+    - sap_swpm_mp_stack_path | trim | length > 0
 
 - name: SAP SWPM Pre Install - Check if SAP High Availability installation and using SAP Maintenance Planner
   ansible.builtin.set_fact:
@@ -44,7 +46,9 @@
     sap_swpm_swpm_installation_header: "High Availability Installation using virtual hostname and SAP Maintenance Planner Stack XML"
   when:
     - "'.ABAPHA' in sap_swpm_product_catalog_id | string"
-    - sap_swpm_mp_stack_path is defined and not sap_swpm_mp_stack_path is none
+    - sap_swpm_mp_stack_path is defined
+    - sap_swpm_mp_stack_path is string
+    - sap_swpm_mp_stack_path | trim | length > 0
 
 ################
 # Run Installation Type Steps
@@ -84,7 +88,7 @@
     fail_msg: "FAIL: {{ sap_swpm_virtual_hostname }} is not defined!"
     success_msg: "PASS: The variable 'sap_swpm_virtual_hostname' is defined, as '{{ sap_swpm_virtual_hostname }}'."
   when:
-    - sap_swpm_swpm_installation_type | regex_search('ha')
+    - sap_swpm_swpm_installation_type is search('ha')
 
 ################
 # Installation Type file will not be included if install type is empty (= the default):

--- a/roles/sap_swpm/tasks/pre_install/prepare_software.yml
+++ b/roles/sap_swpm/tasks/pre_install/prepare_software.yml
@@ -10,8 +10,12 @@
 - name: SAP SWPM Pre Install - Check availability of software path - {{ sap_swpm_software_path }}
   ansible.builtin.stat:
     path: "{{ sap_swpm_software_path }}"
-  register: sap_swpm_software_path_stat
-  failed_when: not sap_swpm_software_path_stat.stat.exists
+  register: __sap_swpm_register_software_path
+
+- name: SAP SWPM Pre Install - Fail if the software path does not exist
+  ansible.builtin.fail:
+    msg: "The software path at '{{ sap_swpm_software_path }}' does not exist!"
+  when: not __sap_swpm_register_software_path.stat.exists
 
 - name: SAP SWPM Pre Install - Set directory and file permissions
   when: sap_swpm_set_file_permissions

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -280,10 +280,11 @@ ERROR:      Inifile Parameter: 'NW_ABAP_Include_Corrections.transportFilesLocati
 ###################################################################
 # BEGIN section maintenance_plan_stack_spam_config                #
 #                                                                 #
-{% if sap_swpm_spam_update | string | trim | length > 0 %}
+{% if sap_swpm_spam_update is boolean %}
 NW_ABAP_SPAM_Update.SPAMUpdateDecision = {{ sap_swpm_spam_update | lower }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_spam_update' is empty!
+ERROR:FAIL: Variable 'sap_swpm_spam_update' is defined as '{{ sap_swpm_spam_update }}', type '{{ sap_swpm_spam_update | type_debug }}', must be defined as a boolean!!XXX      Inifile Section: 'maintenance_plan_stack_spam_config'
+ERROR:      Inifile parameter: 'NW_ABAP_SPAM_Update.SPAMUpdateDecision'
 {% endif %}
 {% if sap_swpm_spam_update %}
 NW_ABAP_SPAM_Update.SPAMUpdateArchive = {{ sap_swpm_spam_update_sar }}
@@ -299,8 +300,19 @@ NW_ABAP_SPAM_Update.SPAMUpdateArchive = {{ sap_swpm_spam_update_sar }}
 ###################################################################
 # BEGIN section maintenance_plan_stack_sum_config
 #                                                                 #
+
+{% if sap_swpm_sum_prepare is boolean %}
 NW_ABAP_Prepare_SUM.prepareSUM = {{ sap_swpm_sum_prepare | lower }}
+{% else %}
+ERROR:FAIL: Variable 'sap_swpm_sum_prepare' is defined as '{{ sap_swpm_sum_prepare }}', type '{{ sap_swpm_sum_prepare | type_debug }}', must be defined as a boolean!XXX      Inifile Section: 'maintenance_plan_stack_sum_config'
+ERROR:      Inifile parameter: 'NW_ABAP_Prepare_SUM.prepareSUM'
+{% endif %}
+{% if sap_swpm_sum_start is boolean %}
 NW_ABAP_Prepare_SUM.startSUM = {{ sap_swpm_sum_start | lower }}
+{% else %}
+ERROR:FAIL: Variable 'sap_swpm_sum_start' is defined as '{{ sap_swpm_sum_start }}', type '{{ sap_swpm_sum_start | type_debug }}', must be defined as a boolean!XXX      Inifile Section: 'maintenance_plan_stack_sum_config'
+ERROR:      Inifile parameter: 'NW_ABAP_Prepare_SUM.startSUM'
+{% endif %}
 
 # Password for SUM must be for '<sapsid>adm' user
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -36,17 +36,20 @@ ERROR:FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_so
 {% if sap_swpm_cd_language_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LANGUAGE = {{ sap_swpm_cd_language_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_language_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_language_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.LANGUAGE'
 {% endif %}
 {% if sap_swpm_cd_java_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.JAVA = {{ sap_swpm_cd_java_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_java_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_java_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.JAVA'
 {% endif %}
 {% if sap_swpm_cd_rdbms_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS = {{ sap_swpm_cd_rdbms_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_rdbms_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_rdbms_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS'
 {% endif %}
 # SAPINST.CD.PACKAGE.KERNEL =
 # SAPINST.CD.PACKAGE.KERNEL2 =
@@ -69,18 +72,21 @@ ERROR:FAIL: Variable 'sap_swpm_cd_rdbms_path' id empty!
 {% if sap_swpm_cd_export_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.EXPORT = {{ sap_swpm_cd_export_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_export_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_export_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_exportfiles'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.EXPORT'
 {% endif %}
 # SAPINST.CD.PACKAGE.LOAD =
 {% if sap_swpm_cd_export_pt1_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD1 = {{ sap_swpm_cd_export_pt1_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_export_pt1_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_export_pt1_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_exportfiles'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.LOAD1'
 {% endif %}
 {% if sap_swpm_cd_export_pt2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD2 = {{ sap_swpm_cd_export_pt2_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_export_pt2_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_export_pt2_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_exportfiles'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.LOAD2'
 {% endif %}
 # SAPINST.CD.PACKAGE.JMIG =
 #                                                                 #
@@ -96,21 +102,24 @@ ERROR:FAIL: Variable 'sap_swpm_cd_export_pt2_path' id empty!
 {% if sap_swpm_cd_ibmdb2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.DB2 = {{ sap_swpm_cd_ibmdb2_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_ibmdb2_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_ibmdb2_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_ibmdb2'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.DB2'
 {% endif %}
 
 # Requested package : RDBMS-DB6 CLIENT
 {% if sap_swpm_cd_ibmdb2_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.DB2CLIENT = {{ sap_swpm_cd_ibmdb2_client_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_ibmdb2_client_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_ibmdb2_client_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_ibmdb2'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.DB2CLIENT'
 {% endif %}
 
 # IBM DB2 software unpack path e.g. /db2/db2x01/db2_software
 {% if sap_swpm_ibmdb2_unpack_path | string | trim | length > 0 %}
 db6.DB2SoftwarePath = {{ sap_swpm_ibmdb2_unpack_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_ibmdb2'
+ERROR:      Inifile Parameter: 'db6.DB2SoftwarePath'
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_ibmdb2              #
@@ -125,14 +134,16 @@ ERROR:FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' id empty!
 {% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA121 = {{ sap_swpm_cd_oracle_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_oracledb_121'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-ORA121'
 {% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
 {% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI121 = {{ sap_swpm_cd_oracle_client_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_oracledb_121'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.ORACLI121'
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_121        #
@@ -147,14 +158,16 @@ ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
 {% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA122 = {{ sap_swpm_cd_oracle_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_oracledb_122'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-ORA122'
 {% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
 {% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI122 = {{ sap_swpm_cd_oracle_client_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_oracledb_122'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.ORACLI122'
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_122        #
@@ -169,14 +182,16 @@ ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
 {% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA19 = {{ sap_swpm_cd_oracle_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_oracledb_19'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-ORA19'
 {% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
 {% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI19 = {{ sap_swpm_cd_oracle_client_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_oracledb_19'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.ORACLI19'
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_19         #
@@ -191,12 +206,14 @@ ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
 {% if sap_swpm_cd_sapase_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-SYB = {{ sap_swpm_cd_sapase_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_sapase_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_sapase_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_sapase'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-SYB'
 {% endif %}
 {% if sap_swpm_cd_sapase_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-SYB-CLIENT = {{ sap_swpm_cd_sapase_client_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_sapase_client_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_sapase_client_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_sapase'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-SYB-CLIENT'
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapase              #
@@ -211,7 +228,8 @@ ERROR:FAIL: Variable 'sap_swpm_cd_sapase_client_path' id empty!
 {% if sap_swpm_cd_sapmaxdb_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ADA = {{ sap_swpm_cd_sapmaxdb_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_sapmaxdb'
+ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-ADA'
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapmaxdb            #
@@ -250,7 +268,8 @@ NW_ABAP_Include_Corrections.includeTransports = true
 {% if sap_swpm_tms_tr_files_path | string | trim | length > 0 %}
 NW_ABAP_Include_Corrections.transportFilesLocations = {{ sap_swpm_tms_tr_files_path }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_tms_tr_files_path' id empty!
+ERROR:FAIL: Variable 'sap_swpm_tms_tr_files_path' is empty!XXX      Inifile Section: 'maintenance_plan_stack_tms_transports'
+ERROR:      Inifile Parameter: 'NW_ABAP_Include_Corrections.transportFilesLocations'
 {% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_tms_transports             #
@@ -264,7 +283,7 @@ ERROR:FAIL: Variable 'sap_swpm_tms_tr_files_path' id empty!
 {% if sap_swpm_spam_update | string | trim | length > 0 %}
 NW_ABAP_SPAM_Update.SPAMUpdateDecision = {{ sap_swpm_spam_update | lower }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_spam_update' id empty!
+ERROR:FAIL: Variable 'sap_swpm_spam_update' is empty!
 {% endif %}
 {% if sap_swpm_spam_update %}
 NW_ABAP_SPAM_Update.SPAMUpdateArchive = {{ sap_swpm_spam_update_sar }}
@@ -611,7 +630,7 @@ ERROR:      Inifile Parameter: 'NW_DDIC_Password.ddic000Password'
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 storageBasedCopy.hdb.instanceNumber = {{ sap_swpm_db_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is empty!
 {% endif %}
 HDB_Schema_Check_Dialogs.schemaName = {{ sap_swpm_db_schema }}
 ######################################################################
@@ -651,12 +670,12 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast LOAD:C
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_host' is empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 NW_getUnicode.isUnicode = true
 # db6.useMcod = true
@@ -691,14 +710,14 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 storageBasedCopy.ora.listenerName = SAPORALISTENER
 # storageBasedCopy.ora.listenerPort =
 {% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 storageBasedCopy.ora.ABAPSchema = {{ sap_swpm_db_schema_abap }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_schema_abap' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_schema_abap' is empty!
 {% endif %}
 # storageBasedCopy.ora.JavaSchema = {{ sap_swpm_db_schema_java }}
 # storageBasedCopy.ora.swowner = oracle
@@ -729,7 +748,7 @@ ora.multitenant.installMT = FALSE
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/121
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 storageBasedCopy.ora.clientVersion = 121
 storageBasedCopy.ora.serverVersion = 121
@@ -746,7 +765,7 @@ storageBasedCopy.ora.serverVersion = 121
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/122
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 storageBasedCopy.ora.clientVersion = 122
 storageBasedCopy.ora.serverVersion = 122
@@ -763,7 +782,7 @@ storageBasedCopy.ora.serverVersion = 122
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/19
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 storageBasedCopy.ora.clientVersion = 19
 storageBasedCopy.ora.serverVersion = 19
@@ -799,14 +818,14 @@ SYB.NW_DB.sqlServerConnections = 200
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 SYB.NW_DB.sqlServerHostname = {{ sap_swpm_db_host }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_host' is empty!
 {% endif %}
 SYB.NW_DB.sybmgmtdbDataDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
 SYB.NW_DB.sybmgmtdbLogDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
 {% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 SYB.NW_DB.userstore_hostname = {{ sap_swpm_ascs_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' is empty!
 {% endif %}
 
 # To avoid conflicts, leave all Ports blank and SAP SWPM will auto-assign
@@ -829,7 +848,7 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -para_cnt 90
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_ADA_getDBInfo.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 SdbInstanceDialogs.DB_sessions = 100
 SdbInstanceDialogs.minlogsize = 4000
@@ -847,22 +866,22 @@ SdbInstanceDialogs.saplogFolder = saplog
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_HDB_getDBInfo.dbhost = {{ sap_swpm_db_host }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_host' is empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_HDB_getDBInfo.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 NW_HDB_getDBInfo.instanceNumber = {{ sap_swpm_db_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemid = {{ sap_swpm_db_sid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_db_system_password }}
@@ -888,7 +907,7 @@ ERROR:      Inifile Parameter: 'NW_HDB_getDBInfo.systemDbPassword'
 {% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaName = {{ sap_swpm_db_schema_abap }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_schema_abap' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_schema_abap' is empty!
 {% endif %}
 {% if sap_swpm_db_schema_abap_password | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
@@ -915,19 +934,19 @@ ERROR:      Inifile Parameter: 'NW_HDB_DB.javaSchemaPassword'
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.extractLocation = /usr/sap/{{ sap_swpm_db_sid }}/HDB{{ sap_swpm_db_instance_nr }}/backup/data/DB_HDB
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is empty!
 {% endif %}
 {% else %}
 {% if sap_swpm_db_instance_nr | string | trim | length == 0 %}
-ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is empty!
 {% endif %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 NW_Recovery_Install_HDB.extractParallelJobs = {{ sap_swpm_parallel_jobs_nr }}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
@@ -972,12 +991,12 @@ ERROR:      Inifile Parameter: 'nwUsers.db6.sapsidPassword'
 {% if sap_swpm_sid | string | trim | length > 0 %}
 NW_DB6_DB.db6.abap.connect.user = sap{{ sap_swpm_sid | lower }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_sid' is empty!
 {% endif %}
 {% if sap_swpm_sid | string | trim | length > 0 %}
 NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_sid | lower }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_sid' is empty!
 {% endif %}
 # NW_DB6_DB.db6.java.connect.user =
 # NW_DB6_DB.db6.java.schema =
@@ -1039,29 +1058,29 @@ ERROR:      Inifile Parameter: 'NW_HDB_getDBInfo.systemPasswordBackup'
 {% if sap_swpm_backup_location | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupLocation = {{ sap_swpm_backup_location }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_backup_location' id empty!
+ERROR:FAIL: Variable 'sap_swpm_backup_location' is empty!
 {% endif %}
 {% if sap_swpm_backup_prefix | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_backup_prefix' id empty!
+ERROR:FAIL: Variable 'sap_swpm_backup_prefix' is empty!
 {% endif %}
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sapControlWsdlUrl = http://{{ sap_swpm_db_host }}:5{{ sap_swpm_db_instance_nr }}13/SAPControl?wsdl
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is empty!
 {% endif %}
 {% else %}
 {% if sap_swpm_db_instance_nr | string | trim | length == 0 %}
 ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string!
 {% endif %}
-ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_host' is empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
@@ -1136,18 +1155,18 @@ NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 {% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' is empty!
 {% endif %}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' is empty!
 {% endif %}
 # NW_SCS_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_SCS_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' is empty!
 {% endif %}
 #                                                                 #
 #  END  section nw_config_central_services_abap                   #
@@ -1167,23 +1186,23 @@ ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
 {% if sap_swpm_java_scs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.scsVirtualHostname = {{ sap_swpm_java_scs_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_hostname' is empty!
 {% endif %}
 {% if sap_swpm_java_scs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.scsInstanceNumber = {{ sap_swpm_java_scs_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' is empty!
 {% endif %}
 {% if sap_swpm_java_scs_instance_hostname | string | trim | length > 0 %}
 NW_SCS_Instance.scsVirtualHostname = {{ sap_swpm_java_scs_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_hostname' is empty!
 {% endif %}
 # NW_SCS_Instance.scsInstanceNumber =
 {% if sap_swpm_java_scs_instance_nr | string | trim | length > 0 %}
 NW_SCS_Instance.instanceNumber = {{ sap_swpm_java_scs_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' is empty!
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_JAVA_Export.keyPhrase = {{ sap_swpm_master_password }}
@@ -1208,12 +1227,12 @@ ERROR:      Inifile Parameter: 'NW_JAVA_Export.keyPhrase'
 {% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ciVirtualHostname = {{ sap_swpm_pas_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' is empty!
 {% endif %}
 {% if sap_swpm_pas_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciInstanceNumber = {{ sap_swpm_pas_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_pas_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_pas_instance_nr' is empty!
 {% endif %}
 # NW_CI_Instance.nodesNum = 
 # NW_CI_Instance.nodesNumber = defNodes
@@ -1235,7 +1254,7 @@ ERROR:FAIL: Variable 'sap_swpm_pas_instance_nr' id empty!
 {% if sap_swpm_aas_instance_nr | string | trim | length > 0 %}
 NW_AS.instanceNumber = {{ sap_swpm_aas_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_aas_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_aas_instance_nr' is empty!
 {% endif %}
 
 # Do not skip unpacking archives if adding the SAP NetWeaver Application Server to another operating system / host. Default is 'false'.
@@ -1258,12 +1277,12 @@ NW_DI_Instance.virtualHostname = {{ sap_swpm_aas_instance_hostname }}
 {% if sap_swpm_ers_instance_hostname | string | trim | length > 0 %}
 nw_instance_ers.ersVirtualHostname = {{ sap_swpm_ers_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ers_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ers_instance_hostname' is empty!
 {% endif %}
 {% if sap_swpm_ers_instance_nr | string | trim | length > 0 %}
 nw_instance_ers.ersInstanceNumber = {{ sap_swpm_ers_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ers_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ers_instance_nr' is empty!
 {% endif %}
 
 # Disable 'Automatic Instance and Service Restart' for SAP SWPM Unattended Mode,
@@ -1282,12 +1301,12 @@ nw_instance_ers.restartSCS = false
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciMSPort = 36{{ sap_swpm_ascs_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' is empty!
 {% endif %}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_checkMsgServer.abapMSPort = 36{{ sap_swpm_ascs_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' is empty!
 {% endif %}
 # NW_CI_Instance.ciMSPortInternal = 
 # NW_CI_Instance.createGlobalProxyInfoFile = false
@@ -1331,12 +1350,12 @@ UmeConfiguration.umeClient = {{ sap_swpm_ume_client_nr }}
 {% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 UmeConfiguration.umeHost = {{ sap_swpm_pas_instance_hostname }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' id empty!
+ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' is empty!
 {% endif %}
 {% if sap_swpm_ume_instance_nr | string | trim | length > 0 %}
 UmeConfiguration.umeInstance = {{ sap_swpm_ume_instance_nr }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_ume_instance_nr' id empty!
+ERROR:FAIL: Variable 'sap_swpm_ume_instance_nr' is empty!
 {% endif %}
 UmeConfiguration.umeType = {{ sap_swpm_ume_type }}
 # UmeConfiguration.sapjsfName = SAPJSF
@@ -1533,17 +1552,17 @@ NW_Language_Inst_Dialogs.languages = AR,BG,CA,CS,DA,EL,ES,ET,FI,FR,HE,HI,HR,HU,I
 {% if sap_swpm_sapadm_uid | string | trim | length > 0 %}
 nwUsers.sapadmUID = {{ sap_swpm_sapadm_uid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_sapadm_uid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_sapadm_uid' is empty!
 {% endif %}
 {% if sap_swpm_sapsys_gid | string | trim | length > 0 %}
 nwUsers.sapsysGID = {{ sap_swpm_sapsys_gid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_sapsys_gid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_sapsys_gid' is empty!
 {% endif %}
 {% if sap_swpm_sidadm_uid | string | trim | length > 0 %}
 nwUsers.sidAdmUID = {{ sap_swpm_sidadm_uid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_sidadm_uid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_sidadm_uid' is empty!
 {% endif %}
 #                                                                 #
 #  END  section sap_os_linux_user                                 #
@@ -1607,7 +1626,7 @@ InitDeclusteringForImport.decluster = false
 #{% if sap_swpm_diagnostics_agent_password | string | trim | length > 0 %}
 # DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
 #{% else %}
-#ERROR:FAIL: Variable 'sap_swpm_diagnostics_agent_password' id empty!
+#ERROR:FAIL: Variable 'sap_swpm_diagnostics_agent_password' is empty!
 #{% endif %}
 # DiagnosticsAgent.installSAPHostAgent
 # DiagnosticsAgent.InstanceNumber
@@ -1736,12 +1755,12 @@ db6.usingSystemCopyBRforHADR = true
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_host' is empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' is empty!
 {% endif %}
 NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 NW_getLoadType.importManuallyExecuted = false

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -4,7 +4,11 @@
 ###################################################################
 # BEGIN section swpm_installation_media                           #
 #                                                                 #
+{% if sap_swpm_software_path | length > 0 %}
 archives.downloadBasket = {{ sap_swpm_software_path }}
+{% else %}
+archives.downloadBasket = FAIL: Variable 'sap_swpm_software_path' is defined with an empty string!
+{% endif %}
 
 # installation_export.archivesFolder = {{ sap_swpm_cd_export_path }}
 
@@ -19,7 +23,11 @@ archives.downloadBasket = {{ sap_swpm_software_path }}
 ###################################################################
 # BEGIN section swpm_installation_media_swpm2_hana                #
 #                                                                 #
+{% if sap_swpm_software_use_media is boolean %}
 HDB_Software_Dialogs.useMediaCD = {{ sap_swpm_software_use_media }}
+{% else %}
+HDB_Software_Dialogs.useMediaCD = FAIL: Variable 'sap_swpm_software_use_media' is not defined as a boolean!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm2_hana                #
 ###################################################################

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -22,7 +22,7 @@ archives.downloadBasket = {{ sap_swpm_software_path }}
 {% if sap_swpm_software_use_media is boolean %}
 HDB_Software_Dialogs.useMediaCD = {{ sap_swpm_software_use_media | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software_use_media }}', type '{{ sap_swpm_software_use_media | type_debug }}', must be defined as a boolean!
+ERROR:FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software_use_media }}', type '{{ sap_swpm_software_use_media | type_debug }}', must be defined as a boolean!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm2_hana                #
@@ -36,17 +36,17 @@ FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software
 {% if sap_swpm_cd_language_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LANGUAGE = {{ sap_swpm_cd_language_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_language_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_language_path' id empty!
 {% endif %}
 {% if sap_swpm_cd_java_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.JAVA = {{ sap_swpm_cd_java_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_java_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_java_path' id empty!
 {% endif %}
 {% if sap_swpm_cd_rdbms_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS = {{ sap_swpm_cd_rdbms_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_rdbms_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_rdbms_path' id empty!
 {% endif %}
 # SAPINST.CD.PACKAGE.KERNEL =
 # SAPINST.CD.PACKAGE.KERNEL2 =
@@ -69,18 +69,18 @@ FAIL: Variable 'sap_swpm_cd_rdbms_path' is defined with an empty string or with 
 {% if sap_swpm_cd_export_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.EXPORT = {{ sap_swpm_cd_export_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_export_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_export_path' id empty!
 {% endif %}
 # SAPINST.CD.PACKAGE.LOAD =
 {% if sap_swpm_cd_export_pt1_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD1 = {{ sap_swpm_cd_export_pt1_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_export_pt1_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_export_pt1_path' id empty!
 {% endif %}
 {% if sap_swpm_cd_export_pt2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD2 = {{ sap_swpm_cd_export_pt2_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_export_pt2_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_export_pt2_path' id empty!
 {% endif %}
 # SAPINST.CD.PACKAGE.JMIG =
 #                                                                 #
@@ -96,21 +96,21 @@ FAIL: Variable 'sap_swpm_cd_export_pt2_path' is defined with an empty string or 
 {% if sap_swpm_cd_ibmdb2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.DB2 = {{ sap_swpm_cd_ibmdb2_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_ibmdb2_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_ibmdb2_path' id empty!
 {% endif %}
 
 # Requested package : RDBMS-DB6 CLIENT
 {% if sap_swpm_cd_ibmdb2_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.DB2CLIENT = {{ sap_swpm_cd_ibmdb2_client_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_ibmdb2_client_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_ibmdb2_client_path' id empty!
 {% endif %}
 
 # IBM DB2 software unpack path e.g. /db2/db2x01/db2_software
 {% if sap_swpm_ibmdb2_unpack_path | string | trim | length > 0 %}
 db6.DB2SoftwarePath = {{ sap_swpm_ibmdb2_unpack_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_ibmdb2              #
@@ -125,14 +125,14 @@ FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' is defined with an empty string or 
 {% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA121 = {{ sap_swpm_cd_oracle_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_oracle_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' id empty!
 {% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
 {% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI121 = {{ sap_swpm_cd_oracle_client_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_121        #
@@ -147,14 +147,14 @@ FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string 
 {% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA122 = {{ sap_swpm_cd_oracle_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_oracle_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' id empty!
 {% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
 {% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI122 = {{ sap_swpm_cd_oracle_client_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_122        #
@@ -169,14 +169,14 @@ FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string 
 {% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA19 = {{ sap_swpm_cd_oracle_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_oracle_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_path' id empty!
 {% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
 {% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI19 = {{ sap_swpm_cd_oracle_client_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_oracle_client_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_19         #
@@ -191,12 +191,12 @@ FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string 
 {% if sap_swpm_cd_sapase_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-SYB = {{ sap_swpm_cd_sapase_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_sapase_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_sapase_path' id empty!
 {% endif %}
 {% if sap_swpm_cd_sapase_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-SYB-CLIENT = {{ sap_swpm_cd_sapase_client_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_sapase_client_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_sapase_client_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapase              #
@@ -211,7 +211,7 @@ FAIL: Variable 'sap_swpm_cd_sapase_client_path' is defined with an empty string 
 {% if sap_swpm_cd_sapmaxdb_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ADA = {{ sap_swpm_cd_sapmaxdb_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapmaxdb            #
@@ -225,7 +225,7 @@ FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' is defined with an empty string or wi
 {% if sap_swpm_configure_tms is boolean %}
 NW_ABAP_TMSConfig.configureTMS = {{ sap_swpm_configure_tms | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_configure_tms' is defined as '{{ sap_swpm_configure_tms }}', type '{{ sap_swpm_configure_tms | type_debug }}', must be defined as a boolean!
+ERROR:FAIL: Variable 'sap_swpm_configure_tms' is defined as '{{ sap_swpm_configure_tms }}', type '{{ sap_swpm_configure_tms | type_debug }}', must be defined as a boolean!
 {% endif %}
 {% if sap_swpm_tmsadm_password | string | trim | length > 0 %}
 NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_tmsadm_password }}
@@ -233,7 +233,8 @@ NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_tmsadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_ABAP_TMSConfig.transportPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_tmsadm_password', is empty!XXX      Inifile Section: 'maintenance_plan_stack_tms_config'
+ERROR:      Inifile parameter: 'NW_ABAP_TMSConfig.transportPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -249,7 +250,7 @@ NW_ABAP_Include_Corrections.includeTransports = true
 {% if sap_swpm_tms_tr_files_path | string | trim | length > 0 %}
 NW_ABAP_Include_Corrections.transportFilesLocations = {{ sap_swpm_tms_tr_files_path }}
 {% else %}
-FAIL: Variable 'sap_swpm_tms_tr_files_path' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_tms_tr_files_path' id empty!
 {% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_tms_transports             #
@@ -263,7 +264,7 @@ FAIL: Variable 'sap_swpm_tms_tr_files_path' is defined with an empty string or w
 {% if sap_swpm_spam_update | string | trim | length > 0 %}
 NW_ABAP_SPAM_Update.SPAMUpdateDecision = {{ sap_swpm_spam_update | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_spam_update' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_spam_update' id empty!
 {% endif %}
 {% if sap_swpm_spam_update %}
 NW_ABAP_SPAM_Update.SPAMUpdateArchive = {{ sap_swpm_spam_update_sar }}
@@ -289,7 +290,8 @@ NW_ABAP_Prepare_SUM.Password = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_ABAP_Prepare_SUM.Password = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_ABAP_Prepare_SUM.Password', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'maintenance_plan_stack_sum_config'
+ERROR:      Inifile parameter: 'NW_ABAP_Prepare_SUM.Password'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -321,7 +323,8 @@ nwUsers.sidadmPassword = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 nwUsers.sidadmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.sidadmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'credentials'
+ERROR:      Inifile Parameter: 'nwUsers.sidadmPassword'
 {% endif %}
 {% endif %}
 # Diagnostics Agent user:
@@ -331,7 +334,8 @@ DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'DiagnosticsAgent.dasidAdmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_diagnostics_agent_password', is empty!XXX      Inifile Section 'credentials'
+ERROR:      Inifile Parameter: 'DiagnosticsAgent.dasidAdmPassword'
 {% endif %}
 {% endif %}
 # 'sapadm' user of the SAP Host Agent:
@@ -341,7 +345,8 @@ hostAgent.sapAdmPassword = {{ sap_swpm_sapadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 hostAgent.sapAdmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'hostAgent.sapAdmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sapadm_password', is empty!XXX      Inifile Section: 'credentials'
+ERROR:      Inifile Parameter: 'hostAgent.sapAdmPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -359,7 +364,8 @@ HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_swpm_db_schema_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'HDB_Schema_Check_Dialogs.schemaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_schema_password', is empty!XXX      Inifile Section: 'credentials_hana'
+ERROR:      Inifile Parameter: 'HDB_Schema_Check_Dialogs.schemaPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
@@ -368,7 +374,8 @@ storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 storageBasedCopy.hdb.systemPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'storageBasedCopy.hdb.systemPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'credentials_hana'
+ERROR:      Inifile Parameter: 'storageBasedCopy.hdb.systemPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -386,7 +393,8 @@ nwUsers.db6.db2sidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 nwUsers.db6.db2sidPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.db6.db2sidPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'credentials_anydb_ibmdb2'
+ERROR:      Inifile Parameter: 'nwUsers.db6.db2sidPassword'
 {% endif %}
 {% endif %}
 # nwUsers.db6.db2sidUid =
@@ -406,7 +414,8 @@ ora.oraclePassword = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 ora.oraclePassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'ora.oraclePassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'credentials_anydb_oracledb'
+ERROR:      Inifile Parameter: 'ora.oraclePassword'
 {% endif %}
 {% endif %}
 # 'ora<dbsid>' user
@@ -416,7 +425,8 @@ ora.orasidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 ora.orasidPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'ora.orasidPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'credentials_anydb_oracledb'
+ERROR:      Inifile Parameter: 'ora.orasidPassword'
 {% endif %}
 {% endif %}
 # Oracle 'SYS' password
@@ -426,7 +436,8 @@ ora.SysPassword = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 ora.SysPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'ora.SysPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'credentials_anydb_oracledb'
+ERROR:      Inifile Parameter: 'ora.SysPassword'
 {% endif %}
 {% endif %}
 # Oracle 'SYSTEM' password
@@ -436,7 +447,8 @@ ora.SystemPassword = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 ora.SystemPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'ora.SystemPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'credentials_anydb_oracledb'
+ERROR:      Inifile Parameter: 'ora.SystemPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -454,23 +466,30 @@ nwUsers.syb.sybsidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 nwUsers.syb.sybsidPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.syb.sybsidPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'credentials_anydb_sapase'
+ERROR:      Inifile Parameter: 'nwUsers.syb.sybsidPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sa_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sa_pass', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
+ERROR:      Inifile Template Section: 'credentials_anydb_sapase'
+ERROR:      Inifile Parameter: 'SYB.NW_DB.sa_pass'
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsa_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sapsa_pass', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
+ERROR:      Inifile Template Section: 'credentials_anydb_sapase'
+ERROR:      Inifile Parameter: 'SYB.NW_DB.sapsa_pass'
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sapsr3_pass', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
+ERROR:      Inifile Template Section: 'credentials_anydb_sapase'
+ERROR:      Inifile Parameter: 'SYB.NW_DB.sapsr3_pass'
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_db_system_password }}
@@ -478,7 +497,8 @@ SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sapsr3db_pass', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'credentials_anydb_sapase'
+ERROR:      Inifile Parameter: 'SYB.NW_DB.sapsr3db_pass'
 {% endif %}
 {% endif %}
 # SYB.NW_DB.encryptionMasterKeyPassword =
@@ -500,7 +520,8 @@ nwUsers.ada.sqdsidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 nwUsers.ada.sqdsidPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.ada.sqdsidPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sap_sidadm_password', is empty!XXX      Inifile Section: 'credentials_anydb_sapmaxdb'
+ERROR:      Inifile Parameter: 'nwUsers.ada.sqdsidPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
@@ -509,7 +530,8 @@ Sdb_DBUser.dbaPassword = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 Sdb_DBUser.dbaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'Sdb_DBUser.dbaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'credentials_anydb_sapmaxdb'
+ERROR:      Inifile Parameter: 'Sdb_DBUser.dbaPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
@@ -518,7 +540,8 @@ Sdb_DBUser.dbmPassword = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 Sdb_DBUser.dbmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'Sdb_DBUser.dbmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'credentials_anydb_sapmaxdb'
+ERROR:      Inifile Parameter: 'Sdb_DBUser.dbmPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_schema_password | string | trim | length > 0 %}
@@ -527,7 +550,8 @@ Sdb_Schema_Dialogs.dbSchemaPassword = {{ sap_swpm_db_schema_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 Sdb_Schema_Dialogs.dbSchemaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'Sdb_Schema_Dialogs.dbSchemaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_schema_password', is empty!XXX      Inifile Section: 'credentials_anydb_sapmaxdb'
+ERROR:      Inifile Parameter: 'Sdb_Schema_Dialogs.dbSchemaPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -573,7 +597,8 @@ NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_DDIC_Password.ddic000Password = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_DDIC_Password.ddic000Password', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_ddic_000_password', is empty!XXX      Inifile Section: 'credentials_syscopy'
+ERROR:      Inifile Parameter: 'NW_DDIC_Password.ddic000Password'
 {% endif %}
 {% endif %}
 #NW_DDIC_Password.ddic001Password =
@@ -589,7 +614,7 @@ FAIL: Variable 'sap_swpm_master_password', required for 'NW_DDIC_Password.ddic00
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 storageBasedCopy.hdb.instanceNumber = {{ sap_swpm_db_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
 {% endif %}
 HDB_Schema_Check_Dialogs.schemaName = {{ sap_swpm_db_schema }}
 ######################################################################
@@ -629,12 +654,12 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast LOAD:C
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 NW_getUnicode.isUnicode = true
 # db6.useMcod = true
@@ -669,14 +694,14 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 storageBasedCopy.ora.listenerName = SAPORALISTENER
 # storageBasedCopy.ora.listenerPort =
 {% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 storageBasedCopy.ora.ABAPSchema = {{ sap_swpm_db_schema_abap }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_abap' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_schema_abap' id empty!
 {% endif %}
 # storageBasedCopy.ora.JavaSchema = {{ sap_swpm_db_schema_java }}
 # storageBasedCopy.ora.swowner = oracle
@@ -707,7 +732,7 @@ ora.multitenant.installMT = FALSE
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/121
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 storageBasedCopy.ora.clientVersion = 121
 storageBasedCopy.ora.serverVersion = 121
@@ -724,7 +749,7 @@ storageBasedCopy.ora.serverVersion = 121
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/122
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 storageBasedCopy.ora.clientVersion = 122
 storageBasedCopy.ora.serverVersion = 122
@@ -741,7 +766,7 @@ storageBasedCopy.ora.serverVersion = 122
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/19
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 storageBasedCopy.ora.clientVersion = 19
 storageBasedCopy.ora.serverVersion = 19
@@ -777,14 +802,14 @@ SYB.NW_DB.sqlServerConnections = 200
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 SYB.NW_DB.sqlServerHostname = {{ sap_swpm_db_host }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
 {% endif %}
 SYB.NW_DB.sybmgmtdbDataDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
 SYB.NW_DB.sybmgmtdbLogDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
 {% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 SYB.NW_DB.userstore_hostname = {{ sap_swpm_ascs_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' id empty!
 {% endif %}
 
 # To avoid conflicts, leave all Ports blank and SAP SWPM will auto-assign
@@ -807,7 +832,7 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -para_cnt 90
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_ADA_getDBInfo.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 SdbInstanceDialogs.DB_sessions = 100
 SdbInstanceDialogs.minlogsize = 4000
@@ -825,22 +850,22 @@ SdbInstanceDialogs.saplogFolder = saplog
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_HDB_getDBInfo.dbhost = {{ sap_swpm_db_host }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_HDB_getDBInfo.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 NW_HDB_getDBInfo.instanceNumber = {{ sap_swpm_db_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemid = {{ sap_swpm_db_sid }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_db_system_password }}
@@ -848,7 +873,8 @@ NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_db_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_getDBInfo.systemPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_system_password', is empty!XXX      Inifile Section: 'db_connection_nw_hana'
+ERROR:      Inifile Parameter: 'NW_HDB_getDBInfo.systemPassword'
 {% endif %}
 {% endif %}
 # NW_HDB_getDBInfo.systemDbSid = SystemDB
@@ -858,13 +884,14 @@ NW_HDB_getDBInfo.systemDbPassword = {{ sap_swpm_db_systemdb_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemDbPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_getDBInfo.systemDbPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_systemdb_password', is empty!XXX      Inifile Section: 'db_connection_nw_hana'
+ERROR:      Inifile Parameter: 'NW_HDB_getDBInfo.systemDbPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaName = {{ sap_swpm_db_schema_abap }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_abap' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_schema_abap' id empty!
 {% endif %}
 {% if sap_swpm_db_schema_abap_password | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
@@ -872,7 +899,8 @@ NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_DB.abapSchemaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_schema_abap_password', is empty!XXX      Inifile Section: 'db_connection_nw_hana'
+ERROR:      Inifile Parameter: 'NW_HDB_DB.abapSchemaPassword'
 {% endif %}
 {% endif %}
 NW_HDB_DB.javaSchemaName = {{ sap_swpm_db_schema_java }}
@@ -882,26 +910,27 @@ NW_HDB_DB.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_HDB_DB.javaSchemaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_DB.javaSchemaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_schema_java_password', is empty!XXX      Inifile Section: 'db_connection_nw_hana'
+ERROR:      Inifile Parameter: 'NW_HDB_DB.javaSchemaPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.extractLocation = /usr/sap/{{ sap_swpm_db_sid }}/HDB{{ sap_swpm_db_instance_nr }}/backup/data/DB_HDB
 {% else %}
-FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
 {% endif %}
 {% else %}
 {% if sap_swpm_db_instance_nr | string | trim | length == 0 %}
-FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
 {% endif %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 NW_Recovery_Install_HDB.extractParallelJobs = {{ sap_swpm_parallel_jobs_nr }}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
@@ -909,7 +938,8 @@ NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_Recovery_Install_HDB.sidAdmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_sidadm_password', is empty!XXX      Inifile Section: 'db_connection_nw_hana'
+ERROR:      Inifile Parameter: 'NW_Recovery_Install_HDB.sidAdmPassword'
 {% endif %}
 {% endif %}
 # NW_HDB_getDBInfo.dbadmin = SYSTEM
@@ -932,7 +962,8 @@ nwUsers.db6.sapsidPassword = {{ sap_swpm_sapadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 nwUsers.db6.sapsidPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.db6.sapsidPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_sapadm_password', is empty!XXX      Inifile Section: 'db_connection_nw_anydb_ibmdb2'
+ERROR:      Inifile Parameter: 'nwUsers.db6.sapsidPassword'
 {% endif %}
 {% endif %}
 # nwUsers.db6.sapsidUid =
@@ -944,12 +975,12 @@ FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.db6.sapsidPassw
 {% if sap_swpm_sid | string | trim | length > 0 %}
 NW_DB6_DB.db6.abap.connect.user = sap{{ sap_swpm_sid | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_sid' id empty!
 {% endif %}
 {% if sap_swpm_sid | string | trim | length > 0 %}
 NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_sid | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_sid' id empty!
 {% endif %}
 # NW_DB6_DB.db6.java.connect.user =
 # NW_DB6_DB.db6.java.schema =
@@ -968,7 +999,8 @@ storageBasedCopy.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 storageBasedCopy.abapSchemaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'storageBasedCopy.abapSchemaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_schema_abap_password', is empty!XXX      Inifile Section: 'db_connection_nw_anydb_oracledb'
+ERROR:      Inifile Parameter: 'storageBasedCopy.abapSchemaPassword'
 {% endif %}
 {% endif %}
 {% if sap_swpm_db_schema_java_password | string | trim | length > 0 %}
@@ -977,7 +1009,8 @@ storageBasedCopy.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 storageBasedCopy.javaSchemaPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'storageBasedCopy.javaSchemaPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_schema_java_password', is empty!XXX      Inifile Section: 'db_connection_nw_anydb_oracledb'
+ERROR:      Inifile Parameter: 'storageBasedCopy.javaSchemaPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -1002,35 +1035,36 @@ NW_HDB_getDBInfo.systemPasswordBackup = {{ sap_swpm_backup_system_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPasswordBackup = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_getDBInfo.systemPasswordBackup', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_backup_system_password', is empty!XXX      Inifile Section: 'db_restore_hana'
+ERROR:      Inifile Parameter: 'NW_HDB_getDBInfo.systemPasswordBackup'
 {% endif %}
 {% endif %}
 {% if sap_swpm_backup_location | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupLocation = {{ sap_swpm_backup_location }}
 {% else %}
-FAIL: Variable 'sap_swpm_backup_location' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_backup_location' id empty!
 {% endif %}
 {% if sap_swpm_backup_prefix | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
 {% else %}
-FAIL: Variable 'sap_swpm_backup_prefix' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_backup_prefix' id empty!
 {% endif %}
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sapControlWsdlUrl = http://{{ sap_swpm_db_host }}:5{{ sap_swpm_db_instance_nr }}13/SAPControl?wsdl
 {% else %}
-FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' id empty!
 {% endif %}
 {% else %}
 {% if sap_swpm_db_instance_nr | string | trim | length == 0 %}
-FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string!
+ERROR:FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string!
 {% endif %}
-FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
@@ -1038,7 +1072,8 @@ HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'HDB_Recovery_Dialogs.sidAdmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_db_sidadm_password', is empty!XXX      Inifile Section: 'db_restore_hana'
+ERROR:      Inifile Parameter: 'HDB_Recovery_Dialogs.sidAdmPassword'
 {% endif %}
 {% endif %}
 # HDB_Recovery_Dialogs.backupDestinationType = File
@@ -1104,18 +1139,18 @@ NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 {% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' id empty!
 {% endif %}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
 {% endif %}
 # NW_SCS_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_SCS_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
 {% endif %}
 #                                                                 #
 #  END  section nw_config_central_services_abap                   #
@@ -1135,28 +1170,30 @@ FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or wi
 {% if sap_swpm_java_scs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.scsVirtualHostname = {{ sap_swpm_java_scs_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_java_scs_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_hostname' id empty!
 {% endif %}
 {% if sap_swpm_java_scs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.scsInstanceNumber = {{ sap_swpm_java_scs_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_java_scs_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' id empty!
 {% endif %}
 {% if sap_swpm_java_scs_instance_hostname | string | trim | length > 0 %}
 NW_SCS_Instance.scsVirtualHostname = {{ sap_swpm_java_scs_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_java_scs_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_hostname' id empty!
 {% endif %}
 # NW_SCS_Instance.scsInstanceNumber =
 {% if sap_swpm_java_scs_instance_nr | string | trim | length > 0 %}
 NW_SCS_Instance.instanceNumber = {{ sap_swpm_java_scs_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_java_scs_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' id empty!
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_JAVA_Export.keyPhrase = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_JAVA_Export.keyPhrase', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
+ERROR:      Inifile Template Section: 'nw_config_central_services_java'
+ERROR:      Inifile Parameter: 'NW_JAVA_Export.keyPhrase'
 {% endif %}
 #                                                                 #
 #  END  section nw_config_central_services_java                   #
@@ -1175,12 +1212,12 @@ FAIL: Variable 'sap_swpm_master_password', required for 'NW_JAVA_Export.keyPhras
 {% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ciVirtualHostname = {{ sap_swpm_pas_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_pas_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' id empty!
 {% endif %}
 {% if sap_swpm_pas_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciInstanceNumber = {{ sap_swpm_pas_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_pas_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_pas_instance_nr' id empty!
 {% endif %}
 # NW_CI_Instance.nodesNum = 
 # NW_CI_Instance.nodesNumber = defNodes
@@ -1202,7 +1239,7 @@ FAIL: Variable 'sap_swpm_pas_instance_nr' is defined with an empty string or wit
 {% if sap_swpm_aas_instance_nr | string | trim | length > 0 %}
 NW_AS.instanceNumber = {{ sap_swpm_aas_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_aas_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_aas_instance_nr' id empty!
 {% endif %}
 
 # Do not skip unpacking archives if adding the SAP NetWeaver Application Server to another operating system / host. Default is 'false'.
@@ -1225,17 +1262,17 @@ NW_DI_Instance.virtualHostname = {{ sap_swpm_aas_instance_hostname }}
 {% if sap_swpm_ers_instance_hostname | string | trim | length > 0 %}
 nw_instance_ers.ersVirtualHostname = {{ sap_swpm_ers_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_ers_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ers_instance_hostname' id empty!
 {% endif %}
 {% if sap_swpm_ers_instance_nr | string | trim | length > 0 %}
 nw_instance_ers.ersInstanceNumber = {{ sap_swpm_ers_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_ers_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ers_instance_nr' id empty!
 {% endif %}
 
 # Disable 'Automatic Instance and Service Restart' for SAP SWPM Unattended Mode,
 # otherwise by default SAP SWPM will use sapcontrol -queryuser -function Stop and will cause error
-# "User? Password? Stop. FAIL: Invalid Credentials"
+# "User? Password? Stop. ERROR:FAIL: Invalid Credentials"
 nw_instance_ers.restartSCS = false
 #                                                                 #
 #  END  section nw_config_ers                                     #
@@ -1249,12 +1286,12 @@ nw_instance_ers.restartSCS = false
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciMSPort = 36{{ sap_swpm_ascs_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
 {% endif %}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_checkMsgServer.abapMSPort = 36{{ sap_swpm_ascs_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ascs_instance_nr' id empty!
 {% endif %}
 # NW_CI_Instance.ciMSPortInternal = 
 # NW_CI_Instance.createGlobalProxyInfoFile = false
@@ -1279,7 +1316,8 @@ UmeConfiguration.adminPassword = {{ sap_swpm_ume_j2ee_admin_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 UmeConfiguration.adminPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'UmeConfiguration.adminPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_ume_j2ee_admin_password', is empty!XXX      Inifile Section: 'nw_config_java_ume'
+ERROR:      Inifile Parameter: 'UmeConfiguration.adminPassword'
 {% endif %}
 {% endif %}
 UmeConfiguration.guestName = J2EE_GST_{{ sap_swpm_sid }}
@@ -1289,19 +1327,20 @@ UmeConfiguration.sapjsfPassword = {{ sap_swpm_ume_sapjsf_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 UmeConfiguration.sapjsfPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'UmeConfiguration.sapjsfPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_ume_sapjsf_password', is empty!XXX      Inifile Section: 'nw_config_java_ume'
+ERROR:      Inifile Parameter: 'UmeConfiguration.sapjsfPassword'
 {% endif %}
 {% endif %}
 UmeConfiguration.umeClient = {{ sap_swpm_ume_client_nr }}
 {% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 UmeConfiguration.umeHost = {{ sap_swpm_pas_instance_hostname }}
 {% else %}
-FAIL: Variable 'sap_swpm_pas_instance_hostname' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' id empty!
 {% endif %}
 {% if sap_swpm_ume_instance_nr | string | trim | length > 0 %}
 UmeConfiguration.umeInstance = {{ sap_swpm_ume_instance_nr }}
 {% else %}
-FAIL: Variable 'sap_swpm_ume_instance_nr' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_ume_instance_nr' id empty!
 {% endif %}
 UmeConfiguration.umeType = {{ sap_swpm_ume_type }}
 # UmeConfiguration.sapjsfName = SAPJSF
@@ -1361,7 +1400,8 @@ NW_webdispatcher_Instance.rfcPassword = {{ sap_swpm_wd_backend_rfc_user_password
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_webdispatcher_Instance.rfcPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_webdispatcher_Instance.rfcPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_wd_backend_rfc_user_password', is empty!XXX      Inifile Section: 'nw_config_webdisp_generic'
+ERROR:      Inifile Parameter: 'NW_webdispatcher_Instance.rfcPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -1379,7 +1419,7 @@ FAIL: Variable 'sap_swpm_master_password', required for 'NW_webdispatcher_Instan
 {% if sap_swpm_ascs_install_gateway is boolean %}
 NW_CI_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_ascs_install_gateway' is defined as '{{ sap_swpm_ascs_install_gateway }}', type '{{ sap_swpm_ascs_install_gateway | type_debug }}', must be defined as a boolean!
+ERROR:FAIL: Variable 'sap_swpm_ascs_install_gateway' is defined as '{{ sap_swpm_ascs_install_gateway }}', type '{{ sap_swpm_ascs_install_gateway | type_debug }}', must be defined as a boolean!
 {% endif %}
 # NW_SCS_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
 
@@ -1395,7 +1435,7 @@ FAIL: Variable 'sap_swpm_ascs_install_gateway' is defined as '{{ sap_swpm_ascs_i
 {% if sap_swpm_install_saphostagent is boolean %}
 NW_System.installSAPHostAgent = {{ sap_swpm_install_saphostagent | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_install_saphostagent' is defined as '{{ sap_swpm_install_saphostagent }}', type '{{ sap_swpm_install_saphostagent | type_debug }}', must be defined as a boolean!
+ERROR:FAIL: Variable 'sap_swpm_install_saphostagent' is defined as '{{ sap_swpm_install_saphostagent }}', type '{{ sap_swpm_install_saphostagent | type_debug }}', must be defined as a boolean!
 {% endif %}
 #                                                                 #
 #  END  section nw_config_host_agent                              #
@@ -1497,17 +1537,17 @@ NW_Language_Inst_Dialogs.languages = AR,BG,CA,CS,DA,EL,ES,ET,FI,FR,HE,HI,HR,HU,I
 {% if sap_swpm_sapadm_uid | string | trim | length > 0 %}
 nwUsers.sapadmUID = {{ sap_swpm_sapadm_uid }}
 {% else %}
-FAIL: Variable 'sap_swpm_sapadm_uid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_sapadm_uid' id empty!
 {% endif %}
 {% if sap_swpm_sapsys_gid | string | trim | length > 0 %}
 nwUsers.sapsysGID = {{ sap_swpm_sapsys_gid }}
 {% else %}
-FAIL: Variable 'sap_swpm_sapsys_gid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_sapsys_gid' id empty!
 {% endif %}
 {% if sap_swpm_sidadm_uid | string | trim | length > 0 %}
 nwUsers.sidAdmUID = {{ sap_swpm_sidadm_uid }}
 {% else %}
-FAIL: Variable 'sap_swpm_sidadm_uid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_sidadm_uid' id empty!
 {% endif %}
 #                                                                 #
 #  END  section sap_os_linux_user                                 #
@@ -1543,7 +1583,8 @@ NW_IcmAuth.webadmPassword = {{ sap_swpm_ume_j2ee_admin_password }}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_IcmAuth.webadmPassword = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password', required for 'NW_IcmAuth.webadmPassword', is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_master_password', fallback for 'sap_swpm_ume_j2ee_admin_password', is empty!XXX      Inifile Section: 'nw_config_java_icm_credentials'
+ERROR:      Inifile Parameter: 'NW_IcmAuth.webadmPassword'
 {% endif %}
 {% endif %}
 #                                                                 #
@@ -1570,7 +1611,7 @@ InitDeclusteringForImport.decluster = false
 #{% if sap_swpm_diagnostics_agent_password | string | trim | length > 0 %}
 # DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
 #{% else %}
-#FAIL: Variable 'sap_swpm_diagnostics_agent_password' is defined with an empty string or with only spaces!
+#ERROR:FAIL: Variable 'sap_swpm_diagnostics_agent_password' id empty!
 #{% endif %}
 # DiagnosticsAgent.installSAPHostAgent
 # DiagnosticsAgent.InstanceNumber
@@ -1699,12 +1740,12 @@ db6.usingSystemCopyBRforHADR = true
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_host' id empty!
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+ERROR:FAIL: Variable 'sap_swpm_db_sid' id empty!
 {% endif %}
 NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 NW_getLoadType.importManuallyExecuted = false

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -33,24 +33,9 @@ ERROR:FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_so
 ###################################################################
 # BEGIN section swpm_installation_media_swpm1                     #
 #                                                                 #
-{% if sap_swpm_cd_language_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LANGUAGE = {{ sap_swpm_cd_language_path }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_language_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1'
-ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.LANGUAGE'
-{% endif %}
-{% if sap_swpm_cd_java_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.JAVA = {{ sap_swpm_cd_java_path }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_java_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1'
-ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.JAVA'
-{% endif %}
-{% if sap_swpm_cd_rdbms_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS = {{ sap_swpm_cd_rdbms_path }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_rdbms_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1'
-ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS'
-{% endif %}
 # SAPINST.CD.PACKAGE.KERNEL =
 # SAPINST.CD.PACKAGE.KERNEL2 =
 # SAPINST.CD.PACKAGE.KERNEL3 =
@@ -76,18 +61,8 @@ ERROR:FAIL: Variable 'sap_swpm_cd_export_path' is empty!XXX      Inifile Section
 ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.EXPORT'
 {% endif %}
 # SAPINST.CD.PACKAGE.LOAD =
-{% if sap_swpm_cd_export_pt1_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD1 = {{ sap_swpm_cd_export_pt1_path }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_export_pt1_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_exportfiles'
-ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.LOAD1'
-{% endif %}
-{% if sap_swpm_cd_export_pt2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD2 = {{ sap_swpm_cd_export_pt2_path }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_export_pt2_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_exportfiles'
-ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.LOAD2'
-{% endif %}
 # SAPINST.CD.PACKAGE.JMIG =
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_exportfiles         #
@@ -225,12 +200,7 @@ ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-SYB-CLIENT'
 # BEGIN section swpm_installation_media_swpm1_sapmaxdb            #
 #                                                                 #
 # Requested package : RDBMS-ADA
-{% if sap_swpm_cd_sapmaxdb_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ADA = {{ sap_swpm_cd_sapmaxdb_path }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' is empty!XXX      Inifile Section: 'swpm_installation_media_swpm1_sapmaxdb'
-ERROR:      Inifile Parameter: 'SAPINST.CD.PACKAGE.RDBMS-ADA'
-{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapmaxdb            #
 ###################################################################
@@ -834,11 +804,7 @@ ERROR:FAIL: Variable 'sap_swpm_db_host' is empty!
 {% endif %}
 SYB.NW_DB.sybmgmtdbDataDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
 SYB.NW_DB.sybmgmtdbLogDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
-{% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
-SYB.NW_DB.userstore_hostname = {{ sap_swpm_ascs_instance_hostname }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' is empty!
-{% endif %}
+SYB.NW_DB.userstore_hostname = {{ sap_swpm_db_host | d(sap_swpm_ascs_instance_hostname) }}
 
 # To avoid conflicts, leave all Ports blank and SAP SWPM will auto-assign
 # Ports by default are in order 4901, 4902, 4903, 4904. For each new ASE DB Server instance on the host, each port number is incremented by 4
@@ -1164,11 +1130,7 @@ NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 # Central Services (ASCS) contains the Message server (MS) and Enqueue work processes (EN) for the ABAP Dispatcher.
 # Formerly the processes were contained in the Central Instance (CI).
 ###################################################################
-{% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_ascs_instance_hostname' is empty!
-{% endif %}
 {% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
 {% else %}
@@ -1236,11 +1198,7 @@ ERROR:      Inifile Parameter: 'NW_JAVA_Export.keyPhrase'
 # - Gateway (GW) and
 # - ABAP Dispatcher (DI/WP) work processes.
 # Formerly called the Central Instance (CI).
-{% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ciVirtualHostname = {{ sap_swpm_pas_instance_hostname }}
-{% else %}
-ERROR:FAIL: Variable 'sap_swpm_pas_instance_hostname' is empty!
-{% endif %}
 {% if sap_swpm_pas_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciInstanceNumber = {{ sap_swpm_pas_instance_nr }}
 {% else %}

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -473,22 +473,19 @@ ERROR:      Inifile Parameter: 'nwUsers.syb.sybsidPassword'
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sa_pass = {{ sap_swpm_master_password }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
-ERROR:      Inifile Template Section: 'credentials_anydb_sapase'
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!XXX      Inifile Section: 'credentials_anydb_sapase'
 ERROR:      Inifile Parameter: 'SYB.NW_DB.sa_pass'
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsa_pass = {{ sap_swpm_master_password }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
-ERROR:      Inifile Template Section: 'credentials_anydb_sapase'
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!XXX      Inifile Section: 'credentials_anydb_sapase'
 ERROR:      Inifile Parameter: 'SYB.NW_DB.sapsa_pass'
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3_pass = {{ sap_swpm_master_password }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
-ERROR:      Inifile Template Section: 'credentials_anydb_sapase'
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!XXX      Inifile Section: 'credentials_anydb_sapase'
 ERROR:      Inifile Parameter: 'SYB.NW_DB.sapsr3_pass'
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
@@ -1191,8 +1188,7 @@ ERROR:FAIL: Variable 'sap_swpm_java_scs_instance_nr' id empty!
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_JAVA_Export.keyPhrase = {{ sap_swpm_master_password }}
 {% else %}
-ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!
-ERROR:      Inifile Template Section: 'nw_config_central_services_java'
+ERROR:FAIL: Variable 'sap_swpm_master_password' is empty!XXX      Inifile Section: 'nw_config_central_services_java'
 ERROR:      Inifile Parameter: 'NW_JAVA_Export.keyPhrase'
 {% endif %}
 #                                                                 #

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -230,7 +230,11 @@ FAIL: Variable 'sap_swpm_configure_tms' is defined as '{{ sap_swpm_configure_tms
 {% if sap_swpm_tmsadm_password | string | trim | length > 0 %}
 NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_tmsadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_tmsadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_ABAP_TMSConfig.transportPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_tms_config                 #
@@ -282,7 +286,11 @@ NW_ABAP_Prepare_SUM.startSUM = {{ sap_swpm_sum_start | lower }}
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 NW_ABAP_Prepare_SUM.Password = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_ABAP_Prepare_SUM.Password = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_ABAP_Prepare_SUM.Password', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_sum_config
@@ -304,28 +312,37 @@ NW_ABAP_Prepare_SUM.SUMBatchFile = {{ sap_swpm_sum_batch_file }}
 ###################################################################
 # BEGIN section credentials                                       #
 #                                                                 #
-# Master password:
-{% if sap_swpm_master_password | string | trim | length > 0 %}
+# Master password (can be empty):
 NW_GetMasterPassword.masterPwd = {{ sap_swpm_master_password }}
-{% else %}
-FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
-{% endif %}
 # '<sapsid>adm' user:
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.sidadmPassword = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+nwUsers.sidadmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.sidadmPassword', is defined with an empty string or with only spaces!
 {% endif %}
+{% endif %}
+# Diagnostics Agent user:
 {% if sap_swpm_diagnostics_agent_password | string | trim | length > 0 %}
 DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_diagnostics_agent_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'DiagnosticsAgent.dasidAdmPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # 'sapadm' user of the SAP Host Agent:
 {% if sap_swpm_sapadm_password | string | trim | length > 0 %}
 hostAgent.sapAdmPassword = {{ sap_swpm_sapadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sapadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+hostAgent.sapAdmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'hostAgent.sapAdmPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section credentials                                       #
@@ -339,12 +356,20 @@ FAIL: Variable 'sap_swpm_sapadm_password' is defined with an empty string or wit
 {% if sap_swpm_db_schema_password | string | trim | length > 0 %}
 HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_swpm_db_schema_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'HDB_Schema_Check_Dialogs.schemaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+storageBasedCopy.hdb.systemPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'storageBasedCopy.hdb.systemPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section credentials_hana                                  #
@@ -358,7 +383,11 @@ FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or 
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.db6.db2sidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+nwUsers.db6.db2sidPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.db6.db2sidPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # nwUsers.db6.db2sidUid =
 #                                                                 #
@@ -374,25 +403,41 @@ FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 ora.oraclePassword = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+ora.oraclePassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'ora.oraclePassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # 'ora<dbsid>' user
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 ora.orasidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+ora.orasidPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'ora.orasidPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # Oracle 'SYS' password
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 ora.SysPassword = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+ora.SysPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'ora.SysPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # Oracle 'SYSTEM' password
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 ora.SystemPassword = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+ora.SystemPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'ora.SystemPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section credentials_anydb_oracledb                        #
@@ -406,27 +451,35 @@ FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or 
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.syb.sybsidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+nwUsers.syb.sybsidPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.syb.sybsidPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sa_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sa_pass', is defined with an empty string or with only spaces!
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsa_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sapsa_pass', is defined with an empty string or with only spaces!
 {% endif %}
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3_pass = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sapsr3_pass', is defined with an empty string or with only spaces!
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'SYB.NW_DB.sapsr3db_pass', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # SYB.NW_DB.encryptionMasterKeyPassword =
 # SYB.NW_DB.sapsso_pass =
@@ -444,22 +497,38 @@ FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or 
 {% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.ada.sqdsidPassword = {{ sap_swpm_sap_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+nwUsers.ada.sqdsidPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.ada.sqdsidPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 Sdb_DBUser.dbaPassword = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+Sdb_DBUser.dbaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'Sdb_DBUser.dbaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 Sdb_DBUser.dbmPassword = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+Sdb_DBUser.dbmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'Sdb_DBUser.dbmPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_schema_password | string | trim | length > 0 %}
 Sdb_Schema_Dialogs.dbSchemaPassword = {{ sap_swpm_db_schema_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+Sdb_Schema_Dialogs.dbSchemaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'Sdb_Schema_Dialogs.dbSchemaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section credentials_anydb_sapmaxdb                        #
@@ -501,7 +570,11 @@ NW_DDIC_Password.needDDICPasswords = true
 {% if sap_swpm_ddic_000_password | string | trim | length > 0 %}
 NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_ddic_000_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_DDIC_Password.ddic000Password = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_DDIC_Password.ddic000Password', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #NW_DDIC_Password.ddic001Password =
 #                                                                 #
@@ -772,13 +845,21 @@ FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only sp
 {% if sap_swpm_db_system_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_db_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_getDBInfo.systemPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # NW_HDB_getDBInfo.systemDbSid = SystemDB
 {% if sap_swpm_db_systemdb_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemDbPassword = {{ sap_swpm_db_systemdb_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_systemdb_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_HDB_getDBInfo.systemDbPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_getDBInfo.systemDbPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaName = {{ sap_swpm_db_schema_abap }}
@@ -788,13 +869,21 @@ FAIL: Variable 'sap_swpm_db_schema_abap' is defined with an empty string or with
 {% if sap_swpm_db_schema_abap_password | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_abap_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_DB.abapSchemaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 NW_HDB_DB.javaSchemaName = {{ sap_swpm_db_schema_java }}
 {% if sap_swpm_db_schema_java_password | string | trim | length > 0 %}
 NW_HDB_DB.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_java_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_HDB_DB.javaSchemaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_DB.javaSchemaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_sid | string | trim | length > 0 %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
@@ -817,7 +906,11 @@ FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only sp
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_Recovery_Install_HDB.sidAdmPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # NW_HDB_getDBInfo.dbadmin = SYSTEM
 # NW_HDB_getDBInfo.tenantOsGroup = {{ sap_swpm_db_sid | lower }}grp
@@ -836,7 +929,11 @@ FAIL: Variable 'sap_swpm_db_sidadm_password' is defined with an empty string or 
 {% if sap_swpm_sapadm_password | string | trim | length > 0 %}
 nwUsers.db6.sapsidPassword = {{ sap_swpm_sapadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_sapadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+nwUsers.db6.sapsidPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'nwUsers.db6.sapsidPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # nwUsers.db6.sapsidUid =
 
@@ -868,12 +965,20 @@ FAIL: Variable 'sap_swpm_sid' is defined with an empty string or with only space
 {% if sap_swpm_db_schema_abap_password | string | trim | length > 0 %}
 storageBasedCopy.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_abap_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+storageBasedCopy.abapSchemaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'storageBasedCopy.abapSchemaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_db_schema_java_password | string | trim | length > 0 %}
 storageBasedCopy.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_schema_java_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+storageBasedCopy.javaSchemaPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'storageBasedCopy.javaSchemaPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section db_connection_nw_anydb_oracledb                    #
@@ -894,14 +999,17 @@ FAIL: Variable 'sap_swpm_db_schema_java_password' is defined with an empty strin
 {% if sap_swpm_backup_system_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPasswordBackup = {{ sap_swpm_backup_system_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_backup_system_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_HDB_getDBInfo.systemPasswordBackup = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_HDB_getDBInfo.systemPasswordBackup', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 {% if sap_swpm_backup_location | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupLocation = {{ sap_swpm_backup_location }}
 {% else %}
 FAIL: Variable 'sap_swpm_backup_location' is defined with an empty string or with only spaces!
 {% endif %}
-HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
 {% if sap_swpm_backup_prefix | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
 {% else %}
@@ -927,7 +1035,11 @@ FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only sp
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_db_sidadm_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'HDB_Recovery_Dialogs.sidAdmPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 # HDB_Recovery_Dialogs.backupDestinationType = File
 # HDB_Recovery_Dialogs.licenseFile =
@@ -1044,7 +1156,7 @@ FAIL: Variable 'sap_swpm_java_scs_instance_nr' is defined with an empty string o
 {% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_JAVA_Export.keyPhrase = {{ sap_swpm_master_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_JAVA_Export.keyPhrase', is defined with an empty string or with only spaces!
 {% endif %}
 #                                                                 #
 #  END  section nw_config_central_services_java                   #
@@ -1164,13 +1276,21 @@ UmeConfiguration.adminName = J2EE_ADM_{{ sap_swpm_sid }}
 {% if sap_swpm_ume_j2ee_admin_password | string | trim | length > 0 %}
 UmeConfiguration.adminPassword = {{ sap_swpm_ume_j2ee_admin_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_ume_j2ee_admin_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+UmeConfiguration.adminPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'UmeConfiguration.adminPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 UmeConfiguration.guestName = J2EE_GST_{{ sap_swpm_sid }}
 {% if sap_swpm_ume_sapjsf_password | string | trim | length > 0 %}
 UmeConfiguration.sapjsfPassword = {{ sap_swpm_ume_sapjsf_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_ume_sapjsf_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+UmeConfiguration.sapjsfPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'UmeConfiguration.sapjsfPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 UmeConfiguration.umeClient = {{ sap_swpm_ume_client_nr }}
 {% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
@@ -1238,7 +1358,11 @@ NW_webdispatcher_Instance.rfcUser = {{ sap_swpm_wd_backend_rfc_user }}
 {% if sap_swpm_wd_backend_rfc_user_password | string | trim | length > 0 %}
 NW_webdispatcher_Instance.rfcPassword = {{ sap_swpm_wd_backend_rfc_user_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_wd_backend_rfc_user_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_webdispatcher_Instance.rfcPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_webdispatcher_Instance.rfcPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section nw_config_webdisp_generic                         #
@@ -1416,7 +1540,11 @@ FAIL: Variable 'sap_swpm_sidadm_uid' is defined with an empty string or with onl
 {% if sap_swpm_ume_j2ee_admin_password | string | trim | length > 0 %}
 NW_IcmAuth.webadmPassword = {{ sap_swpm_ume_j2ee_admin_password }}
 {% else %}
-FAIL: Variable 'sap_swpm_ume_j2ee_admin_password' is defined with an empty string or with only spaces!
+{% if sap_swpm_master_password | string | trim | length > 0 %}
+NW_IcmAuth.webadmPassword = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password', required for 'NW_IcmAuth.webadmPassword', is defined with an empty string or with only spaces!
+{% endif %}
 {% endif %}
 #                                                                 #
 #  END  section nw_config_java_icm_credentials                    #

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -22,7 +22,7 @@ archives.downloadBasket = {{ sap_swpm_software_path }}
 {% if sap_swpm_software_use_media is boolean %}
 HDB_Software_Dialogs.useMediaCD = {{ sap_swpm_software_use_media | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software_use_media }}', which is not a boolean!
+FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software_use_media }}', type '{{ sap_swpm_software_use_media | type_debug }}', must be defined as a boolean!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm2_hana                #
@@ -33,9 +33,21 @@ FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software
 ###################################################################
 # BEGIN section swpm_installation_media_swpm1                     #
 #                                                                 #
+{% if sap_swpm_cd_language_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LANGUAGE = {{ sap_swpm_cd_language_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_language_path' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_cd_java_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.JAVA = {{ sap_swpm_cd_java_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_java_path' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_cd_rdbms_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS = {{ sap_swpm_cd_rdbms_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_rdbms_path' is defined with an empty string or with only spaces!
+{% endif %}
 # SAPINST.CD.PACKAGE.KERNEL =
 # SAPINST.CD.PACKAGE.KERNEL2 =
 # SAPINST.CD.PACKAGE.KERNEL3 =
@@ -54,10 +66,22 @@ SAPINST.CD.PACKAGE.RDBMS = {{ sap_swpm_cd_rdbms_path }}
 ###################################################################
 # BEGIN section swpm_installation_media_swpm1_exportfiles         #
 #                                                                 #
+{% if sap_swpm_cd_export_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.EXPORT = {{ sap_swpm_cd_export_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_export_path' is defined with an empty string or with only spaces!
+{% endif %}
 # SAPINST.CD.PACKAGE.LOAD =
+{% if sap_swpm_cd_export_pt1_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD1 = {{ sap_swpm_cd_export_pt1_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_export_pt1_path' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_cd_export_pt2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.LOAD2 = {{ sap_swpm_cd_export_pt2_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_export_pt2_path' is defined with an empty string or with only spaces!
+{% endif %}
 # SAPINST.CD.PACKAGE.JMIG =
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_exportfiles         #
@@ -69,13 +93,25 @@ SAPINST.CD.PACKAGE.LOAD2 = {{ sap_swpm_cd_export_pt2_path }}
 # BEGIN section swpm_installation_media_swpm1_ibmdb2              #
 #                                                                 #
 # Requested package : RDBMS-DB6
+{% if sap_swpm_cd_ibmdb2_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.DB2 = {{ sap_swpm_cd_ibmdb2_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_ibmdb2_path' is defined with an empty string or with only spaces!
+{% endif %}
 
 # Requested package : RDBMS-DB6 CLIENT
+{% if sap_swpm_cd_ibmdb2_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.DB2CLIENT = {{ sap_swpm_cd_ibmdb2_client_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_ibmdb2_client_path' is defined with an empty string or with only spaces!
+{% endif %}
 
 # IBM DB2 software unpack path e.g. /db2/db2x01/db2_software
+{% if sap_swpm_ibmdb2_unpack_path | string | trim | length > 0 %}
 db6.DB2SoftwarePath = {{ sap_swpm_ibmdb2_unpack_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_ibmdb2_unpack_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_ibmdb2              #
 ###################################################################
@@ -86,10 +122,18 @@ db6.DB2SoftwarePath = {{ sap_swpm_ibmdb2_unpack_path }}
 # BEGIN section swpm_installation_media_swpm1_oracledb_121        #
 #                                                                 #
 # Requested package : RDBMS-ORA
+{% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA121 = {{ sap_swpm_cd_oracle_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_oracle_path' is defined with an empty string or with only spaces!
+{% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
+{% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI121 = {{ sap_swpm_cd_oracle_client_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_121        #
 ###################################################################
@@ -100,10 +144,18 @@ SAPINST.CD.PACKAGE.ORACLI121 = {{ sap_swpm_cd_oracle_client_path }}
 # BEGIN section swpm_installation_media_swpm1_oracledb_122        #
 #                                                                 #
 # Requested package : RDBMS-ORA
+{% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA122 = {{ sap_swpm_cd_oracle_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_oracle_path' is defined with an empty string or with only spaces!
+{% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
+{% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI122 = {{ sap_swpm_cd_oracle_client_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_122        #
 ###################################################################
@@ -114,10 +166,18 @@ SAPINST.CD.PACKAGE.ORACLI122 = {{ sap_swpm_cd_oracle_client_path }}
 ###################################################################
 # BEGIN section swpm_installation_media_swpm1_oracledb_19         #
 #                                                                 #
+{% if sap_swpm_cd_oracle_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ORA19 = {{ sap_swpm_cd_oracle_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_oracle_path' is defined with an empty string or with only spaces!
+{% endif %}
 
 # Requested package : RDBMS-ORA CLIENT
+{% if sap_swpm_cd_oracle_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.ORACLI19 = {{ sap_swpm_cd_oracle_client_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_oracle_client_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_oracledb_19         #
 ###################################################################
@@ -128,8 +188,16 @@ SAPINST.CD.PACKAGE.ORACLI19 = {{ sap_swpm_cd_oracle_client_path }}
 # BEGIN section swpm_installation_media_swpm1_sapase              #
 #                                                                 #
 # Requested package : RDBMS-SYB
+{% if sap_swpm_cd_sapase_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-SYB = {{ sap_swpm_cd_sapase_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_sapase_path' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_cd_sapase_client_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-SYB-CLIENT = {{ sap_swpm_cd_sapase_client_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_sapase_client_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapase              #
 ###################################################################
@@ -140,7 +208,11 @@ SAPINST.CD.PACKAGE.RDBMS-SYB-CLIENT = {{ sap_swpm_cd_sapase_client_path }}
 # BEGIN section swpm_installation_media_swpm1_sapmaxdb            #
 #                                                                 #
 # Requested package : RDBMS-ADA
+{% if sap_swpm_cd_sapmaxdb_path | string | trim | length > 0 %}
 SAPINST.CD.PACKAGE.RDBMS-ADA = {{ sap_swpm_cd_sapmaxdb_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_cd_sapmaxdb_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm1_sapmaxdb            #
 ###################################################################
@@ -150,7 +222,11 @@ SAPINST.CD.PACKAGE.RDBMS-ADA = {{ sap_swpm_cd_sapmaxdb_path }}
 ###################################################################
 # BEGIN section maintenance_plan_stack_tms_config                 #
 #                                                                 #
+{% if sap_swpm_configure_tms is boolean %}
 NW_ABAP_TMSConfig.configureTMS = {{ sap_swpm_configure_tms | lower }}
+{% else %}
+FAIL: Variable 'sap_swpm_configure_tms' is defined as '{{ sap_swpm_configure_tms }}', type '{{ sap_swpm_configure_tms | type_debug }}', must be defined as a boolean!
+{% endif %}
 {% if sap_swpm_tmsadm_password | string | trim | length > 0 %}
 NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_tmsadm_password }}
 {% else %}
@@ -166,7 +242,11 @@ FAIL: Variable 'sap_swpm_tmsadm_password' is defined with an empty string or wit
 # BEGIN section maintenance_plan_stack_tms_transports             #
 #                                                                 #
 NW_ABAP_Include_Corrections.includeTransports = true
+{% if sap_swpm_tms_tr_files_path | string | trim | length > 0 %}
 NW_ABAP_Include_Corrections.transportFilesLocations = {{ sap_swpm_tms_tr_files_path }}
+{% else %}
+FAIL: Variable 'sap_swpm_tms_tr_files_path' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_tms_transports             #
 ###################################################################
@@ -176,7 +256,11 @@ NW_ABAP_Include_Corrections.transportFilesLocations = {{ sap_swpm_tms_tr_files_p
 ###################################################################
 # BEGIN section maintenance_plan_stack_spam_config                #
 #                                                                 #
+{% if sap_swpm_spam_update | string | trim | length > 0 %}
 NW_ABAP_SPAM_Update.SPAMUpdateDecision = {{ sap_swpm_spam_update | lower }}
+{% else %}
+FAIL: Variable 'sap_swpm_spam_update' is defined with an empty string or with only spaces!
+{% endif %}
 {% if sap_swpm_spam_update %}
 NW_ABAP_SPAM_Update.SPAMUpdateArchive = {{ sap_swpm_spam_update_sar }}
 {% else %}
@@ -760,8 +844,16 @@ FAIL: Variable 'sap_swpm_sapadm_password' is defined with an empty string or wit
 # nwUsers.db6.sapsiddbUid =
 
 # Database Schema and Database Connect User for ABAP (default is sap<sapsid> and not sap<anydbsid>)
+{% if sap_swpm_sid | string | trim | length > 0 %}
 NW_DB6_DB.db6.abap.connect.user = sap{{ sap_swpm_sid | lower }}
+{% else %}
+FAIL: Variable 'sap_swpm_sid' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_sid | string | trim | length > 0 %}
 NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_sid | lower }}
+{% else %}
+FAIL: Variable 'sap_swpm_sid' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_DB6_DB.db6.java.connect.user =
 # NW_DB6_DB.db6.java.schema =
 #                                                                 #
@@ -804,8 +896,17 @@ NW_HDB_getDBInfo.systemPasswordBackup = {{ sap_swpm_backup_system_password }}
 {% else %}
 FAIL: Variable 'sap_swpm_backup_system_password' is defined with an empty string or with only spaces!
 {% endif %}
+{% if sap_swpm_backup_location | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.backupLocation = {{ sap_swpm_backup_location }}
+{% else %}
+FAIL: Variable 'sap_swpm_backup_location' is defined with an empty string or with only spaces!
+{% endif %}
 HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
+{% if sap_swpm_backup_prefix | string | trim | length > 0 %}
+HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
+{% else %}
+FAIL: Variable 'sap_swpm_backup_prefix' is defined with an empty string or with only spaces!
+{% endif %}
 {% if sap_swpm_db_host | string | trim | length > 0 %}
 {% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sapControlWsdlUrl = http://{{ sap_swpm_db_host }}:5{{ sap_swpm_db_instance_nr }}13/SAPControl?wsdl
@@ -818,7 +919,11 @@ FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string!
 {% endif %}
 FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
 {% endif %}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 {% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 {% else %}
@@ -1147,7 +1252,11 @@ FAIL: Variable 'sap_swpm_wd_backend_rfc_user_password' is defined with an empty 
 # It is recommended to install gateway as part of ASCS
 # It is NOT recommended to install webdispatcher as part of ASCS. A separate Web Dispatcher instance should be installed (SAP Note 908097)
 ###################################################################
+{% if sap_swpm_ascs_install_gateway is boolean %}
 NW_CI_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_install_gateway' is defined as '{{ sap_swpm_ascs_install_gateway }}', type '{{ sap_swpm_ascs_install_gateway | type_debug }}', must be defined as a boolean!
+{% endif %}
 # NW_SCS_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
 
 # Embedded SAP Web Dispatcher
@@ -1162,7 +1271,7 @@ NW_CI_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
 {% if sap_swpm_install_saphostagent is boolean %}
 NW_System.installSAPHostAgent = {{ sap_swpm_install_saphostagent | lower }}
 {% else %}
-FAIL: Variable 'sap_swpm_install_saphostagent' is defined as '{{ sap_swpm_install_saphostagent }}', which is not a boolean!
+FAIL: Variable 'sap_swpm_install_saphostagent' is defined as '{{ sap_swpm_install_saphostagent }}', type '{{ sap_swpm_install_saphostagent | type_debug }}', must be defined as a boolean!
 {% endif %}
 #                                                                 #
 #  END  section nw_config_host_agent                              #

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -1299,7 +1299,7 @@ ERROR:FAIL: Variable 'sap_swpm_ers_instance_nr' is empty!
 
 # Disable 'Automatic Instance and Service Restart' for SAP SWPM Unattended Mode,
 # otherwise by default SAP SWPM will use sapcontrol -queryuser -function Stop and will cause error
-# "User? Password? Stop. ERROR:FAIL: Invalid Credentials"
+# "User? Password? Stop. FAIL: Invalid Credentials"
 nw_instance_ers.restartSCS = false
 #                                                                 #
 #  END  section nw_config_ers                                     #

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -4,11 +4,7 @@
 ###################################################################
 # BEGIN section swpm_installation_media                           #
 #                                                                 #
-{% if sap_swpm_software_path | length > 0 %}
 archives.downloadBasket = {{ sap_swpm_software_path }}
-{% else %}
-archives.downloadBasket = FAIL: Variable 'sap_swpm_software_path' is defined with an empty string!
-{% endif %}
 
 # installation_export.archivesFolder = {{ sap_swpm_cd_export_path }}
 
@@ -26,7 +22,7 @@ archives.downloadBasket = FAIL: Variable 'sap_swpm_software_path' is defined wit
 {% if sap_swpm_software_use_media is boolean %}
 HDB_Software_Dialogs.useMediaCD = {{ sap_swpm_software_use_media }}
 {% else %}
-HDB_Software_Dialogs.useMediaCD = FAIL: Variable 'sap_swpm_software_use_media' is not defined as a boolean!
+FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software_use_media }}', which is not a boolean!
 {% endif %}
 #                                                                 #
 #  END  section swpm_installation_media_swpm2_hana                #
@@ -155,7 +151,11 @@ SAPINST.CD.PACKAGE.RDBMS-ADA = {{ sap_swpm_cd_sapmaxdb_path }}
 # BEGIN section maintenance_plan_stack_tms_config                 #
 #                                                                 #
 NW_ABAP_TMSConfig.configureTMS = {{ sap_swpm_configure_tms | lower }}
+{% if sap_swpm_tmsadm_password | string | trim | length > 0 %}
 NW_ABAP_TMSConfig.transportPassword = {{ sap_swpm_tmsadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_tmsadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_tms_config                 #
 ###################################################################
@@ -195,7 +195,11 @@ NW_ABAP_Prepare_SUM.prepareSUM = {{ sap_swpm_sum_prepare | lower }}
 NW_ABAP_Prepare_SUM.startSUM = {{ sap_swpm_sum_start | lower }}
 
 # Password for SUM must be for '<sapsid>adm' user
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 NW_ABAP_Prepare_SUM.Password = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section maintenance_plan_stack_sum_config
 ###################################################################
@@ -217,12 +221,28 @@ NW_ABAP_Prepare_SUM.SUMBatchFile = {{ sap_swpm_sum_batch_file }}
 # BEGIN section credentials                                       #
 #                                                                 #
 # Master password:
+{% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_GetMasterPassword.masterPwd = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+{% endif %}
 # '<sapsid>adm' user:
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.sidadmPassword = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_diagnostics_agent_password | string | trim | length > 0 %}
 DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_diagnostics_agent_password' is defined with an empty string or with only spaces!
+{% endif %}
 # 'sapadm' user of the SAP Host Agent:
+{% if sap_swpm_sapadm_password | string | trim | length > 0 %}
 hostAgent.sapAdmPassword = {{ sap_swpm_sapadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sapadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section credentials                                       #
 ###################################################################
@@ -232,8 +252,16 @@ hostAgent.sapAdmPassword = {{ sap_swpm_sapadm_password }}
 ###################################################################
 # BEGIN section credentials_hana                                  #
 #                                                                 #
+{% if sap_swpm_db_schema_password | string | trim | length > 0 %}
 HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_swpm_db_schema_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section credentials_hana                                  #
 ###################################################################
@@ -243,7 +271,11 @@ storageBasedCopy.hdb.systemPassword = {{ sap_swpm_db_system_password }}
 ###################################################################
 # BEGIN section credentials_anydb_ibmdb2                          #
 #                                                                 #
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.db6.db2sidPassword = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 # nwUsers.db6.db2sidUid =
 #                                                                 #
 #  END  section credentials_anydb_ibmdb2                          #
@@ -255,13 +287,29 @@ nwUsers.db6.db2sidPassword = {{ sap_swpm_sap_sidadm_password }}
 # BEGIN section credentials_anydb_oracledb                        #
 #                                                                 #
 # Oracle database software owner
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 ora.oraclePassword = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 # 'ora<dbsid>' user
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 ora.orasidPassword = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 # Oracle 'SYS' password
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 ora.SysPassword = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
 # Oracle 'SYSTEM' password
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 ora.SystemPassword = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section credentials_anydb_oracledb                        #
 ###################################################################
@@ -271,11 +319,31 @@ ora.SystemPassword = {{ sap_swpm_db_system_password }}
 ###################################################################
 # BEGIN section credentials_anydb_sapase                          #
 #                                                                 #
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.syb.sybsidPassword = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sa_pass = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsa_pass = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_master_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3_pass = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
 # SYB.NW_DB.encryptionMasterKeyPassword =
 # SYB.NW_DB.sapsso_pass =
 # SYB.NW_DB.sslPassword =
@@ -289,10 +357,26 @@ SYB.NW_DB.sapsr3db_pass = {{ sap_swpm_db_system_password }}
 # BEGIN section credentials_anydb_sapmaxdb                        #
 #                                                                 #
 # Note: The password of user DBUser may only consist of alphanumeric characters and the special characters #, $, @ and _
+{% if sap_swpm_sap_sidadm_password | string | trim | length > 0 %}
 nwUsers.ada.sqdsidPassword = {{ sap_swpm_sap_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sap_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 Sdb_DBUser.dbaPassword = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 Sdb_DBUser.dbmPassword = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_schema_password | string | trim | length > 0 %}
 Sdb_Schema_Dialogs.dbSchemaPassword = {{ sap_swpm_db_schema_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section credentials_anydb_sapmaxdb                        #
 ###################################################################
@@ -330,7 +414,11 @@ HDB_Userstore.useABAPSSFS = false
 #                                                                 #
 # Are the passwords for the DDIC users different from the default value?
 NW_DDIC_Password.needDDICPasswords = true
+{% if sap_swpm_ddic_000_password | string | trim | length > 0 %}
 NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_ddic_000_password' is defined with an empty string or with only spaces!
+{% endif %}
 #NW_DDIC_Password.ddic001Password =
 #                                                                 #
 #  END  section credentials_syscopy                               #
@@ -341,7 +429,11 @@ NW_DDIC_Password.ddic000Password = {{ sap_swpm_ddic_000_password }}
 ###################################################################
 # BEGIN section db_config_hana                                    #
 #                                                                 #
+{% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 storageBasedCopy.hdb.instanceNumber = {{ sap_swpm_db_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 HDB_Schema_Check_Dialogs.schemaName = {{ sap_swpm_db_schema }}
 ######################################################################
 # BEGIN subsection nw_config_additional_application_server_instance  #
@@ -377,8 +469,16 @@ NW_ABAP_Import_Dialog.dbCodepage = 4103
 #                                                                 #
 NW_ABAP_Import_Dialog.migmonJobNum = 3
 NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast LOAD:COMPRESS_ALL:DEF_CRT
+{% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 NW_getUnicode.isUnicode = true
 # db6.useMcod = true
 # db6.useBluSettings = false
@@ -409,10 +509,18 @@ storageBasedCopy.db6.PortRangeStart = 5914
 #                                                                 #
 NW_ABAP_Import_Dialog.migmonJobNum = 3
 NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 storageBasedCopy.ora.listenerName = SAPORALISTENER
 # storageBasedCopy.ora.listenerPort =
+{% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 storageBasedCopy.ora.ABAPSchema = {{ sap_swpm_db_schema_abap }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_abap' is defined with an empty string or with only spaces!
+{% endif %}
 # storageBasedCopy.ora.JavaSchema = {{ sap_swpm_db_schema_java }}
 # storageBasedCopy.ora.swowner = oracle
 ora.createStatisticsCodeABAP = SKIP
@@ -439,7 +547,11 @@ ora.multitenant.installMT = FALSE
 # BEGIN section db_config_anydb_oracledb_121                      #
 #                                                                 #
 # Use path to Oracle Home - Runtime (i.e. $OHRDBMS env var)
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/121
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 storageBasedCopy.ora.clientVersion = 121
 storageBasedCopy.ora.serverVersion = 121
 #                                                                 #
@@ -452,7 +564,11 @@ storageBasedCopy.ora.serverVersion = 121
 # BEGIN section db_config_anydb_oracledb_122                      #
 #                                                                 #
 # Use path to Oracle Home - Runtime (i.e. $OHRDBMS env var)
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/122
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 storageBasedCopy.ora.clientVersion = 122
 storageBasedCopy.ora.serverVersion = 122
 #                                                                 #
@@ -465,7 +581,11 @@ storageBasedCopy.ora.serverVersion = 122
 # BEGIN section db_config_anydb_oracledb_19                       #
 #                                                                 #
 # Use path to Oracle Home - Runtime (i.e. $OHRDBMS env var)
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 ora.dbhome = /oracle/{{ sap_swpm_db_sid }}/19
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 storageBasedCopy.ora.clientVersion = 19
 storageBasedCopy.ora.serverVersion = 19
 #                                                                 #
@@ -497,10 +617,18 @@ SYB.NW_DB.maxIndexParallelDegree = 10
 SYB.NW_DB.maxQueryParallelDegree = 10
 SYB.NW_DB.numberWorkerProcesses = 50
 SYB.NW_DB.sqlServerConnections = 200
+{% if sap_swpm_db_host | string | trim | length > 0 %}
 SYB.NW_DB.sqlServerHostname = {{ sap_swpm_db_host }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+{% endif %}
 SYB.NW_DB.sybmgmtdbDataDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
 SYB.NW_DB.sybmgmtdbLogDeviceFolder = /sybase/{{ sap_swpm_sid | upper }}/sybsystem
+{% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 SYB.NW_DB.userstore_hostname = {{ sap_swpm_ascs_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
 
 # To avoid conflicts, leave all Ports blank and SAP SWPM will auto-assign
 # Ports by default are in order 4901, 4902, 4903, 4904. For each new ASE DB Server instance on the host, each port number is incremented by 4
@@ -519,7 +647,11 @@ SYB.NW_DB.portXPServer =
 #                                                                 #
 NW_ABAP_Import_Dialog.migmonJobNum = 90
 NW_ABAP_Import_Dialog.migmonLoadArgs = -para_cnt 90
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_ADA_getDBInfo.dbsid = {{ sap_swpm_db_sid }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 SdbInstanceDialogs.DB_sessions = 100
 SdbInstanceDialogs.minlogsize = 4000
 SdbInstanceDialogs.sapdataFolder = sapdata
@@ -533,21 +665,76 @@ SdbInstanceDialogs.saplogFolder = saplog
 ###################################################################
 # BEGIN section db_connection_nw_hana                             #
 #                                                                 #
+{% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_HDB_getDBInfo.dbhost = {{ sap_swpm_db_host }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_HDB_getDBInfo.dbsid = {{ sap_swpm_db_sid }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 NW_HDB_getDBInfo.instanceNumber = {{ sap_swpm_db_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemid = {{ sap_swpm_db_sid }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_system_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPassword = {{ sap_swpm_db_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_system_password' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_HDB_getDBInfo.systemDbSid = SystemDB
+{% if sap_swpm_db_systemdb_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemDbPassword = {{ sap_swpm_db_systemdb_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_systemdb_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_schema_abap | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaName = {{ sap_swpm_db_schema_abap }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_abap' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_schema_abap_password | string | trim | length > 0 %}
 NW_HDB_DB.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_abap_password' is defined with an empty string or with only spaces!
+{% endif %}
 NW_HDB_DB.javaSchemaName = {{ sap_swpm_db_schema_java }}
+{% if sap_swpm_db_schema_java_password | string | trim | length > 0 %}
 NW_HDB_DB.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_java_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
+{% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.extractLocation = /usr/sap/{{ sap_swpm_db_sid }}/HDB{{ sap_swpm_db_instance_nr }}/backup/data/DB_HDB
+{% else %}
+FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+{% else %}
+{% if sap_swpm_db_instance_nr | string | trim | length == 0 %}
+FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 NW_Recovery_Install_HDB.extractParallelJobs = {{ sap_swpm_parallel_jobs_nr }}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_HDB_getDBInfo.dbadmin = SYSTEM
 # NW_HDB_getDBInfo.tenantOsGroup = {{ sap_swpm_db_sid | lower }}grp
 # NW_HDB_getDBInfo.tenantOsUser = {{ sap_swpm_db_sid | lower }}usr
@@ -562,7 +749,11 @@ NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
 # BEGIN section db_connection_nw_anydb_ibmdb2                     #
 #                                                                 #
 # db6.UseDb2SSLClientServerComm = false
+{% if sap_swpm_sapadm_password | string | trim | length > 0 %}
 nwUsers.db6.sapsidPassword = {{ sap_swpm_sapadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_sapadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 # nwUsers.db6.sapsidUid =
 
 # nwUsers.db6.sapsiddbPassword =
@@ -582,8 +773,16 @@ NW_DB6_DB.db6.abap.schema = sap{{ sap_swpm_sid | lower }}
 ###################################################################
 # BEGIN section db_connection_nw_anydb_oracledb                    #
 #                                                                 #
+{% if sap_swpm_db_schema_abap_password | string | trim | length > 0 %}
 storageBasedCopy.abapSchemaPassword = {{ sap_swpm_db_schema_abap_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_abap_password' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_schema_java_password | string | trim | length > 0 %}
 storageBasedCopy.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_schema_java_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section db_connection_nw_anydb_oracledb                    #
 ###################################################################
@@ -600,12 +799,31 @@ storageBasedCopy.javaSchemaPassword = {{ sap_swpm_db_schema_java_password }}
 ###################################################################
 # BEGIN section db_restore_hana                                   #
 #                                                                 #
+{% if sap_swpm_backup_system_password | string | trim | length > 0 %}
 NW_HDB_getDBInfo.systemPasswordBackup = {{ sap_swpm_backup_system_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_backup_system_password' is defined with an empty string or with only spaces!
+{% endif %}
 HDB_Recovery_Dialogs.backupLocation = {{ sap_swpm_backup_location }}
 HDB_Recovery_Dialogs.backupName = {{ sap_swpm_backup_prefix }}
+{% if sap_swpm_db_host | string | trim | length > 0 %}
+{% if sap_swpm_db_instance_nr | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sapControlWsdlUrl = http://{{ sap_swpm_db_host }}:5{{ sap_swpm_db_instance_nr }}13/SAPControl?wsdl
+{% else %}
+FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+{% else %}
+{% if sap_swpm_db_instance_nr | string | trim | length == 0 %}
+FAIL: Variable 'sap_swpm_db_instance_nr' is defined with an empty string!
+{% endif %}
+FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+{% endif %}
 HDB_Recovery_Dialogs.sidAdmName = {{ sap_swpm_db_sid | lower }}adm
+{% if sap_swpm_db_sidadm_password | string | trim | length > 0 %}
 HDB_Recovery_Dialogs.sidAdmPassword = {{ sap_swpm_db_sidadm_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sidadm_password' is defined with an empty string or with only spaces!
+{% endif %}
 # HDB_Recovery_Dialogs.backupDestinationType = File
 # HDB_Recovery_Dialogs.licenseFile =
 # HDB_Recovery_Dialogs.skipExistenceCheck = false
@@ -666,10 +884,22 @@ NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 # Central Services (ASCS) contains the Message server (MS) and Enqueue work processes (EN) for the ABAP Dispatcher.
 # Formerly the processes were contained in the Central Instance (CI).
 ###################################################################
+{% if sap_swpm_ascs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_SCS_Instance.ascsVirtualHostname = {{ sap_swpm_ascs_instance_hostname }}
+{% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_SCS_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section nw_config_central_services_abap                   #
 ###################################################################
@@ -685,12 +915,32 @@ NW_SCS_Instance.ascsInstanceNumber = {{ sap_swpm_ascs_instance_nr }}
 # - Java Gateway (GW) and
 # - Java Internal Web Dispatcher (WD).
 ###################################################################
+{% if sap_swpm_java_scs_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.scsVirtualHostname = {{ sap_swpm_java_scs_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_java_scs_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_java_scs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.scsInstanceNumber = {{ sap_swpm_java_scs_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_java_scs_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_java_scs_instance_hostname | string | trim | length > 0 %}
 NW_SCS_Instance.scsVirtualHostname = {{ sap_swpm_java_scs_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_java_scs_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_SCS_Instance.scsInstanceNumber =
+{% if sap_swpm_java_scs_instance_nr | string | trim | length > 0 %}
 NW_SCS_Instance.instanceNumber = {{ sap_swpm_java_scs_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_java_scs_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_master_password | string | trim | length > 0 %}
 NW_JAVA_Export.keyPhrase = {{ sap_swpm_master_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_master_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section nw_config_central_services_java                   #
 ###################################################################
@@ -705,8 +955,16 @@ NW_JAVA_Export.keyPhrase = {{ sap_swpm_master_password }}
 # - Gateway (GW) and
 # - ABAP Dispatcher (DI/WP) work processes.
 # Formerly called the Central Instance (CI).
+{% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 NW_CI_Instance.ciVirtualHostname = {{ sap_swpm_pas_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_pas_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_pas_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciInstanceNumber = {{ sap_swpm_pas_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_pas_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_CI_Instance.nodesNum = 
 # NW_CI_Instance.nodesNumber = defNodes
 # NW_WPConfiguration.ciBtcWPNumber = 6
@@ -724,7 +982,11 @@ NW_CI_Instance.ciInstanceNumber = {{ sap_swpm_pas_instance_nr }}
 # - ABAP Dispatcher (DI/WP) work processes.
 # Formerly called the Dialog Instance (DI).
 # Instance number of SAP NetWeaver Application Server. Leave empty for default.
+{% if sap_swpm_aas_instance_nr | string | trim | length > 0 %}
 NW_AS.instanceNumber = {{ sap_swpm_aas_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_aas_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 
 # Do not skip unpacking archives if adding the SAP NetWeaver Application Server to another operating system / host. Default is 'false'.
 # NW_AS.skipUnpacking = false
@@ -743,8 +1005,16 @@ NW_DI_Instance.virtualHostname = {{ sap_swpm_aas_instance_hostname }}
 ###################################################################
 # BEGIN section nw_config_ers                                     #
 #                                                                 #
+{% if sap_swpm_ers_instance_hostname | string | trim | length > 0 %}
 nw_instance_ers.ersVirtualHostname = {{ sap_swpm_ers_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_ers_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_ers_instance_nr | string | trim | length > 0 %}
 nw_instance_ers.ersInstanceNumber = {{ sap_swpm_ers_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_ers_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 
 # Disable 'Automatic Instance and Service Restart' for SAP SWPM Unattended Mode,
 # otherwise by default SAP SWPM will use sapcontrol -queryuser -function Stop and will cause error
@@ -759,8 +1029,16 @@ nw_instance_ers.restartSCS = false
 ###################################################################
 # BEGIN section nw_config_ports                                   #
 #                                                                 #
+{% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_CI_Instance.ciMSPort = 36{{ sap_swpm_ascs_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_ascs_instance_nr | string | trim | length > 0 %}
 NW_checkMsgServer.abapMSPort = 36{{ sap_swpm_ascs_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_ascs_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 # NW_CI_Instance.ciMSPortInternal = 
 # NW_CI_Instance.createGlobalProxyInfoFile = false
 # NW_CI_Instance.createGlobalRegInfoFile = false
@@ -778,12 +1056,28 @@ NW_checkMsgServer.abapMSPort = 36{{ sap_swpm_ascs_instance_nr }}
 # BEGIN section nw_config_java_ume                                #
 #                                                                 #
 UmeConfiguration.adminName = J2EE_ADM_{{ sap_swpm_sid }}
+{% if sap_swpm_ume_j2ee_admin_password | string | trim | length > 0 %}
 UmeConfiguration.adminPassword = {{ sap_swpm_ume_j2ee_admin_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_ume_j2ee_admin_password' is defined with an empty string or with only spaces!
+{% endif %}
 UmeConfiguration.guestName = J2EE_GST_{{ sap_swpm_sid }}
+{% if sap_swpm_ume_sapjsf_password | string | trim | length > 0 %}
 UmeConfiguration.sapjsfPassword = {{ sap_swpm_ume_sapjsf_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_ume_sapjsf_password' is defined with an empty string or with only spaces!
+{% endif %}
 UmeConfiguration.umeClient = {{ sap_swpm_ume_client_nr }}
+{% if sap_swpm_pas_instance_hostname | string | trim | length > 0 %}
 UmeConfiguration.umeHost = {{ sap_swpm_pas_instance_hostname }}
+{% else %}
+FAIL: Variable 'sap_swpm_pas_instance_hostname' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_ume_instance_nr | string | trim | length > 0 %}
 UmeConfiguration.umeInstance = {{ sap_swpm_ume_instance_nr }}
+{% else %}
+FAIL: Variable 'sap_swpm_ume_instance_nr' is defined with an empty string or with only spaces!
+{% endif %}
 UmeConfiguration.umeType = {{ sap_swpm_ume_type }}
 # UmeConfiguration.sapjsfName = SAPJSF
 #                                                                 #
@@ -836,7 +1130,11 @@ NW_webdispatcher_Instance.rfcHost = {{ sap_swpm_wd_backend_rfc_host }}
 NW_webdispatcher_Instance.rfcInstance = {{ sap_swpm_wd_backend_rfc_instance_nr }}
 NW_webdispatcher_Instance.rfcClient = {{ sap_swpm_wd_backend_rfc_client_nr }}
 NW_webdispatcher_Instance.rfcUser = {{ sap_swpm_wd_backend_rfc_user }}
+{% if sap_swpm_wd_backend_rfc_user_password | string | trim | length > 0 %}
 NW_webdispatcher_Instance.rfcPassword = {{ sap_swpm_wd_backend_rfc_user_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_wd_backend_rfc_user_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section nw_config_webdisp_generic                         #
 ###################################################################
@@ -861,7 +1159,11 @@ NW_CI_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
 ###################################################################
 # BEGIN section nw_config_host_agent                              #
 #                                                                 #
-NW_System.installSAPHostAgent = {{ sap_swpm_install_saphostagent | lower }}
+{% if sap_swpm_install_saphostagent is boolean %}
+NW_System.installSAPHostAgent = {{ sap_swpm_install_saphostagent }}
+{% else %}
+FAIL: Variable 'sap_swpm_install_saphostagent' is defined as '{{ sap_swpm_install_saphostagent }}', which is not a boolean!
+{% endif %}
 #                                                                 #
 #  END  section nw_config_host_agent                              #
 ###################################################################
@@ -959,9 +1261,21 @@ NW_Language_Inst_Dialogs.languages = AR,BG,CA,CS,DA,EL,ES,ET,FI,FR,HE,HI,HR,HU,I
 ###################################################################
 # BEGIN section sap_os_linux_user                                 #
 #                                                                 #
+{% if sap_swpm_sapadm_uid | string | trim | length > 0 %}
 nwUsers.sapadmUID = {{ sap_swpm_sapadm_uid }}
+{% else %}
+FAIL: Variable 'sap_swpm_sapadm_uid' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_sapsys_gid | string | trim | length > 0 %}
 nwUsers.sapsysGID = {{ sap_swpm_sapsys_gid }}
+{% else %}
+FAIL: Variable 'sap_swpm_sapsys_gid' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_sidadm_uid | string | trim | length > 0 %}
 nwUsers.sidAdmUID = {{ sap_swpm_sidadm_uid }}
+{% else %}
+FAIL: Variable 'sap_swpm_sidadm_uid' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section sap_os_linux_user                                 #
 ###################################################################
@@ -990,7 +1304,11 @@ nwUsers.sidAdmUID = {{ sap_swpm_sidadm_uid }}
 ###################################################################
 # BEGIN section nw_config_java_icm_credentials                    #
 #                                                                 #
+{% if sap_swpm_ume_j2ee_admin_password | string | trim | length > 0 %}
 NW_IcmAuth.webadmPassword = {{ sap_swpm_ume_j2ee_admin_password }}
+{% else %}
+FAIL: Variable 'sap_swpm_ume_j2ee_admin_password' is defined with an empty string or with only spaces!
+{% endif %}
 #                                                                 #
 #  END  section nw_config_java_icm_credentials                    #
 ###################################################################
@@ -1012,7 +1330,11 @@ InitDeclusteringForImport.decluster = false
 # BEGIN section solman_daa_swpm1                                  #
 # Note: This section is not in use by sap_swpm Ansible Role       #
 #                                                                 #
+#{% if sap_swpm_diagnostics_agent_password | string | trim | length > 0 %}
 # DiagnosticsAgent.dasidAdmPassword = {{ sap_swpm_diagnostics_agent_password }}
+#{% else %}
+#FAIL: Variable 'sap_swpm_diagnostics_agent_password' is defined with an empty string or with only spaces!
+#{% endif %}
 # DiagnosticsAgent.installSAPHostAgent
 # DiagnosticsAgent.InstanceNumber
 # DiagnosticsAgent.LogicalHostName
@@ -1137,8 +1459,16 @@ NW_getLoadType.importManuallyExecuted = false
 db6.allowUnsignedDatabaseSoftware = true
 db6.cluster.ClusterType = HADR (High Availability Disaster Recovery)
 db6.usingSystemCopyBRforHADR = true
+{% if sap_swpm_db_host | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbhost = {{ sap_swpm_db_host }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_host' is defined with an empty string or with only spaces!
+{% endif %}
+{% if sap_swpm_db_sid | string | trim | length > 0 %}
 NW_getDBInfoGeneric.dbsid = {{ sap_swpm_db_sid }}
+{% else %}
+FAIL: Variable 'sap_swpm_db_sid' is defined with an empty string or with only spaces!
+{% endif %}
 NW_getLoadType.loadType = {{ sap_swpm_load_type }}
 NW_getLoadType.importManuallyExecuted = false
 NW_getUnicode.isUnicode = true

--- a/roles/sap_swpm/templates/inifile_params.j2
+++ b/roles/sap_swpm/templates/inifile_params.j2
@@ -20,7 +20,7 @@ archives.downloadBasket = {{ sap_swpm_software_path }}
 # BEGIN section swpm_installation_media_swpm2_hana                #
 #                                                                 #
 {% if sap_swpm_software_use_media is boolean %}
-HDB_Software_Dialogs.useMediaCD = {{ sap_swpm_software_use_media }}
+HDB_Software_Dialogs.useMediaCD = {{ sap_swpm_software_use_media | lower }}
 {% else %}
 FAIL: Variable 'sap_swpm_software_use_media' is defined as '{{ sap_swpm_software_use_media }}', which is not a boolean!
 {% endif %}
@@ -1160,7 +1160,7 @@ NW_CI_Instance.ascsInstallGateway = {{ sap_swpm_ascs_install_gateway | lower }}
 # BEGIN section nw_config_host_agent                              #
 #                                                                 #
 {% if sap_swpm_install_saphostagent is boolean %}
-NW_System.installSAPHostAgent = {{ sap_swpm_install_saphostagent }}
+NW_System.installSAPHostAgent = {{ sap_swpm_install_saphostagent | lower }}
 {% else %}
 FAIL: Variable 'sap_swpm_install_saphostagent' is defined as '{{ sap_swpm_install_saphostagent }}', which is not a boolean!
 {% endif %}


### PR DESCRIPTION
Main changes in this PR:
- All variables in `defaults/main.yml` are now defined, typically with an empty string.
- Some long comments in `defaults/main.yml` are rearranged to shorten the line length.
- In `tasks/pre_install.yml`, we are now detecting early if an inifile exists at location
  `{{ sap_swpm_inifile_directory }}/inifile.params`.
  This allows for the early detection of the 4 essential role variables:
    - `sap_swpm_software_path`
    - `sap_swpm_product_catalog_id`
    - `sap_swpm_sid`
    - `sap_swpm_fqdn`
- We are now validating all role parameters (as contained in the section `# Following variables are defined and
  validated:` of the Ansible Playbooks for SAP and as used in the inifile sections defined under `sap_swpm_inifile_sections_list` in all files named `ansible_extravars.yml`), using the Ansible template module, using two stages:
  - Any undefined variable which is used in a defined inifile section (there should be none due to the new definitions in `defaults/main.yml`) will cause the template task to fail immediately after the first occurrence.
  - Further validation is done using Jinja2 if-else-endif inside the file `templates/inifile_params.j2`, so that there will be one output line in the templating result for any validation failure. The output lines must start with `FAIL: ` so that these outputs can easily be collected and displayed. After stage 2, all the validation failures are reported in one task.
  If the validation has **failed** in stage 2, the remplating result can be kept by running the role/playbook with `-v` or more verbosity. By default, the templating result will be removed.
  If the validation has **not failed**, the remplating result will always be removed.
  No validation of the variables of inifile sections will be performed if an existing inifile has been found, because then the existing infile will be used and a reverse extraction of the role variables is not possible and not necessary.

Solves issue #1060.