### PR TITLE
sap_hana_install: Enhance variable validation and account for missed variable combinations

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -265,7 +265,7 @@ in a temporary directory for use by the hdblcm command in the next step.
         name: community.sap_install.sap_hana_install
       vars:
         sap_hana_install_software_directory: /software/hana
-        sap_hana_install_common_master_password: 'My SAP HANA Master Password'
+        sap_hana_install_master_password: 'My SAP HANA Master Password'
         sap_hana_install_sid: 'H01'
         sap_hana_install_instance_nr: '00'
 ```
@@ -284,7 +284,7 @@ Installs SAP HANA on `host0` and other hosts listed in `sap_hana_install_addhost
         name: community.sap_install.sap_hana_install
       vars:
         sap_hana_install_software_directory: /software/hana
-        sap_hana_install_common_master_password: 'My SAP HANA Master Password'
+        sap_hana_install_master_password: 'My SAP HANA Master Password'
         sap_hana_install_root_password: 'My root password'
         sap_hana_install_addhosts: 'host0:role=worker,host1:role=worker:group=g02,host2:role=standby:group=g02'
         sap_hana_install_sid: 'H01'
@@ -307,7 +307,7 @@ Installs SAP HANA on `host1` and `host2`, while running on host `host0` where ex
         sap_hana_install_software_directory: /software/hana
         sap_hana_install_new_system: false
         sap_hana_install_addhosts: 'host0:role=worker,host1:role=worker:group=g02,host2:role=standby:group=g02'
-        sap_hana_install_common_master_password: 'My SAP HANA Master Password'
+        sap_hana_install_master_password: 'My SAP HANA Master Password'
         sap_hana_install_root_password: 'My root password'
         sap_hana_install_sid: 'H01'
         sap_hana_install_instance_nr: '00'

--- a/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
+++ b/roles/sap_hana_install/tasks/assert-addhosts-loop-block.yml
@@ -8,16 +8,16 @@
 
 - name: SAP HANA Add Hosts - Show the path name of the instance profile
   ansible.builtin.debug:
