### PR TITLE
sap_hostagent: Fix linting errors

### DIFF
--- a/roles/sap_hostagent/tasks/config_ssl.yml
+++ b/roles/sap_hostagent/tasks/config_ssl.yml
@@ -39,8 +39,8 @@
   environment:
     LD_LIBRARY_PATH: /usr/sap/hostctrl/exe
     SECUDIR: /usr/sap/hostctrl/exe/sec
-  register: ssl_config_output
-  changed_when: "'Certificate Request:' in ssl_config_output.stdout"
+  register: __sap_hostagent_register_sapgenpse_gen_pse
+  changed_when: "'Certificate Request:' in __sap_hostagent_register_sapgenpse_gen_pse.stdout"
 
 - name: Grant SAP Host Agent access to the server PSE
   ansible.builtin.command: >
@@ -55,8 +55,8 @@
   environment:
     LD_LIBRARY_PATH: /usr/sap/hostctrl/exe
     SECUDIR: /usr/sap/hostctrl/exe/sec
-  register: ssl_config_output
-  changed_when: "'Added SSO-credentials for PSE' in ssl_config_output.stdout"
+  register: __sap_hostagent_register_sapgenpse_seclogin
+  changed_when: "'Added SSO-credentials for PSE' in __sap_hostagent_register_sapgenpse_seclogin.stdout"
 
 # Right now there is no option to import the signed certificate. The CSR must be signed
 # by a valid CA in order to import it
@@ -86,10 +86,10 @@
   environment:
     LD_LIBRARY_PATH: /usr/sap/hostctrl/exe
     SECUDIR: /usr/sap/hostctrl/exe/sec
-  register: ssl_config_output
-  changed_when: "'Opening PSE' in ssl_config_output.stdout"
+  register: __sap_hostagent_register_sapgenpse_get_my_name
+  changed_when: "'Opening PSE' in __sap_hostagent_register_sapgenpse_get_my_name.stdout"
 
 - name: Restart SAPHOSTAGENT
   ansible.builtin.command: /usr/sap/hostctrl/exe/saphostexec -restart
-  register: ssl_config_output
-  changed_when: "'start hostcontrol using profile' in ssl_config_output.stdout"
+  register: __sap_hostagent_register_saphostexec_restart
+  changed_when: "'start hostcontrol using profile' in __sap_hostagent_register_saphostexec_restart.stdout"

--- a/roles/sap_hostagent/tasks/deploy_bundle.yml
+++ b/roles/sap_hostagent/tasks/deploy_bundle.yml
@@ -10,7 +10,7 @@
 
 - name: Install SAPHOSTAGENT
   ansible.builtin.command: "{{ sap_hostagent_agent_tmp_directory }}/global/hdb/saphostagent_setup/saphostexec -install"
-  register: installagent
+  register: __sap_hostagent_register_install_saphostagent_bundle
   args:
     chdir: "{{ sap_hostagent_agent_tmp_directory }}/global/hdb/saphostagent_setup/"
-  changed_when: "'Install service' in installagent.stdout"
+  changed_when: "'Install service' in __sap_hostagent_register_install_saphostagent_bundle.stdout"

--- a/roles/sap_hostagent/tasks/deploy_rpm.yml
+++ b/roles/sap_hostagent/tasks/deploy_rpm.yml
@@ -8,16 +8,18 @@
     mode: '0755'
   when: sap_hostagent_rpm_local_path is defined
 
+# disable_gpg_check is not package parameter,
+# but it is recognized by underlying package manager
 - name: Ensure RPM file is installed
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name: "{{ sap_hostagent_agent_tmp_directory }}/{{ sap_hostagent_rpm_file_name }}"
     state: present
-    disable_gpg_check: yes
+    disable_gpg_check: true
   when: sap_hostagent_rpm_local_path is defined
 
 - name: Ensure RPM file is installed
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name: "{{ sap_hostagent_rpm_remote_path }}/{{ sap_hostagent_rpm_file_name }}"
     state: present
