### PR TITLE
sap_install_media_detect: Fix linting errors

### DIFF
--- a/roles/sap_install_media_detect/tasks/find_files_after_extraction.yml
+++ b/roles/sap_install_media_detect/tasks/find_files_after_extraction.yml
@@ -1,19 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+# NOTE: noqa var-naming[no-role-prefix] is required when setting variable names for other roles.
 
 - name: SAP Install Media Detect - Find files after extraction - Initialize fact variables
   ansible.builtin.set_fact:
     __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results: []
 
 - name: SAP Install Media Detect - Find files after extraction - Set fact for SAP kernel files, move_or_copy_archives parameter set
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_software_path: "{{ __sap_install_media_detect_software_main_directory }}/sap_swpm_download_basket" # for setting consecutive vars
   ignore_errors: true
   when:
     - sap_install_media_detect_move_or_copy_archives
 
 - name: SAP Install Media Detect - Find files after extraction - Set fact for SAP kernel files, move_or_copy_archives parameter not set
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_software_path: "{{ __sap_install_media_detect_software_main_directory }}" # for setting consecutive vars
   ignore_errors: true
   when:
@@ -23,7 +24,7 @@
   ansible.builtin.shell: set -o pipefail && ls -1tr SAPCAR*.EXE | tail -1
   args:
     chdir: "{{ __sap_install_media_detect_software_main_directory }}"
-  register: sap_swpm_sapcar_file_name_get
+  register: __sap_install_media_detect_register_sapcar_file_name
   changed_when: false
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP_HANA_CLIENT for SAP SWPM
@@ -32,7 +33,7 @@
     recurse: true
     file_type: directory
     patterns: "SAP_HANA_CLIENT"
-  register: sap_hana_client_path
+  register: __sap_install_media_detect_register_cd_rdbms_path
   ignore_errors: true
   when:
     - sap_install_media_detect_db_client == 'saphana'
@@ -44,7 +45,7 @@
     file_type: directory
     patterns: ".*LINUXX86_64.*"
     use_regex: true
-  register: detect_directory_ibmdb2_extracted
+  register: __sap_install_media_detect_register_cd_ibmdb2_path
   when: sap_install_media_detect_db == 'ibmdb2'
 
 - name: SAP Install Media Detect - Find files after extraction - Find IBM Db2 Client
@@ -54,7 +55,7 @@
     file_type: directory
     patterns: ".*DATA_UNITS.*"
     use_regex: true
-  register: detect_directory_ibmdb2_client_extracted
+  register: __sap_install_media_detect_register_cd_ibmdb2_client_path
   when:
     - sap_install_media_detect_db_client == 'ibmdb2'
 
@@ -65,7 +66,7 @@
     file_type: directory
     patterns: ".*LINUX_X86_64.*"
     use_regex: true
-  register: detect_directory_oracledb_extracted
+  register: __sap_install_media_detect_register_cd_oracle_path
   when: sap_install_media_detect_db == 'oracledb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find Oracle DB Client
@@ -75,7 +76,7 @@
     file_type: directory
     patterns: ".*OCL_LINUX_X86_64.*"
     use_regex: true
-  register: detect_directory_oracledb_client_extracted
+  register: __sap_install_media_detect_register_cd_oracle_client_path
   when:
     - sap_install_media_detect_db_client == 'oracledb'
 
@@ -86,7 +87,7 @@
     file_type: directory
     patterns: ".*SYBASE_LINUX.*"
     use_regex: true
-  register: detect_directory_sapase_extracted
+  register: __sap_install_media_detect_register_cd_sapase_path
   when: sap_install_media_detect_db == 'sapase'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ASE Client
@@ -96,7 +97,7 @@
     file_type: directory
     patterns: "sybodbc"
     use_regex: true
-  register: detect_directory_sapase_client_extracted
+  register: __sap_install_media_detect_register_cd_sapase_client_path
   when:
     - sap_install_media_detect_db_client == 'sapase'
 
@@ -107,14 +108,14 @@
     file_type: directory
     patterns: '.*MaxDB_7.9.*'
     use_regex: true
-  register: detect_directory_sapmaxdb_extracted
+  register: __sap_install_media_detect_register_cd_sapmaxdb_path
   when: sap_install_media_detect_db == 'sapmaxdb'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXE
   ansible.builtin.shell: ls SAPEXE_*.SAR
   args:
     chdir: "{{ sap_swpm_software_path }}"