-    msg: "Instance profile: '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/\
-          {{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}'"
+    msg: >-
+      Instance profile: '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/
+        {{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}'
 
 - name: SAP HANA Add Hosts - Assert that there is no instance profile for the additional hosts
   ansible.builtin.assert:
     that: not __sap_hana_install_register_instance_profile_addhost.stat.exists
-    fail_msg:
-      - "FAIL: There is already an instance profile for host '{{ line_item }}', at location:"
-      - "  '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{'{ line_item }}."
-      - "Because of this, the addhost operation will not be performed."
+    fail_msg: >-
+      FAIL: Addhost operation will not be performed because there is already an instance profile for host {{ line_item }} at
+      {{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_{{ line_item }}
     success_msg: "PASS: No instance profile was found for host '{{ line_item }}'."
 
 - name: SAP HANA Add Hosts - Check for SAP HANA instance directory in '/usr/sap'
@@ -32,8 +32,7 @@
 - name: SAP HANA Add Hosts - Assert that there is no SAP HANA instance directory in '/usr/sap' for the additional hosts
   ansible.builtin.assert:
     that: not __sap_hana_install_register_usr_sap_instance_directory.stat.exists
-    fail_msg:
-      - "FAIL: There is already an instance directory for host '{{ sap_hana_install_addhosts.split(':')[0] }}', at location:"
-      - "  '/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/{{ line_item }}' ."
-      - "Because of this, the addhost operation will not be performed."
+    fail_msg: >-
+      FAIL: Addhost operation will not be performed because there is already an instance directory for host {{ line_item }} at location
+      /usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/{{ line_item }}
     success_msg: "PASS: No instance directory was found for host '{{ line_item }}' in /usr/sap."

--- a/roles/sap_hana_install/tasks/assert_variables.yml
+++ b/roles/sap_hana_install/tasks/assert_variables.yml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: Assert that the variable 'sap_hana_install_sid' is defined as String consisting of 3 characters
+  ansible.builtin.assert:
+    that:
+      - sap_hana_install_sid is defined
+      - sap_hana_install_sid is string
+      - sap_hana_install_sid | trim | length == 3
+    success_msg: |
+      PASS: The length of SAP HANA System ID '{{ sap_hana_install_sid }}' is 3 characters.
+    fail_msg: |
+      {% if sap_hana_install_sid is not string %}
+        FAIL: The variable 'sap_hana_install_sid' is not String.
+      {% elif sap_hana_install_sid | length == 0 %}
+        FAIL: The variable 'sap_hana_install_sid' is empty.
+      {% else %}
+        FAIL: The length of SAP HANA System ID '{{ sap_hana_install_sid }}' is not 3 characters!
+      {% endif %}
+
+- name: Assert that the variable 'sap_hana_install_sid' is not in the list of reserved SAP SIDs
+  ansible.builtin.assert:
+    that: sap_hana_install_sid not in __sap_hana_install_sid_prohibited
+    success_msg: |
+      PASS: The SAP HANA System ID '{{ sap_hana_install_sid }}' is not in the list of reserved SAP SIDs in SAP note 1979280 v.20.
+    fail_msg: |
+      FAIL: The SAP HANA System ID '{{ sap_hana_install_sid }}' is in the list of reserved SAP SIDs in SAP note 1979280 v.20!
+
+- name: Assert that the variable 'sap_hana_install_number' is defined as String consisting of 2 digits
+  ansible.builtin.assert:
+    that:
+      - sap_hana_install_number is defined
+      - sap_hana_install_number is string
+      - sap_hana_install_number | trim | length == 2
+      - sap_hana_install_number is match('^[0-9]{2}$')
+    success_msg: |
+      PASS: The SAP HANA Instance Number '{{ sap_hana_install_number }}' is defined as String consisting of 2 digits.
+    fail_msg: |
+      {% if sap_hana_install_number is not string %}
+        FAIL: The variable 'sap_hana_install_number' is not String.
+      {% elif sap_hana_install_number | length == 0 %}
+        FAIL: The variable 'sap_hana_install_number' is empty.
+      {% else %}
+        FAIL: The SAP HANA Instance Number '{{ sap_hana_install_number }}' is not 2 digits!
+      {% endif %}
+
+- name: Assert that the variable 'sap_hana_install_master_password' is defined as String and not empty
+  ansible.builtin.assert:
+    that:
+      - sap_hana_install_master_password is defined
+      - sap_hana_install_master_password is string
+      - sap_hana_install_master_password | trim | length > 0
+    success_msg: |
+      PASS: The variable 'sap_hana_install_master_password' is defined as String and not empty.
+    fail_msg: |
+      {% if sap_hana_install_master_password is not defined %}
+        FAIL: The variable 'sap_hana_install_master_password' is not defined.
+      {% elif sap_hana_install_master_password is not string %}
+        FAIL: The variable 'sap_hana_install_master_password' is not String.
+      {% else %}
+        FAIL: The variable 'sap_hana_install_master_password' is empty.
+      {% endif %}
+
+
+- name: Assert that the variable 'sap_hana_install_addhosts' is defined as String and not empty
+  ansible.builtin.assert:
+    that:
+      - sap_hana_install_addhosts is defined
+      - sap_hana_install_addhosts is string
+      - sap_hana_install_addhosts | trim | length > 0
+    success_msg: |
+      PASS: The variable 'sap_hana_install_addhosts' is defined as String and not empty.
+    fail_msg: |
+      {% if sap_hana_install_addhosts is not defined %}
+        FAIL: The variable 'sap_hana_install_addhosts' is not defined.
+      {% elif sap_hana_install_addhosts is not string %}
+        FAIL: The variable 'sap_hana_install_addhosts' is not String.
+      {% else %}
+        FAIL: The variable 'sap_hana_install_addhosts' is empty.
+      {% endif %}
+  when:
+    - not sap_hana_install_new_system

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -43,9 +43,9 @@
     - name: SAP HANA Add Hosts - Assert that the additional hosts are not shown in hdblcm --list_systems
       ansible.builtin.assert:
         that: line_item not in __sap_hana_install_register_hdblcm_list_systems.stdout
-        fail_msg:
-          - "FAIL: Host '{{ line_item }}' is already part of system '{{ sap_hana_install_sid }}'"
-          - "Because of this, the addhost operation will not be performed."
+        fail_msg: >-
+          FAIL: The host '{{ line_item }}' is already part of system '{{ sap_hana_install_sid }}'
+          and addhosts operation will not be performed.
         success_msg: "PASS: Host '{{ line_item }}' is not yet part of system '{{ sap_hana_install_sid }}'."
       loop: "{{ __sap_hana_install_addhosts_hosts }}"
       loop_control:

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-## Try to use saphostctrl to figure out if HANA or other SID is installed
+# Required to reset status if the role is used multiple times in one playbook.
+- name: SAP HANA Checks - Reset the status variable if defined from previous run
+  ansible.builtin.set_fact:
+    __sap_hana_install_fact_is_installed: false
+  when: __sap_hana_install_fact_is_installed is defined
+
 - name: SAP HANA Checks - Check if saphostctrl is installed
   ansible.builtin.stat:
     path: /usr/sap/hostctrl/exe/saphostctrl
@@ -9,12 +14,16 @@
   register: __sap_hana_install_register_stat_saphostctrl
   failed_when: false
 
+
+# Check 1: Use found sapcontrol to get list of SAP instances.
+# Only valid combination of SID and Instance Number will pass.
 - name: SAP HANA Checks - Check if SAP instances are installed with saphostctrl
   when: __sap_hana_install_register_stat_saphostctrl.stat.exists
   block:
 
     - name: SAP HANA Checks - Get list of installed SAP instances
-      ansible.builtin.shell: set -o pipefail && /usr/sap/hostctrl/exe/saphostctrl -function ListInstances | cut -d":" -f2-
+      ansible.builtin.shell:
+        cmd: set -o pipefail && /usr/sap/hostctrl/exe/saphostctrl -function ListInstances | cut -d":" -f2-
       register: __sap_hana_install_register_instancelist
       changed_when: false
 
@@ -23,7 +32,7 @@
         var: __sap_hana_install_register_instancelist.stdout_lines
         verbosity: 1
 
-    - name: SAP HANA Checks - Desired HANA is installed and running
+    - name: SAP HANA Checks - Desired SAP HANA is installed and running
       ansible.builtin.set_fact:
         __sap_hana_install_fact_is_installed: true
       when:
@@ -34,10 +43,11 @@
         loop_var: __sap_hana_install_loop_instance
         label: "{{ __sap_hana_install_loop_instance.split('-')[0] | trim }}"
 
-    - name: SAP HANA Checks - Fail if existing HANA was detected with same instance number but different SID
+    - name: SAP HANA Checks - Fail if existing SAP HANA was detected with same instance number but different SID
       ansible.builtin.fail:
-        msg: "The instance number {{ sap_hana_install_number }} is already used by
-              HANA system {{ __sap_hana_install_loop_instance.split('-')[0] | trim }}!"
+        msg: >-
+          The instance number {{ sap_hana_install_number }} is already used by
+          SAP HANA system {{ __sap_hana_install_loop_instance.split('-')[0] | trim }}!
       when:
         - __sap_hana_install_loop_instance.split('-')[0] | trim != sap_hana_install_sid
         - __sap_hana_install_loop_instance.split('-')[1] | trim == sap_hana_install_number
@@ -46,10 +56,11 @@
         loop_var: __sap_hana_install_loop_instance
         label: "{{ __sap_hana_install_loop_instance.split('-')[0] | trim }}"
 
-    - name: SAP HANA Checks - Fail if existing HANA was detected with same SID but different instance number
+    - name: SAP HANA Checks - Fail if existing SAP HANA was detected with same SID but different instance number
       ansible.builtin.fail:
-        msg: "HANA system {{ sap_hana_install_sid }} already exists with different instance number
-              {{ __sap_hana_install_loop_instance.split('-')[1] | trim }}!"
+        msg: >-
+          The SAP HANA system {{ sap_hana_install_sid }} already exists with different instance number
+            {{ __sap_hana_install_loop_instance.split('-')[1] | trim }}!"
       when:
         - __sap_hana_install_loop_instance.split('-')[0] | trim  == sap_hana_install_sid
         - __sap_hana_install_loop_instance.split('-')[1] | trim != sap_hana_install_number
@@ -59,6 +70,8 @@
         label: "{{ __sap_hana_install_loop_instance.split('-')[0] | trim }}"
 
 
+# Check 2: Check presence of directories if saphostctrl was not found.
+# These checks do not set '__sap_hana_install_fact_is_installed' as they pass only if directories are empty.
 - name: SAP HANA Checks - Check directories if no saphostctrl is found
   when: not __sap_hana_install_register_stat_saphostctrl.stat.exists
   block:
@@ -74,12 +87,13 @@
       ansible.builtin.find:
         paths: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}"
         patterns: '*'
+        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
       register: __sap_hana_install_register_files_in_hana_shared_sid_assert
       when: __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
 
-    - name: SAP HANA Checks - Fail if directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty
+    - name: SAP HANA Checks - Fail if the path '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty
       ansible.builtin.fail:
-        msg: "FAIL: Directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
+        msg: "FAIL: The path '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
       when:
         - __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
         - __sap_hana_install_register_files_in_hana_shared_sid_assert.matched | int != 0
@@ -95,61 +109,81 @@
       ansible.builtin.find:
         paths: "/usr/sap/{{ sap_hana_install_sid }}"
         patterns: '*'
+        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
       register: __sap_hana_install_register_files_in_usr_sap_sid_assert
       when: __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
 
-    - name: SAP HANA Checks - Fail if directory '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty
+    - name: SAP HANA Checks - Fail if the path '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty
       ansible.builtin.fail:
-        msg: "FAIL: Directory '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty!"
+        msg: "FAIL: The path '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty!"
       when:
         - __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
         - __sap_hana_install_register_files_in_usr_sap_sid_assert.matched | int != 0
 
-- name: SAP HANA Checks - HANA admin user check
-  when:
-    - sap_hana_install_check_sidadm_user | d(true)
-    - not __sap_hana_install_fact_is_installed | d(false)
-  block:
 
-    - name: SAP HANA Checks - Get info about '{{ sap_hana_install_sid | lower }}adm' user
-      ansible.builtin.command: getent passwd {{ sap_hana_install_sid | lower }}adm
-      check_mode: false
-      register: __sap_hana_install_register_getent_passwd_sidadm
-      changed_when: false
-      failed_when: false
-
-    - name: SAP HANA Checks - Fail if the user '{{ sap_hana_install_sid | lower }}adm' exists
-      ansible.builtin.fail:
-        msg: "FAIL: User '{{ sap_hana_install_sid | lower }}adm' exists!"
-      when: __sap_hana_install_register_getent_passwd_sidadm.rc == 0
-
+# Check 3: Check if the group 'sapsys' exists with correct ID.
 # The role supports specifying the SAP HANA group id in variable `sap_hana_install_groupid`, which is the id of the sapsys group.
 # The SAP HANA installation will fail if there is already a group named sapsys but with a different ID. Let's better fail before.
-- name: SAP HANA Checks - Check HANA admin group
+- name: SAP HANA Checks - Check SAP HANA admin group
   when:
     - sap_hana_install_groupid is defined
-    - sap_hana_install_groupid | string != "None"
-    - sap_hana_install_groupid | string | length > 0
+    - sap_hana_install_groupid is string
+    - sap_hana_install_groupid | trim | length > 0
     - not __sap_hana_install_fact_is_installed | d(false)
   block:
 
-    - name: SAP HANA Checks - Get info about the ID of the 'sapsys' group
-      ansible.builtin.command: getent group sapsys
-      check_mode: false
-      register: __sap_hana_install_register_getent_group_sapsys
-      changed_when: false
+    # getent_groups will be populated, with fields:
+    # [0] - 'X' if the password is set.
+    # [1] - Group ID.
+    # [2] - Group members.
+    - name: SAP HANA Checks - Get details of the 'sapsys' group
+      ansible.builtin.getent:
+        database: group
+        key: sapsys
       failed_when: false
-
-    - name: SAP HANA Checks - Define new variable for the assertion
-      ansible.builtin.set_fact:
-        __sap_hana_install_existing_sapsys_gid: "{{ __sap_hana_install_register_getent_group_sapsys.stdout.split(':')[2] }}"
-      when: __sap_hana_install_register_getent_group_sapsys.rc == 0
 
     - name: SAP HANA Checks - In case there is a group 'sapsys', assert that its group ID is identical to 'sap_hana_install_groupid'
       ansible.builtin.assert:
-        that: (__sap_hana_install_existing_sapsys_gid | int) == (sap_hana_install_groupid | int)
+        that:
+          - getent_group['sapsys'][1] | int == sap_hana_install_groupid | int
         success_msg: "PASS: The group ID of 'sapsys' is identical to the value of variable
                       sap_hana_install_groupid, which is '{{ sap_hana_install_groupid }}'"
-        fail_msg: "FAIL: Group 'sapsys' exists but with a different group ID than '{{ sap_hana_install_groupid }}'
-                   (specified in variable sap_hana_install_groupid)!"
-      when: __sap_hana_install_register_getent_group_sapsys.rc == 0
+        fail_msg: >-
+          FAIL: Group 'sapsys' exists but with a different group ID than '{{ sap_hana_install_groupid }}'
+            defined in the variable 'sap_hana_install_groupid'!
+      when:
+        - getent_group is defined
+        - "'sapsys' in getent_group"
+
+
+# Check 4: Check if the user 'sidadm' exists.
+- name: SAP HANA Checks - SAP HANA admin user check
+  when:
+    - sap_hana_install_check_sidadm_user | d(true)
+    - not __sap_hana_install_fact_is_installed | d(false)
+  vars:
+    __sap_hana_install_sidadm: "{{ sap_hana_install_sid | lower }}adm"
+  block:
+
+    - name: SAP HANA Checks - Get info about user '{{ __sap_hana_install_sidadm }}'
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ __sap_hana_install_sidadm }}"
+      failed_when: false
+
+    - name: SAP HANA Checks - Fail if the user '{{ __sap_hana_install_sidadm }}' exists
+      ansible.builtin.fail:
+        msg: "FAIL: The user '{{ __sap_hana_install_sidadm }}' already exists!"
+      when:
+        - getent_passwd is defined
+        - __sap_hana_install_sidadm in getent_passwd
+
+
+- name: SAP HANA Checks - Fail if SAP HANA is not found when addhosts is used
+  ansible.builtin.fail:
+    msg: |
+      FAIL: The existing SAP HANA System was not detected when adding new hosts!
+      This is required when the variable 'sap_hana_install_new_system' is set to false.
+  when:
+    - not sap_hana_install_new_system
+    - not __sap_hana_install_fact_is_installed | d(false)

