### PR TITLE
sap_ha_pacemaker_cluster:: Fix linting errors

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
@@ -43,104 +43,104 @@
       {{ __sap_ha_pacemaker_cluster_ha_cluster_stonith }}
       {%- endif -%}
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster'"
   when: __sap_ha_pacemaker_cluster_ha_cluster is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster: "{{ __sap_ha_pacemaker_cluster_ha_cluster }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_name'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_name'"
   when: __sap_ha_pacemaker_cluster_cluster_name is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_cluster_name: "{{ __sap_ha_pacemaker_cluster_cluster_name }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_properties'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_properties'"
   when: __sap_ha_pacemaker_cluster_cluster_properties is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_cluster_properties: "{{ __sap_ha_pacemaker_cluster_cluster_properties }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_defaults'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_defaults'"
   when: __sap_ha_pacemaker_cluster_resource_defaults is defined
-  ansible.builtin.set_fact:
-    ha_cluster_resource_defaults: "{{ __sap_ha_pacemaker_cluster_resource_defaults }}"  # noqa var-naming[no-role-prefix]
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    ha_cluster_resource_defaults: "{{ __sap_ha_pacemaker_cluster_resource_defaults }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_operation_defaults'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_operation_defaults'"
   when: __sap_ha_pacemaker_cluster_resource_operation_defaults is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_resource_operation_defaults: "{{ __sap_ha_pacemaker_cluster_resource_operation_defaults }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_colocation'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_colocation'"
   when: __sap_ha_pacemaker_cluster_constraints_colocation is defined
-  ansible.builtin.set_fact:
-    ha_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation }}"  # noqa var-naming[no-role-prefix]
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    ha_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_location'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_location'"
   when: __sap_ha_pacemaker_cluster_constraints_location is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_constraints_location: "{{ __sap_ha_pacemaker_cluster_constraints_location }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_order'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_order'"
   when: __sap_ha_pacemaker_cluster_constraints_order is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_extra_packages'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_extra_packages'"
   when: __sap_ha_pacemaker_cluster_extra_packages is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_extra_packages: "{{ __sap_ha_pacemaker_cluster_extra_packages }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_zypper_patterns'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_zypper_patterns'"
   when: __sap_ha_pacemaker_cluster_zypper_patterns is defined and ansible_os_family == 'Suse'
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_zypper_patterns: "{{ __sap_ha_pacemaker_cluster_zypper_patterns }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_fence_agent_packages'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_fence_agent_packages'"
   when: __sap_ha_pacemaker_cluster_fence_agent_packages is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_fence_agent_packages: "{{ __sap_ha_pacemaker_cluster_fence_agent_packages }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_hacluster_password'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_hacluster_password'"
   when: __sap_ha_pacemaker_cluster_hacluster_user_password is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_hacluster_password: "{{ __sap_ha_pacemaker_cluster_hacluster_user_password }}"
   no_log: true  # secure the credential
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_repos'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_repos'"
   when: __sap_ha_pacemaker_cluster_repos is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     __ha_cluster_repos: "{{ __sap_ha_pacemaker_cluster_repos }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_clones'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_clones'"
   when: __sap_ha_pacemaker_cluster_resource_clones is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_groups'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_groups'"
   when: __sap_ha_pacemaker_cluster_resource_groups is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_primitives'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_primitives'"
   when: __sap_ha_pacemaker_cluster_resource_primitives is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives }}"
   no_log: true  # be paranoid, there could be credentials in it
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_totem'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_totem'"
   when: __sap_ha_pacemaker_cluster_corosync_totem is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_totem: "{{ __sap_ha_pacemaker_cluster_corosync_totem }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_transport'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_transport'"
   when: __sap_ha_pacemaker_cluster_corosync_transport is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_transport: "{{ __sap_ha_pacemaker_cluster_corosync_transport }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_options'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_options'"
   when: __sap_ha_pacemaker_cluster_sbd_options is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_sbd_options: "{{ __sap_ha_pacemaker_cluster_sbd_options }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_enabled'"  # noqa var-naming[no-role-prefix]
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_enabled'"
   when: __sap_ha_pacemaker_cluster_sbd_enabled is defined
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_sbd_enabled: "{{ __sap_ha_pacemaker_cluster_sbd_enabled }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_final_hacluster_vars.yml
@@ -29,6 +29,8 @@
 # __sap_ha_pacemaker_cluster_resource_primitives    ha_cluster_resource_primitives
 # __sap_ha_pacemaker_cluster_corosync_totem                  ha_cluster_totem
 
+# NOTE: noqa var-naming[no-role-prefix] is required when setting variable names for other roles.
+
 # Combines SBD stonith options with ha_cluster if it was not imported as extra var.
 - name: "SAP HA Prepare Pacemaker - (ha_cluster) Include SBD config into 'ha_cluster'"  # noqa jinja[spacing]
   when:
@@ -41,104 +43,104 @@
       {{ __sap_ha_pacemaker_cluster_ha_cluster_stonith }}
       {%- endif -%}
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_ha_cluster is defined
   ansible.builtin.set_fact:
     ha_cluster: "{{ __sap_ha_pacemaker_cluster_ha_cluster }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_name'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_name'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_cluster_name is defined
   ansible.builtin.set_fact:
     ha_cluster_cluster_name: "{{ __sap_ha_pacemaker_cluster_cluster_name }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_properties'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_cluster_properties'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_cluster_properties is defined
   ansible.builtin.set_fact:
     ha_cluster_cluster_properties: "{{ __sap_ha_pacemaker_cluster_cluster_properties }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_defaults'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_defaults'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_resource_defaults is defined
   ansible.builtin.set_fact:
-    ha_cluster_resource_defaults: "{{ __sap_ha_pacemaker_cluster_resource_defaults }}"
+    ha_cluster_resource_defaults: "{{ __sap_ha_pacemaker_cluster_resource_defaults }}"  # noqa var-naming[no-role-prefix]
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_operation_defaults'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_operation_defaults'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_resource_operation_defaults is defined
   ansible.builtin.set_fact:
     ha_cluster_resource_operation_defaults: "{{ __sap_ha_pacemaker_cluster_resource_operation_defaults }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_colocation'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_colocation'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_constraints_colocation is defined
   ansible.builtin.set_fact:
-    ha_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation }}"
+    ha_cluster_constraints_colocation: "{{ __sap_ha_pacemaker_cluster_constraints_colocation }}"  # noqa var-naming[no-role-prefix]
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_location'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_location'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_constraints_location is defined
   ansible.builtin.set_fact:
     ha_cluster_constraints_location: "{{ __sap_ha_pacemaker_cluster_constraints_location }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_order'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_constraints_order'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_constraints_order is defined
   ansible.builtin.set_fact:
     ha_cluster_constraints_order: "{{ __sap_ha_pacemaker_cluster_constraints_order }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_extra_packages'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_extra_packages'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_extra_packages is defined
   ansible.builtin.set_fact:
     ha_cluster_extra_packages: "{{ __sap_ha_pacemaker_cluster_extra_packages }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_zypper_patterns'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_zypper_patterns'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_zypper_patterns is defined and ansible_os_family == 'Suse'
   ansible.builtin.set_fact:
     ha_cluster_zypper_patterns: "{{ __sap_ha_pacemaker_cluster_zypper_patterns }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_fence_agent_packages'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_fence_agent_packages'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_fence_agent_packages is defined
   ansible.builtin.set_fact:
     ha_cluster_fence_agent_packages: "{{ __sap_ha_pacemaker_cluster_fence_agent_packages }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_hacluster_password'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_hacluster_password'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_hacluster_user_password is defined
   ansible.builtin.set_fact:
     ha_cluster_hacluster_password: "{{ __sap_ha_pacemaker_cluster_hacluster_user_password }}"
   no_log: true  # secure the credential
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_repos'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_repos'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_repos is defined
   ansible.builtin.set_fact:
     __ha_cluster_repos: "{{ __sap_ha_pacemaker_cluster_repos }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_clones'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_clones'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_resource_clones is defined
   ansible.builtin.set_fact:
     ha_cluster_resource_clones: "{{ __sap_ha_pacemaker_cluster_resource_clones }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_groups'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_groups'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_resource_groups is defined
   ansible.builtin.set_fact:
     ha_cluster_resource_groups: "{{ __sap_ha_pacemaker_cluster_resource_groups }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_primitives'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_resource_primitives'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_resource_primitives is defined
   ansible.builtin.set_fact:
     ha_cluster_resource_primitives: "{{ __sap_ha_pacemaker_cluster_resource_primitives }}"
   no_log: true  # be paranoid, there could be credentials in it
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_totem'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_totem'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_corosync_totem is defined
   ansible.builtin.set_fact:
     ha_cluster_totem: "{{ __sap_ha_pacemaker_cluster_corosync_totem }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_transport'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_transport'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_corosync_transport is defined
   ansible.builtin.set_fact:
     ha_cluster_transport: "{{ __sap_ha_pacemaker_cluster_corosync_transport }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_options'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_options'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_sbd_options is defined
   ansible.builtin.set_fact:
     ha_cluster_sbd_options: "{{ __sap_ha_pacemaker_cluster_sbd_options }}"
 
-- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_enabled'"
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_sbd_enabled'"  # noqa var-naming[no-role-prefix]
   when: __sap_ha_pacemaker_cluster_sbd_enabled is defined
   ansible.builtin.set_fact:
     ha_cluster_sbd_enabled: "{{ __sap_ha_pacemaker_cluster_sbd_enabled }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_steps_nwas_cs_ers.yml
@@ -64,7 +64,7 @@
   ansible.builtin.set_fact:
     sap_ha_pacemaker_cluster_instance_service_all_fact: "{{
       (sap_ha_pacemaker_cluster_instance_service_all_fact | d([])
-      + hostvars[task_host_item].sap_ha_pacemaker_cluster_instance_service_node_fact)
+      + hostvars[task_host_item].sap_ha_pacemaker_cluster_instance_service_node_fact | d([]))
       | unique
       }}"
   loop: "{{ ansible_play_hosts }}"


### PR DESCRIPTION
Fixes for `ansible-lint` that is updated as part of https://github.com/sap-linuxlab/community.sap_install/pull/1118

## Changes
- `sap_ha_pacemaker_cluster_instance_service_all_fact` defaulted to `[]` to fix `jinja[invalid]: Error rendering template: can only concatenate list (not "UndefinedMarker") to list`
- `# noqa var-naming[no-role-prefix]` added to all tasks setting `ha_cluster` variables, because using .ansible-lint-ignore will show it as warnings, polluting log.

## Result
```bash
ansible-lint --version
ansible-lint 25.9.0 using ansible-core:2.19.2 ansible-compat:25.8.1 ruamel-yaml:0.18.14 ruamel-yaml-clib:0.2.12

ansible-lint roles/sap_ha_pacemaker_cluster/

# Before
Failed: 20 failure(s), 0 warning(s) in 78 files processed of 80 encountered.

# After
Passed: 0 failure(s), 0 warning(s) in 78 files processed of 80 encountered.
```