-  register: sap_swpm_kernel_independent_file_name_get
+  register: __sap_install_media_detect_register_kernel_independent_file_name
   changed_when: false
   when: sap_install_media_detect_kernel
 
@@ -123,7 +124,7 @@
     msg: "More than one SAPEXE file has been detected."
   when:
     - sap_install_media_detect_kernel
-    - sap_swpm_kernel_independent_file_name_get.stdout_lines | count > 1
+    - __sap_install_media_detect_register_kernel_independent_file_name.stdout_lines | count > 1
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXEDB, database unspecific - block
   when:
@@ -136,14 +137,14 @@
       ansible.builtin.shell: ls SAPEXEDB_*.SAR
       args:
         chdir: "{{ sap_swpm_software_path }}"
-      register: sap_swpm_kernel_dependent_file_name_get_db_unspecific
+      register: __sap_install_media_detect_register_kernel_dependent_file_name
       changed_when: false
 
     - name: SAP Install Media Detect - Find files after extraction - Fail if more than one SAPEXEDB file found, database unspecific
       ansible.builtin.fail:
         msg: "No, or more than one, SAPEXEDB file has been detected."
       when:
-        - sap_swpm_kernel_dependent_file_name_get_db_unspecific.stdout_lines | count != 1
+        - __sap_install_media_detect_register_kernel_dependent_file_name.stdout_lines | count != 1
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAPEXEDB, database specific - block
   when:
@@ -179,7 +180,7 @@
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_hdb') | length != 1
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for SAP HANA
-      ansible.builtin.set_fact:
+      ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
         sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_hdb') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'saphana'
@@ -193,7 +194,7 @@
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ase') | length != 1
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for SAP ASE
-      ansible.builtin.set_fact:
+      ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
         sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ase') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'sapase'
@@ -207,7 +208,7 @@
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ada') | length != 1
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for SAP MAXDB
-      ansible.builtin.set_fact:
+      ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
         sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ada') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'sapmaxdb'
@@ -221,7 +222,7 @@
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ora') | length != 1
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for Oracle DB
-      ansible.builtin.set_fact:
+      ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
         sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_ora') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'oracledb'
@@ -235,7 +236,7 @@
         - __sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_db6') | length != 1
 
     - name: SAP Install Media Detect - Find files after extraction - Set the kernel dependent file name for IBM Db2
-      ansible.builtin.set_fact:
+      ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
         sap_swpm_kernel_dependent_file_name_get_db_specific: "{{ (__sap_install_media_detect_fact_db_dependent_kernel_files_sapfile_results | selectattr('sap_file_type', 'search', 'sap_kernel_db_db6') | first).file }}"
       when:
         - sap_install_media_detect_kernel_db == 'ibmdb2'
@@ -245,7 +246,7 @@
   ansible.builtin.shell: set -o pipefail && ls -1tr igsexe*.sar | tail -1
   args:
     chdir: "{{ sap_swpm_software_path }}"
-  register: sap_swpm_igs_file_name_get
+  register: __sap_install_media_detect_register_igs_file_name
   changed_when: false
   when: sap_install_media_detect_igs
 
@@ -253,7 +254,7 @@
   ansible.builtin.shell: set -o pipefail && ls -1tr igshelper*.sar | tail -1
   args:
     chdir: "{{ sap_swpm_software_path }}"
-  register: sap_swpm_igs_helper_file_name_get
+  register: __sap_install_media_detect_register_igs_helper_file_name
   changed_when: false
   when: sap_install_media_detect_igs
 
@@ -261,7 +262,7 @@
   ansible.builtin.shell: ls SAPWEBDISP_*.SAR
   args:
     chdir: "{{ sap_swpm_software_path }}"
-  register: sap_swpm_web_dispatcher_file_name_get
+  register: __sap_install_media_detect_register_web_dispatcher_file_name
   ignore_errors: true
   changed_when: false
   when: sap_install_media_detect_webdisp
@@ -271,13 +272,13 @@
     msg: "More than one SAPWEBDISP file has been detected."
   when:
     - sap_install_media_detect_webdisp