--- a/roles/sap_hana_install/tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/hana_exists.yml
@@ -91,9 +91,9 @@
       register: __sap_hana_install_register_files_in_hana_shared_sid_assert
       when: __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
 
-    - name: SAP HANA Checks - Fail if the path '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty
+    - name: SAP HANA Checks - Fail if the directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty
       ansible.builtin.fail:
-        msg: "FAIL: The path '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
+        msg: "FAIL: The directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty!"
       when:
         - __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
         - __sap_hana_install_register_files_in_hana_shared_sid_assert.matched | int != 0
@@ -113,9 +113,9 @@
       register: __sap_hana_install_register_files_in_usr_sap_sid_assert
       when: __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
 
-    - name: SAP HANA Checks - Fail if the path '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty
+    - name: SAP HANA Checks - Fail if the directory '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty
       ansible.builtin.fail:
-        msg: "FAIL: The path '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty!"
+        msg: "FAIL: The directory '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty!"
       when:
         - __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
         - __sap_hana_install_register_files_in_usr_sap_sid_assert.matched | int != 0

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -4,6 +4,7 @@
 # Load variables while maintaining backwards compatibility when variable is empty string.
 # Check if variable is defined and non-empty before using it, otherwise fall back to backwards
 # compatible variable or default empty string that will fail asserts afterwards.