-    disable_gpg_check: yes
+    disable_gpg_check: true
   when: sap_hostagent_rpm_remote_path is defined

--- a/roles/sap_hostagent/tasks/deploy_sar.yml
+++ b/roles/sap_hostagent/tasks/deploy_sar.yml
@@ -17,14 +17,14 @@
   ansible.builtin.command: >-
     {{ sap_hostagent_agent_tmp_directory }}/{{ sap_hostagent_sapcar_file_name }} \
     -xvf {{ sap_hostagent_agent_tmp_directory }}/{{ sap_hostagent_sar_file_name }} -manifest SIGNATURE.SMF
-  register: extractagent
+  register: __sap_hostagent_register_extract_saphostagent_sar
   args:
     chdir: "{{ sap_hostagent_agent_tmp_directory }}"
-  changed_when: "'SAPCAR: processing archive' in extractagent.stdout"
+  changed_when: "'SAPCAR: processing archive' in __sap_hostagent_register_extract_saphostagent_sar.stdout"
 
 - name: Install SAPHOSTAGENT
   ansible.builtin.command: "{{ sap_hostagent_agent_tmp_directory }}/saphostexec -install"
-  register: installagent
+  register: __sap_hostagent_register_install_saphostagent_sar
   args:
     chdir: "{{ sap_hostagent_agent_tmp_directory }}"
-  changed_when: "'Install service' in installagent.stdout"
+  changed_when: "'Install service' in __sap_hostagent_register_install_saphostagent_sar.stdout"

--- a/roles/sap_hostagent/tasks/deploy_sar_remote.yml
+++ b/roles/sap_hostagent/tasks/deploy_sar_remote.yml
@@ -5,14 +5,14 @@
   ansible.builtin.command: >-
     {{ sap_hostagent_sapcar_remote_path }}/{{ sap_hostagent_sapcar_file_name }} \
     -xvf {{ sap_hostagent_sar_remote_path }}/{{ sap_hostagent_sar_file_name }} -manifest SIGNATURE.SMF
-  register: extractagent
+  register: __sap_hostagent_register_extract_saphostagent_sar_remote
   args:
     chdir: "{{ sap_hostagent_agent_tmp_directory }}"
-  changed_when: "'SAPCAR: processing archive' in extractagent.stdout"
+  changed_when: "'SAPCAR: processing archive' in __sap_hostagent_register_extract_saphostagent_sar_remote.stdout"
 
 - name: Install SAPHOSTAGENT
   ansible.builtin.command: "{{ sap_hostagent_agent_tmp_directory }}/saphostexec -install"
-  register: installagent
+  register: __sap_hostagent_register_install_saphostagent_sar_remote
   args:
     chdir: "{{ sap_hostagent_agent_tmp_directory }}"
-  changed_when: "'Install service' in installagent.stdout"
+  changed_when: "'Install service' in __sap_hostagent_register_install_saphostagent_sar_remote.stdout"


### PR DESCRIPTION
Fixes for `ansible-lint` that is updated as part of https://github.com/sap-linuxlab/community.sap_install/pull/1118

## Changes
- replace module `yum` with `package`.
  - `disable_gpg_check: true` is not recognized by package module, but it is sent to underlying package manager. Tested on SLES with zypper.
- Replace all internal register variables with correct internal name `__sap_hostagent_register_`

## Result
```bash
ansible-lint --version
ansible-lint 25.9.0 using ansible-core:2.19.2 ansible-compat:25.8.1 ruamel-yaml:0.18.14 ruamel-yaml-clib:0.2.12

ansible-lint roles/sap_hostagent/

# Before
Failed: 11 failure(s), 0 warning(s) in 11 files processed of 13 encountered.

# After
Passed: 0 failure(s), 0 warning(s) in 13 files processed of 15 encountered.
```