-    - sap_swpm_web_dispatcher_file_name_get.stdout_lines | count > 1
+    - __sap_install_media_detect_register_web_dispatcher_file_name.stdout_lines | count > 1
 
 - name: SAP Install Media Detect - Find files after extraction - Find Maintenance Planner Stack XML file
   ansible.builtin.shell: set -o pipefail && ls -1tr *.xml | tail -1
   args:
     chdir: "{{ sap_swpm_software_path }}"
-  register: sap_swpm_mp_xml_file_name_get
+  register: __sap_install_media_detect_register_mp_stack_file_name
   changed_when: false
   when: sap_install_media_detect_mpstack
 
@@ -288,7 +289,7 @@
     file_type: directory
     patterns: '.*DATA_UNITS.*'
     use_regex: true
-  register: detect_directory_ecc_export_extracted
+  register: __sap_install_media_detect_register_cd_export_path_ecc
   when: sap_install_media_detect_export == 'sapecc'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP ECC IDES Export
@@ -298,7 +299,7 @@
     file_type: directory
     patterns: '.*EXP.*'
     use_regex: true
-  register: detect_directory_ecc_ides_export_extracted
+  register: __sap_install_media_detect_register_cd_export_path_ecc_ides
   when: sap_install_media_detect_export == 'sapecc_ides'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP S/4HANA Export
@@ -308,7 +309,7 @@
     file_type: file
     patterns: '.*S4.*EXPORT.*'
     use_regex: true
-  register: s4hana_export_files
+  register: __sap_install_media_detect_register_cd_export_path_s4hana
   when: sap_install_media_detect_export == 'saps4hana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP BW/4HANA Export
@@ -318,7 +319,7 @@
     file_type: file
     patterns: '.*BW4.*EXPORT.*'
     use_regex: true
-  register: bw4hana_export_files
+  register: __sap_install_media_detect_register_cd_export_path_bw4hana
   when: sap_install_media_detect_export == 'sapbw4hana'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP NetWeaver AS (ABAP) platform only Export
@@ -328,7 +329,7 @@
     file_type: directory
     patterns: '.*DATA_UNITS.*'
     use_regex: true
-  register: detect_directory_nwas_abap_export_extracted
+  register: __sap_install_media_detect_register_cd_export_path_nwas_abap
   when: sap_install_media_detect_export == 'sapnwas_abap'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP NetWeaver AS (JAVA) platform only Export
@@ -338,7 +339,7 @@
     file_type: directory
     patterns: '.*DATA_UNITS.*'
     use_regex: true
-  register: detect_directory_nwas_java_export_extracted
+  register: __sap_install_media_detect_register_cd_export_path_nwas_java
   when: sap_install_media_detect_export == 'sapnwas_java'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP Solution Manager (ABAP) platform only Export
@@ -348,7 +349,7 @@
     file_type: directory
     patterns: '.*DATA_UNITS.*'
     use_regex: true
-  register: detect_directory_solgmr_abap_export_extracted
+  register: __sap_install_media_detect_register_cd_export_path_solman_abap
   when: sap_install_media_detect_export == 'sapsolman_abap'
 
 - name: SAP Install Media Detect - Find files after extraction - Find SAP Solution Manager (JAVA) platform only Export
@@ -358,5 +359,5 @@
     file_type: directory
     patterns: '.*DATA_UNITS.*'
     use_regex: true
-  register: detect_directory_solgmr_java_export_extracted
+  register: __sap_install_media_detect_register_cd_export_path_solman_java
   when: sap_install_media_detect_export == 'sapsolman_java'

--- a/roles/sap_install_media_detect/tasks/set_global_vars.yml
+++ b/roles/sap_install_media_detect/tasks/set_global_vars.yml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+# NOTE: noqa var-naming[no-role-prefix] is required when setting variable names for other roles.
 
 - name: SAP Install Media Detect - Detection completed - Initialize variables for collecting and displaying all variables
   ansible.builtin.set_fact:
@@ -7,12 +8,12 @@
     __sap_install_media_detect_vars: ''
 
 - name: SAP Install Media Detect - Detection completed - Set fact for SAPCAR
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_sapcar_path: "{{ __sap_install_media_detect_software_main_directory }}/"
-    sap_swpm_sapcar_file_name: "{{ sap_swpm_sapcar_file_name_get.stdout }}"
+    sap_swpm_sapcar_file_name: "{{ __sap_install_media_detect_register_sapcar_file_name.stdout }}"
 
 - name: SAP Install Media Detect - Detection completed - Set fact for SWPM, move_or_copy_archives parameter set
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
 #    sap_swpm_software_path: "{{ __sap_install_media_detect_software_main_directory }}/sap_swpm/" # set in find_files_after_extraction.yml
 #    sap_swpm_install_directory: "{{ __sap_install_media_detect_software_main_directory }}/sap_swpm/"
 #    sap_swpm_install_directory: "{{ __sap_install_media_detect_software_main_directory }}/sap_swpm_download_basket/" # for sap_swpm Ansible Role
@@ -26,7 +27,7 @@
     - sap_install_media_detect_swpm
 
 - name: SAP Install Media Detect - Detection completed - Set fact for SWPM, move_or_copy_archives parameter not set
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
 #    sap_swpm_install_directory: "{{ __sap_install_media_detect_software_main_directory }}/" # for sap_swpm Ansible Role
     sap_swpm_install_directory: "{{ sap_swpm_software_path }}/"
     sap_swpm_swpm_path: "{{ sap_swpm_software_path }}/" # for sap_swpm Ansible Role
@@ -35,7 +36,7 @@
     - sap_install_media_detect_swpm
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA - sap_hana_install, move_or_copy_archives parameter set
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_hana_install_directory: "{{ __sap_install_media_detect_software_main_directory }}/sap_hana/"
     sap_hana_install_software_directory: "{{ __sap_install_media_detect_software_main_directory }}/sap_hana/" # for sap_hana_install Ansible Role
     sap_hana_install_software_extract_directory: "{{ __sap_install_media_detect_software_main_directory }}/sap_hana_extracted/" # for sap_hana_install Ansible Role
@@ -45,7 +46,7 @@
     - sap_install_media_detect_db == 'saphana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA - sap_hana_install, move_or_copy_archives parameter not set
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_hana_install_directory: "{{ __sap_install_media_detect_software_main_directory }}/"
     sap_hana_install_software_directory: "{{ __sap_install_media_detect_software_main_directory }}/" # for sap_hana_install Ansible Role
 #    sap_hana_install_software_extract_directory: "{{ __sap_install_media_detect_software_main_directory }}/sap_hana_extracted/" # for sap_hana_install Ansible Role
@@ -55,8 +56,8 @@
     - sap_install_media_detect_db == 'saphana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP HANA Client - sap_swpm