+# NOTE: This is not __var assignment so it will not override user specified vars due to precedence!
 - name: Rename some variables used by hdblcm configfile
   ansible.builtin.set_fact:
     sap_hana_install_sid:
@@ -38,96 +39,15 @@
     - sap_hana_install_set_log_mode
     - sap_hana_install_configure_firewall
 
-
-- name: Validate SAP HANA System ID - 'sap_hana_install_sid' is defined as String consisting of 3 characters
-  ansible.builtin.assert:
-    that:
-      - sap_hana_install_sid is defined
-      - sap_hana_install_sid is string
-      - sap_hana_install_sid | length == 3
-    success_msg: |
-      PASS: The length of the SAP HANA System ID '{{ sap_hana_install_sid }}' is 3 characters.
-    fail_msg: |
-      {% if sap_hana_install_sid is not string %}
-        FAIL: The variable 'sap_hana_install_sid' is not String. Value: {{ sap_hana_install_sid }}
-      {% elif sap_hana_install_sid | length == 0 %}
-        FAIL: The variable 'sap_hana_install_sid' is empty.
-      {% else %}
-        FAIL: The length of the SAP HANA System ID '{{ sap_hana_install_sid }}' is not 3 characters!
-      {% endif %}
-  tags:
-    - sap_hana_install_check_hana_exists
-    - sap_hana_install_preinstall
-
-- name: Validate SAP HANA System ID - 'sap_hana_install_sid' is not in the list of reserved SAP SIDs
-  ansible.builtin.assert:
-    that: sap_hana_install_sid not in __sap_hana_install_sid_prohibited
-    success_msg: |
-      PASS: The SAP HANA System ID '{{ sap_hana_install_sid }}' is not in the list of reserved SAP SIDs in SAP note 1979280 v.20.
-    fail_msg: |
-      FAIL: The SAP HANA System ID '{{ sap_hana_install_sid }}' is in the list of reserved SAP SIDs in SAP note 1979280 v.20!
-  tags:
-    - sap_hana_install_check_hana_exists
-    - sap_hana_install_preinstall
-
-- name: Validate SAP HANA Instance Number - 'sap_hana_install_number' is defined as String consisting of 2 characters
-  ansible.builtin.assert:
-    that:
-      - sap_hana_install_number is defined
-      - sap_hana_install_number is string
-      - sap_hana_install_number | length == 2
-    success_msg: |
-      PASS: The length of the SAP HANA Instance Number '{{ sap_hana_install_number }}' is 2 characters.
-    fail_msg: |
-      {% if sap_hana_install_number is not string %}
-        FAIL: The variable 'sap_hana_install_number' is not String. Value: {{ sap_hana_install_number }}
-      {% elif sap_hana_install_number | length == 0 %}
-        FAIL: The variable 'sap_hana_install_number' is empty.
-      {% else %}
-        FAIL: The length of the SAP HANA Instance Number '{{ sap_hana_install_number }}' is not 2 characters!
-      {% endif %}
-  tags:
-    - sap_hana_install_check_hana_exists
-    - sap_hana_install_preinstall
-
-- name: Validate SAP HANA Master Password - 'sap_hana_install_master_password' is defined as String and not empty
-  ansible.builtin.assert:
-    that:
-      - sap_hana_install_master_password is defined
-      - sap_hana_install_master_password is string
-      - sap_hana_install_master_password | length > 0
-    fail_msg: |
-      {% if sap_hana_install_master_password is not defined %}
-        FAIL: The variable 'sap_hana_install_master_password' is not defined.
-      {% elif sap_hana_install_master_password is not string %}
-        FAIL: The variable 'sap_hana_install_master_password' is not String.
-      {% else %}
-        FAIL: The variable 'sap_hana_install_master_password' is empty.
-      {% endif %}
-  tags:
-    - sap_hana_install_check_hana_exists
-    - sap_hana_install_preinstall
-
-
-- name: SAP HANA existence checking
+- name: Validate the role variables
   ansible.builtin.include_tasks:
-    file: hana_exists.yml
-  when:
-    - sap_hana_install_new_system | d(true)
-    - not sap_hana_install_force | d(false)
+    file: assert_variables.yml
   tags:
     - sap_hana_install_check_hana_exists
+    - sap_hana_install_check_installation
     - sap_hana_install_preinstall
-
-# SAP HANA has to be started when:
-# 1. Existing SAP HANA was detected and '__sap_hana_install_fact_is_installed' is true.
-# 2. Addhosts is executed when 'not sap_hana_install_new_system'
-- name: Ensure SAP HANA is running for existing systems or addhosts operations
-  ansible.builtin.include_tasks:
-    file: hana_start.yml
-  when:
-    - __sap_hana_install_fact_is_installed | d(false)
-      or not sap_hana_install_new_system | d(true)
+    - sap_hana_install_set_log_mode
+    - sap_hana_install_configure_firewall
 
 # SELinux is not currently supported by SAP using SLES4SAP
 # This can still be overwritten by extra variables.
@@ -137,31 +57,57 @@
   when: ansible_os_family == "Suse"
 
 
-# This role consists of installation and configuration tasks.
-# Installation tasks have to be run only for new installations.
-# Configuration tasks have to be run always to ensure idempotency.
-- name: Install SAP HANA
-  when: not __sap_hana_install_fact_is_installed | d(false)
-  block:
+# SAP HANA presence has to be validated for both new system and adding new hosts.
+- name: Validate presence of existing SAP HANA database
+  ansible.builtin.include_tasks:
+    file: hana_exists.yml
+  when:
+    - (sap_hana_install_new_system and not sap_hana_install_force)
+      or not sap_hana_install_new_system
+  tags:
+    - sap_hana_install_check_hana_exists
+    - sap_hana_install_preinstall
 
-    - name: SAP HANA pre-install steps
-      ansible.builtin.include_tasks:
-        file: pre_install.yml
-      tags: sap_hana_install_preinstall
 
-    - name: SAP HANA installation steps
-      ansible.builtin.include_tasks:
-        file: hana_install.yml
-      when: sap_hana_install_new_system | d(true)
+- name: Ensure SAP HANA is running for existing systems or addhosts operations
+  ansible.builtin.include_tasks:
+    file: hana_start.yml
+  when: __sap_hana_install_fact_is_installed | d(false)
 
-    # addhosts will be run only on new host, where SAP HANA is not installed
-    - name: SAP HANA addhosts steps
-      ansible.builtin.include_tasks:
-        file: hana_addhosts.yml
-      when: not sap_hana_install_new_system | d(true)
 
-# post_install is modular task file, that contains both installation and configuration tasks.
-# This is executed for existing and new installations, further driven by '__sap_hana_install_fact_is_installed'.
+# Instructions for separating tasks to achieve idempotency:
+# - Installation - Run once for new installations, never repeated.
+# - Configuration - Run always to ensure idempotent outcome.
+
+# Pre-installation currently does not contain configuration tasks, which would require idempotency.
+# Executed for new installations and addhosts, because addhosts configfile creation is included.
+- name: SAP HANA pre-install steps
+  ansible.builtin.include_tasks:
+    file: pre_install.yml
+  tags: sap_hana_install_preinstall
+  when:
+    - (sap_hana_install_new_system and not __sap_hana_install_fact_is_installed | d(false))
+      or not sap_hana_install_new_system
+
+# Installation currently does not contain configuration tasks, which would require idempotency.
+# Executed only for new installations.
+- name: SAP HANA installation steps
+  ansible.builtin.include_tasks:
+    file: hana_install.yml
+  when:
+    - not __sap_hana_install_fact_is_installed | d(false)
+    - sap_hana_install_new_system
+
+# Executed only for addhosts.
+- name: SAP HANA addhosts steps
+  ansible.builtin.include_tasks:
+    file: hana_addhosts.yml
+  when:
+    - __sap_hana_install_fact_is_installed | d(false)
+    - not sap_hana_install_new_system
+
+# Post-installation contains both installation and configuration tasks.
+# Executed new or existing installations and addhosts.
 - name: SAP HANA post-install steps
   ansible.builtin.include_tasks:
     file: post_install.yml

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -107,7 +107,7 @@
     - not sap_hana_install_new_system
 
 # Post-installation contains both installation and configuration tasks.