-  ansible.builtin.set_fact:
-    sap_swpm_cd_rdbms_path: "{{ sap_hana_client_path.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_rdbms_path: "{{ __sap_install_media_detect_register_cd_rdbms_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when:
     - sap_install_media_detect_move_or_copy_archives
@@ -65,14 +66,14 @@
 # In 'find_files_after_extraction.yml', we search for a directory named 'LINUXX86_64'. For the role sap_swpm, we need to set
 # exactly this path
 - name: SAP Install Media Detect - Detection completed - Set facts for IBM Db2
-  ansible.builtin.set_fact:
-    sap_swpm_cd_ibmdb2_path: "{{ detect_directory_ibmdb2_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_ibmdb2_path: "{{ __sap_install_media_detect_register_cd_ibmdb2_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db == 'ibmdb2'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for IBM Db2 Client
-  ansible.builtin.set_fact:
-    sap_swpm_cd_ibmdb2_client_path: "{{ detect_directory_ibmdb2_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_ibmdb2_client_path: "{{ __sap_install_media_detect_register_cd_ibmdb2_client_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db_client == 'ibmdb2'
 
@@ -80,15 +81,15 @@
 # to set the path which contains this directory, not the directory itself. For the Oracle client, we search for a directory name which
 # contains 'OCL_LINUX_X86_64'. For the role sap_swpm, we also need the path which contains this directory.
 - name: SAP Install Media Detect - Detection completed - Set facts for Oracle DB
-  ansible.builtin.set_fact:
-    sap_anydb_install_oracle_extract_path: "{{ detect_directory_oracledb_extracted.files[0].path | dirname }}/" # for sap_anydb_install_oracle Ansible Role
-    sap_swpm_cd_oracle_path: "{{ detect_directory_oracledb_extracted.files[0].path | dirname }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_anydb_install_oracle_extract_path: "{{ __sap_install_media_detect_register_cd_oracle_path.files[0].path | dirname }}/" # for sap_anydb_install_oracle Ansible Role
+    sap_swpm_cd_oracle_path: "{{ __sap_install_media_detect_register_cd_oracle_path.files[0].path | dirname }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db == 'oracledb'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Oracle DB Client
-  ansible.builtin.set_fact:
-    sap_swpm_cd_oracle_client_path: "{{ detect_directory_oracledb_client_extracted.files[0].path | dirname }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_oracle_client_path: "{{ __sap_install_media_detect_register_cd_oracle_client_path.files[0].path | dirname }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db_client == 'oracledb'
 
@@ -96,40 +97,40 @@
 # to set exactly this path. For the ASE client, we search for a directory which contains 'sybodbc'. For the role
 # sap_swpm, we need to set exactly this path.
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP ASE
-  ansible.builtin.set_fact:
-    sap_swpm_cd_sapase_path: "{{ detect_directory_sapase_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_sapase_path: "{{ __sap_install_media_detect_register_cd_sapase_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db == 'sapase'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP ASE Client
-  ansible.builtin.set_fact:
-    sap_swpm_cd_sapase_client_path: "{{ detect_directory_sapase_client_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_sapase_client_path: "{{ __sap_install_media_detect_register_cd_sapase_client_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db_client == 'sapase'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP MaxDB
-  ansible.builtin.set_fact:
-    sap_swpm_cd_sapmaxdb_path: "{{ detect_directory_sapmaxdb_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_sapmaxdb_path: "{{ __sap_install_media_detect_register_cd_sapmaxdb_path.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_db == 'sapmaxdb'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAPEXE
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_kernel_independent_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_kernel_independent_file_name: "{{ sap_swpm_kernel_independent_file_name_get.stdout }}"
+    sap_swpm_kernel_independent_file_name: "{{ __sap_install_media_detect_register_kernel_independent_file_name.stdout }}"
   when: sap_install_media_detect_kernel
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAPEXEDB, unspecific
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_kernel_dependent_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_kernel_dependent_file_name: "{{ sap_swpm_kernel_dependent_file_name_get_db_unspecific.stdout }}"
+    sap_swpm_kernel_dependent_file_name: "{{ __sap_install_media_detect_register_kernel_dependent_file_name.stdout }}"
   when:
     - sap_install_media_detect_kernel
     - sap_install_media_detect_kernel_db is not defined or
       sap_install_media_detect_kernel_db | length == 0
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAPEXEDB, specific
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_kernel_dependent_path: "{{ sap_swpm_software_path }}/"
     sap_swpm_kernel_dependent_file_name: "{{ sap_swpm_kernel_dependent_file_name_get_db_specific }}"
   when:
@@ -139,80 +140,80 @@
     - sap_install_media_detect_kernel_db != 'none'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP IGS
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_igs_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_igs_file_name: "{{ sap_swpm_igs_file_name_get.stdout }}"
+    sap_swpm_igs_file_name: "{{ __sap_install_media_detect_register_igs_file_name.stdout }}"
   when: sap_install_media_detect_igs
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP IGS Helper
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_igs_helper_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_igs_helper_file_name: "{{ sap_swpm_igs_helper_file_name_get.stdout }}"
+    sap_swpm_igs_helper_file_name: "{{ __sap_install_media_detect_register_igs_helper_file_name.stdout }}"
   when: sap_install_media_detect_igs
 
 - name: SAP Install Media Detect - Detection completed - Set facts for SAP Maintenance Planner Stack XML files
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_mp_stack_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_mp_stack_file_name: "{{ sap_swpm_mp_xml_file_name_get.stdout }}"
+    sap_swpm_mp_stack_file_name: "{{ __sap_install_media_detect_register_mp_stack_file_name.stdout }}"
   ignore_errors: true
   when: sap_install_media_detect_mpstack
 
 - name: SAP Install Media Detect - Detection completed - Set facts for WebDisp
-  ansible.builtin.set_fact:
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     sap_swpm_web_dispatcher_path: "{{ sap_swpm_software_path }}/"
-    sap_swpm_web_dispatcher_file_name: "{{ sap_swpm_web_dispatcher_file_name_get.stdout }}"
+    sap_swpm_web_dispatcher_file_name: "{{ __sap_install_media_detect_register_web_dispatcher_file_name.stdout }}"
   ignore_errors: true
   when: sap_install_media_detect_webdisp
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP ECC
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ detect_directory_ecc_export_extracted.files[0].path }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_ecc.files[0].path }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapecc'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP ECC IDES
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ detect_directory_ecc_ides_export_extracted.files[0].path | dirname | dirname }}/" # for sap_swpm Ansible Role
-    sap_swpm_cd_export_pt1_path: "{{ (detect_directory_ecc_ides_export_extracted.files | map(attribute='path') | map('dirname') | list | select() | unique)[0] }}/" # for sap_swpm Ansible Role
-    sap_swpm_cd_export_pt2_path: "{{ (detect_directory_ecc_ides_export_extracted.files | map(attribute='path') | map('dirname') | list | select() | unique)[1] }}/" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_ecc_ides.files[0].path | dirname | dirname }}/" # for sap_swpm Ansible Role
+    sap_swpm_cd_export_pt1_path: "{{ (__sap_install_media_detect_register_cd_export_path_ecc_ides.files | map(attribute='path') | map('dirname') | list | select() | unique)[0] }}/" # for sap_swpm Ansible Role
+    sap_swpm_cd_export_pt2_path: "{{ (__sap_install_media_detect_register_cd_export_path_ecc_ides.files | map(attribute='path') | map('dirname') | list | select() | unique)[1] }}/" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapecc_ides'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP S/4HANA
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ s4hana_export_files.files[0].path | dirname }}" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_s4hana.files[0].path | dirname }}" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'saps4hana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP BW/4HANA
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ bw4hana_export_files.files[0].path | dirname }}" # for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_bw4hana.files[0].path | dirname }}" # for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapbw4hana'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP NetWeaver AS (ABAP) platform only
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ detect_directory_nwas_abap_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_nwas_abap.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapnwas_abap'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP NetWeaver AS (JAVA) platform only
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ detect_directory_nwas_java_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_nwas_java.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapnwas_java'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP Solution Manager (ABAP)
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ detect_directory_solgmr_abap_export_extracted.files[0].path | dirname | dirname }}/" # for sap_swpm Ansible Role
-    sap_swpm_cd_export_pt1_path: "{{ detect_directory_solgmr_abap_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
-    sap_swpm_cd_export_pt2_path: "{{ detect_directory_solgmr_abap_export_extracted.files[1].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_solman_abap.files[0].path | dirname | dirname }}/" # for sap_swpm Ansible Role
+    sap_swpm_cd_export_pt1_path: "{{ __sap_install_media_detect_register_cd_export_path_solman_abap.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
+    sap_swpm_cd_export_pt2_path: "{{ __sap_install_media_detect_register_cd_export_path_solman_abap.files[1].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapsolman_abap'
 
 - name: SAP Install Media Detect - Detection completed - Set facts for Export of SAP Solution Manager (JAVA)
-  ansible.builtin.set_fact:
-    sap_swpm_cd_export_path: "{{ detect_directory_solgmr_java_export_extracted.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    sap_swpm_cd_export_path: "{{ __sap_install_media_detect_register_cd_export_path_solman_java.files[0].path }}/" # directory DATA_UNITS, for sap_swpm Ansible Role
   ignore_errors: true
   when: sap_install_media_detect_export == 'sapsolman_java'
 


### PR DESCRIPTION
Fixes for `ansible-lint` that is updated as part of https://github.com/sap-linuxlab/community.sap_install/pull/1118

## Changes
- `# noqa var-naming[no-role-prefix]` added to all tasks setting other `sap_install` variables, because using .ansible-lint-ignore will show it as warnings, polluting log.
- Replace all `detect_` register variables with correct internal name `__sap_install_media_detect_register_`

## Result
```bash
ansible-lint --version
ansible-lint 25.9.0 using ansible-core:2.19.2 ansible-compat:25.8.1 ruamel-yaml:0.18.14 ruamel-yaml-clib:0.2.12

ansible-lint roles/sap_install_media_detect/

# Before
Failed: 73 failure(s), 0 warning(s) in 22 files processed of 24 encountered.

# After
Passed: 0 failure(s), 0 warning(s) in 22 files processed of 24 encountered.
```