-# Executed new or existing installations and addhosts.
+# Executed for new or existing installations and addhosts.
 - name: SAP HANA post-install steps
   ansible.builtin.include_tasks:
     file: post_install.yml

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -36,6 +36,7 @@
 
 - name: SAP HANA Pre Install, fapolicyd - Block to disable fapolicyd
   when:
+    - sap_hana_install_new_system  # Don't disable for existing installations during addhosts.
     # Ensure fapolicyd is checked only on supported systems.
     - ansible_os_family == "RedHat"
   tags: sap_hana_install_use_fapolicyd
@@ -56,7 +57,7 @@
 ################
 
 - name: Prepare the HANA software for installation, new system
-  when: sap_hana_install_new_system | d(true)
+  when: sap_hana_install_new_system
   block:
 
     - name: SAP HANA Pre Install - Normalize directory path
@@ -91,22 +92,6 @@
           loop: "{{ range(1, __sap_hana_install_fact_software_directory_levels | int + 1, 1) | list }}"
           loop_control:
             loop_var: line_item
-
-#        - name: SAP HANA Pre Install - Display __sap_hana_install_fact_software_directories
-#          ansible.builtin.debug:
-#            var: __sap_hana_install_fact_software_directories
-
-#        - name: SAP HANA Pre Install - Change permissions of all directories above the software directory
-#          ansible.builtin.file:
-#            path: "{{ line_item }}"
-#            state: directory
-#            mode: '0755'
-#            owner: root
-#            group: root
-#            recurse: no
-#          loop: "{{ __sap_hana_install_fact_software_directories }}"
-#          loop_control:
-#            loop_var: line_item
 
     - name: SAP HANA Pre Install - Change ownership of HANA directories
       ansible.builtin.file:
@@ -151,7 +136,7 @@
         group: root
       when: __sap_hana_install_register_stat_software_extract_directory.stat.exists
 
-# In case more than one installation is ongoing and extracting to the same shared directory, wait until the extraction has completed:
+    # In case more than one installation is ongoing and extracting to the same shared directory, wait until the extraction has completed:
     - name: SAP HANA Pre Install - Suspending if extraction status file '{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__' exists
       ansible.builtin.wait_for:
         path: "{{ sap_hana_install_software_extract_directory }}/__EXTRACTION_ONGOING__"
@@ -221,13 +206,30 @@
             success_msg: "Using file '{{ __sap_hana_install_fact_hdblcm_path + '/hdblcm' }}' for the installation of SAP HANA."
           when: not ansible_check_mode
 
+
 # For an addhosts operation, we first use the hdblcm command for creating a new configfile template, which
 # we then process with the templating engine. The actual addhosts installation is done via the resident hdblcm.
+# Non-resident hdblcm is used to avoid issues when attempting to generate configfile with resident hdblcm.
 - name: Set the path to hdblcm, addhosts
-  when: not sap_hana_install_new_system | d(true)
+  when: not sap_hana_install_new_system
   block:
 
-    - name: SAP HANA Pre Install - Find directory 'SAP_HANA_DATABASE' in '{{ sap_hana_install_software_extract_directory }}'
+    # 'sap_hana_install_software_extract_directory' is required for configfile creation.
+    - name: SAP HANA Pre Install - Addhosts - Get status of the directory '{{ sap_hana_install_software_extract_directory }}'
+      ansible.builtin.stat:
+        path: "{{ sap_hana_install_software_extract_directory }}"
+      check_mode: false
+      register: __sap_hana_install_register_stat_extract_directory
+      failed_when: false
+
+    - name: SAP HANA Pre Install - Addhosts - Fail if '{{ sap_hana_install_software_extract_directory }}' does not exist
+      ansible.builtin.fail:
+        msg: |
+          FAIL: The path {{ sap_hana_install_software_extract_directory }} does not exist.
+          Path must be defined in the variable 'sap_hana_install_software_extract_directory'.
+      when: not __sap_hana_install_register_stat_extract_directory.stat.exists
+
+    - name: SAP HANA Pre Install - Addhosts - Find directory 'SAP_HANA_DATABASE' in '{{ sap_hana_install_software_extract_directory }}'
       ansible.builtin.find:
         paths: "{{ sap_hana_install_software_extract_directory }}"
         recurse: true
@@ -235,7 +237,13 @@
         patterns: 'SAP_HANA_DATABASE'
       register: __sap_hana_install_register_find_directory_sap_hana_database_addhosts
 
-    - name: SAP HANA Pre Install - Set fact for 'hdblcm' installer directory, addhosts
+    - name: SAP HANA Pre Install - Addhosts - Fail if directory 'SAP_HANA_DATABASE' does not exist in '{{ sap_hana_install_software_extract_directory }}'
+      ansible.builtin.fail:
+        msg: |
+          FAIL: The path {{ sap_hana_install_software_extract_directory }} does not contain directory 'SAP_HANA_DATABASE'.
+      when: __sap_hana_install_register_find_directory_sap_hana_database_addhosts.files | length == 0
+
+    - name: SAP HANA Pre Install - Addhosts - Set fact for 'hdblcm' installer directory, addhosts
       ansible.builtin.set_fact:
         __sap_hana_install_fact_hdblcm_path: "{{ __sap_hana_install_register_find_directory_sap_hana_database_addhosts.files[0].path }}"
 

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -225,7 +225,7 @@
     - name: SAP HANA Pre Install - Addhosts - Fail if '{{ sap_hana_install_software_extract_directory }}' does not exist
       ansible.builtin.fail:
         msg: |
-          FAIL: The path {{ sap_hana_install_software_extract_directory }} does not exist.
+          FAIL: The directory {{ sap_hana_install_software_extract_directory }} does not exist.
           Path must be defined in the variable 'sap_hana_install_software_extract_directory'.
       when: not __sap_hana_install_register_stat_extract_directory.stat.exists
 
@@ -240,7 +240,7 @@
     - name: SAP HANA Pre Install - Addhosts - Fail if directory 'SAP_HANA_DATABASE' does not exist in '{{ sap_hana_install_software_extract_directory }}'
       ansible.builtin.fail:
         msg: |
-          FAIL: The path {{ sap_hana_install_software_extract_directory }} does not contain directory 'SAP_HANA_DATABASE'.
+          FAIL: The directory {{ sap_hana_install_software_extract_directory }} does not contain directory 'SAP_HANA_DATABASE'.
       when: __sap_hana_install_register_find_directory_sap_hana_database_addhosts.files | length == 0
 
     - name: SAP HANA Pre Install - Addhosts - Set fact for 'hdblcm' installer directory, addhosts


### PR DESCRIPTION
## Problem
Several combinations of input variables resulted in skipped tasks in certain conditions, or on other hand executed tasks that should not have been.

Following scenarios were accounted for:

| Scenario | exists | start | pre_install | install | addhosts | post_install |
| --- | --- | --- | --- | --- | --- | --- |
| (1) New install one host | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
| (2) Repeat install one host | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
| (3) New install scaleout | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
| (4) Repeat install scaleout | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
| (5) Add hosts to existing install | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: |

## Changes
- Move variable validation into dedicated task file.
- Reorder main tasks and add detailed conditionals to ensure that it correctly recognizes different scenarios.
- Replace `getent` commands with ansible module.
- Update incorrect fail messages and formatting.
- Add asserts for addhosts.

## Tested
- Fresh SAP HANA installation
- Repeat same SAP HANA installation
- Addhost to existing SAP HANA installation

## Important Disclaimer
**NOTE:** This PR does not fix conceptual issue that I identified and that will be solved in next PR.
> All hosts that are either added (5) or installed as part of scaleout (3 and 4) are not using `delegate_to`, thus resulting in important steps not executed on them.