### PR TITLE
sap_*_preconfigure/SLES: Improved pattern check, sanitize log output and add loop_vars

### DIFF
--- a/roles/sap_general_preconfigure/tasks/SLES/assert-configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/assert-configuration.yml
@@ -3,7 +3,7 @@
 
 - name: Assert - List required SAP Notes
   ansible.builtin.debug:
-    var: __sap_general_preconfigure_sapnotes_versions | difference([''])
+    msg: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"
 
 - name: Gather service facts
   ansible.builtin.service_facts:

--- a/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
@@ -4,16 +4,18 @@
 - name: Query installed zypper patterns
   ansible.builtin.command:
     cmd: zypper patterns --installed-only
-  register: __sap_general_preconfigure_register_patterns
+  register: __sap_general_preconfigure_register_installed_patterns
   changed_when: false
   ignore_errors: true
 
 - name: Assert that all required zypper patterns are installed
   ansible.builtin.assert:
-    that: "'{{ item }}' in __sap_general_preconfigure_register_patterns.stdout"
-    fail_msg: "FAIL: Pattern '{{ item }}' is not installed!"
-    success_msg: "PASS: Pattern '{{ item }}' is installed."
+    that: pattern_item in __sap_general_preconfigure_register_installed_patterns.stdout
+    fail_msg: "FAIL: Pattern '{{ pattern_item }}' is not installed!"
+    success_msg: "PASS: Pattern '{{ pattern_item }}' is installed."
   loop: "{{ sap_general_preconfigure_patterns }}"
+  loop_control:
+    loop_var: pattern_item
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 
@@ -22,24 +24,27 @@
 - name: Query RPM packages
   ansible.builtin.shell:
     cmd: |
-      if rpm -q {{ item }} &> /dev/null;
-      then rpm -q {{ item }}
-      else rpm -q --whatprovides {{ item }};
+      if rpm -q {{ package_item }} &> /dev/null;
+      then rpm -q {{ package_item }}
+      else rpm -q --whatprovides {{ package_item }};
       fi
   register: __sap_general_preconfigure_register_packages
-  changed_when: false
-  ignore_errors: true
   loop: "{{ sap_general_preconfigure_packages if not sap_general_preconfigure_min_package_check | bool
     else ((sap_general_preconfigure_packages | d([])) + (__sap_general_preconfigure_min_pkgs | d([])) | map(attribute='0') | unique) }}"
-
+  loop_control:
+    loop_var: package_item
+  changed_when: false
+  ignore_errors: true
 
 - name: Assert that all required packages are installed
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_packages.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Package '{{ item }}' is not installed!"
-    success_msg: "PASS: Package '{{ item }}' is installed."
+    that: __sap_general_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Package '{{ package_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ package_item }}' is installed."
   loop: "{{ sap_general_preconfigure_packages if not sap_general_preconfigure_min_package_check | bool
     else ((sap_general_preconfigure_packages | d([])) + (__sap_general_preconfigure_min_pkgs | d([])) | map(attribute='0') | unique) }}"
+  loop_control:
+    loop_var: package_item
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 
@@ -51,28 +56,31 @@
     - name: Query RPM packages for minimum required packages
       ansible.builtin.shell:
         cmd: |
-          if rpm -q {{ item[0] }} &> /dev/null;
-          then rpm -q --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n' {{ item[0] }}
-          else rpm -q --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n' --whatprovides {{ item[0] }};
+          if rpm -q {{ package_item[0] }} &> /dev/null;
+          then rpm -q --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n' {{ package_item[0] }}
+          else rpm -q --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}\n' --whatprovides {{ package_item[0] }};
           fi
       register: __sap_general_preconfigure_register_packages_minimum
+      loop: "{{ __sap_general_preconfigure_min_pkgs }}"
+      loop_control:
+        loop_var: package_item
       changed_when: false
       ignore_errors: true
-      loop: "{{ __sap_general_preconfigure_min_pkgs }}"
-
 
     - name: Assert that all minimum required packages are installed with minimum version
       ansible.builtin.assert:
         that:
           - __version[0] is version(item[1], '>=')
-        fail_msg: "FAIL: Minimum package version '{{ item[0] }}-{{ item[1] }}' is not installed! Current version: '{{ __version[0] }}'"
-        success_msg: "PASS: Minimum package version '{{ item[0] }}-{{ item[1] }}' is installed."
+        fail_msg: "FAIL: Minimum package version '{{ package_item[0] }}-{{ package_item[1] }}' is not installed! Current version: '{{ __version[0] }}'"
+        success_msg: "PASS: Minimum package version '{{ package_item[0] }}-{{ package_item[1] }}' is installed."
       vars:
         __version:
-          "{{ __sap_general_preconfigure_register_packages_minimum.results | selectattr('item', 'equalto', item) | map(attribute='stdout') }}"
+          "{{ __sap_general_preconfigure_register_packages_minimum.results | selectattr('package_item', 'equalto', package_item) | map(attribute='stdout') }}"
       loop: "{{ __sap_general_preconfigure_min_pkgs }}"
+      loop_control:
+        loop_var: package_item
       ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
-      when: __sap_general_preconfigure_register_packages.results | selectattr('item', 'equalto', item[0]) | map(attribute='rc') | first == 0
+      when: __sap_general_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item[0]) | map(attribute='rc') | first == 0
 
 
 - name: Gather service facts
@@ -112,7 +120,9 @@
 
 - name: Report if checking for possible package updates is not requested
   ansible.builtin.debug:
-    msg: "INFO: Not checking for possible package updates (variable sap_general_preconfigure_update)."
+    msg: >
+      INFO: Check for latest packages was not executed
+      because the variable 'sap_general_preconfigure_update' is set to false.
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
   when: not sap_general_preconfigure_update
 

--- a/roles/sap_general_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/configuration.yml
@@ -3,7 +3,7 @@
 
 - name: Configure - List required SAP Notes
   ansible.builtin.debug:
-    var: __sap_general_preconfigure_sapnotes_versions | difference([''])
+    msg: "{{ __sap_general_preconfigure_sapnotes_versions | difference(['']) }}"
 
 # Configure /etc/hosts
 - name: Import role sap_maintain_etc_hosts

--- a/roles/sap_general_preconfigure/tasks/SLES/generic/grub_update.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/generic/grub_update.yml
@@ -6,11 +6,13 @@
 - name: Update existing GRUB entries
   ansible.builtin.lineinfile:
     path: /etc/default/grub
-    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=".*?)(\b{{ item.split("=")[0] }}=[^ ]*\b)(.*")'
-    line: '\1{{ item }}\3'
+    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=".*?)(\b{{ grub_line_item.split("=")[0] }}=[^ ]*\b)(.*")'
+    line: '\1{{ grub_line_item }}\3'
     backrefs: true
   register: __sap_general_preconfigure_grub_update
   loop: "{{ __sap_general_preconfigure_grub_cmdline }}"
+  loop_control:
+    loop_var: grub_line_item
 
 
 - name: Get current contents of GRUB
@@ -23,11 +25,13 @@
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*?)"'
-    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 {{ item }}"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 {{ grub_line_item }}"'
     backrefs: true
   register: __sap_general_preconfigure_grub_add
   loop: "{{ __sap_general_preconfigure_grub_cmdline }}"
-  when: item not in (__sap_general_preconfigure_grub_contents.content | b64decode)
+  loop_control:
+    loop_var: grub_line_item
+  when: grub_line_item not in (__sap_general_preconfigure_grub_contents.content | b64decode)
 
 
 - name: Trigger grub update if necessary # noqa no-changed-when

--- a/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -23,7 +23,7 @@
         cmd: rpm -q sapconf
       register: __sap_general_preconfigure_register_sapconf
       changed_when: false
-      ignore_errors: true
+      failed_when: false  # avoid failure in logs if sapconf is not installed
 
     - name: Ensure sapconf is stopped and disabled
       ansible.builtin.systemd:
@@ -44,7 +44,7 @@
         cmd: systemctl is-failed sapconf.service
       register: __sap_general_preconfigure_register_sapconf_failed
       changed_when: false
-      ignore_errors: true
+      failed_when: false  # avoid failure in logs
       when: __sap_general_preconfigure_register_sapconf.rc == 0
 
     - name: Execute systemctl reset-failed sapconf.service  # noqa command-instead-of-module

--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -29,24 +29,52 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+# This workflow is designed to remove dependency on zypper module.
 # Pattern installation will run only if pattern is not installed
 # This ensures that command module shows correct changed status
 - name: Query installed zypper patterns
   ansible.builtin.command:
     cmd: zypper patterns --installed-only
-  register: __sap_general_preconfigure_register_patterns
+  register: __sap_general_preconfigure_register_installed_patterns
   changed_when: false
   ignore_errors: true
 
+# Get only lines starting with "i " or "i+ " and split them into list of installed patterns.
+- name: Parse installed pattern names from stdout into list
+  ansible.builtin.set_fact:
+    __sap_general_preconfigure_fact_installed_patterns: >
+      {{
+        __sap_general_preconfigure_fact_installed_patterns | default([]) +
+        [ (pattern_item.split('|')[1]).strip() ]
+      }}
+  loop: "{{ __sap_general_preconfigure_register_installed_patterns.stdout_lines | default([]) | select('match', '^\\s*i\\+?\\s') | list }}"
+  loop_control:
+    label: "{{ (pattern_item.split('|')[1]).strip() }}"
+    loop_var: pattern_item
+
+# If this '__sap_general_preconfigure_fact_installed_patterns' is empty,
+# the check falls back to searching the raw stdout of the zypper command which is less accurate.
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
-    cmd: zypper install -y -t pattern {{ item }}
+    cmd: zypper install -y -t pattern {{ pattern_item }}
   loop: "{{ sap_general_preconfigure_patterns }}"
+  loop_control:
+    loop_var: pattern_item
   # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10
-  when: item not in __sap_general_preconfigure_register_patterns.stdout
-  changed_when: item not in __sap_general_preconfigure_register_patterns.stdout
+  when: >
+    (__sap_general_preconfigure_fact_installed_patterns | length > 0
+      and pattern_item not in __sap_general_preconfigure_fact_installed_patterns)
+    or (__sap_general_preconfigure_fact_installed_patterns | length == 0
+      and __sap_general_preconfigure_register_installed_patterns.stdout is defined
+      and pattern_item not in __sap_general_preconfigure_register_installed_patterns.stdout)
+  changed_when: >
+    (__sap_general_preconfigure_fact_installed_patterns | length > 0
+      and pattern_item not in __sap_general_preconfigure_fact_installed_patterns)
+    or (__sap_general_preconfigure_fact_installed_patterns | length == 0
+      and __sap_general_preconfigure_register_installed_patterns.stdout is defined
+      and pattern_item not in __sap_general_preconfigure_register_installed_patterns.stdout)
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
@@ -57,11 +85,11 @@
 
 - name: Install minimum packages if required
   ansible.builtin.package:
-    name: '{{ line_item[0] }}>={{ line_item[1] }}'
+    name: '{{ package_item[0] }}>={{ package_item[1] }}'
     state: present
   loop: "{{ __sap_general_preconfigure_min_pkgs }}"
   loop_control:
-    loop_var: line_item
+    loop_var: package_item
   when:
     - sap_general_preconfigure_min_package_check|bool
     - __sap_general_preconfigure_min_pkgs | d([])
@@ -97,7 +125,7 @@
 
 - name: Display the output of the reboot requirement check
   ansible.builtin.debug:
-    var: __sap_general_preconfigure_register_needs_restarting
+    msg: "{{ __sap_general_preconfigure_register_needs_restarting.stdout }}"
 
 
 # sap_general_preconfigure_fact_reboot_required is used by follow up role: sap_hana_preconfigure
@@ -111,10 +139,6 @@
   when:
     - __sap_general_preconfigure_register_needs_restarting is failed
       or __sap_general_preconfigure_register_update_latest.changed
-
-- name: For needs-restarting - Display the content of sap_general_preconfigure_fact_reboot_required
-  ansible.builtin.debug:
-    var: sap_general_preconfigure_fact_reboot_required
 
 
 - name: Call Reboot handler if necessary

--- a/roles/sap_general_preconfigure/tasks/sapnote/2578899/assert-configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2578899/assert-configuration.yml
@@ -5,16 +5,20 @@
 # uuidd.socket is not found, while uuidd.service service is.
 - name: Check status of services - Active  # noqa command-instead-of-module
   ansible.builtin.command:
-    cmd: "systemctl is-active {{ item }}"
+    cmd: "systemctl is-active {{ service_item }}"
   loop: "{{ __sap_general_preconfigure_services_2578899 }}"
+  loop_control:
+    loop_var: service_item
   register: __sap_general_preconfigure_register_services_active
   changed_when: false
   ignore_errors: true  # Disabled is RC 1
 
 - name: Check status of services - Enabled  # noqa command-instead-of-module
   ansible.builtin.command:
-    cmd: "systemctl is-enabled {{ item }}"
+    cmd: "systemctl is-enabled {{ service_item }}"
   loop: "{{ __sap_general_preconfigure_services_2578899 }}"
+  loop_control:
+    loop_var: service_item
   register: __sap_general_preconfigure_register_services_enabled
   changed_when: false
   ignore_errors: true  # Disabled is RC 1
@@ -22,11 +26,13 @@
 - name: Assert that services are running and enabled
   ansible.builtin.assert:
     that:
-      - __sap_general_preconfigure_register_services_active.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-      - __sap_general_preconfigure_register_services_enabled.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Service '{{ item }}' is not running or not enabled!"
-    success_msg: "PASS: Package '{{ item }}' is running and enabled."
+      - __sap_general_preconfigure_register_services_active.results | selectattr('service_item', 'equalto', service_item) | map(attribute='rc') | first == 0
+      - __sap_general_preconfigure_register_services_enabled.results | selectattr('service_item', 'equalto', service_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Service '{{ service_item }}' is not running or not enabled!"
+    success_msg: "PASS: Package '{{ service_item }}' is running and enabled."
   loop: "{{ __sap_general_preconfigure_services_2578899 }}"
+  loop_control:
+    loop_var: service_item
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 
 
@@ -43,10 +49,11 @@
 
     - name: Assert that SAP note 2578899 is verified by saptune
       ansible.builtin.assert:
-        that: "{{ __sap_general_preconfigure_saptune_verify_2578899.rc == 0 }}"
+        that: __sap_general_preconfigure_saptune_verify_2578899.rc == 0
         success_msg: "PASS: SAP note 2578899 is verified by saptune."
         fail_msg: |
-          "FAIL: SAP note 2578899 is not verified by saptune! See details below:"
+          FAIL: SAP Note 2578899 verification failed.
+          Please check the output below:
           {{ __sap_general_preconfigure_saptune_verify_2578899.stdout_lines }}
           {{ __sap_general_preconfigure_saptune_verify_2578899.stderr_lines }}
       ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
@@ -77,9 +84,11 @@
     - name: Assert that GRUB cmdline parameters are set
       ansible.builtin.assert:
         that:
-          - "'{{ item }}' in __sap_general_preconfigure_grub_contents.content | b64decode | string"
-        fail_msg: "FAIL: GRUB cmdline parameter {{ item }} is not set!"
-        success_msg: "PASS: GRUB cmdline parameter {{ item }} is set."
+          - "'{{ grub_line_item }}' in __sap_general_preconfigure_grub_contents.content | b64decode | string"
+        fail_msg: "FAIL: GRUB cmdline parameter {{ grub_line_item }} is not set!"
+        success_msg: "PASS: GRUB cmdline parameter {{ grub_line_item }} is set."
       loop: "{{ __sap_general_preconfigure_grub_cmdline_2578899 }}"
+      loop_control:
+        loop_var: grub_line_item
       when: __sap_general_preconfigure_grub_cmdline_2578899 | length > 0
       ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_general_preconfigure/tasks/sapnote/2578899/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2578899/assert-installation.yml
@@ -5,19 +5,23 @@
 - name: Query RPM packages
   ansible.builtin.shell:
     cmd: |
-      if rpm -q {{ item }} &> /dev/null;
-      then rpm -q {{ item }}
-      else rpm -q --whatprovides {{ item }};
+      if rpm -q {{ package_item }} &> /dev/null;
+      then rpm -q {{ package_item }}
+      else rpm -q --whatprovides {{ package_item }};
       fi
   register: __sap_general_preconfigure_register_packages
+  loop: "{{ __sap_general_preconfigure_packages_2578899 }}"
+  loop_control:
+    loop_var: package_item
   changed_when: false
   ignore_errors: true
-  loop: "{{ __sap_general_preconfigure_packages_2578899 }}"
 
 - name: Assert that all required packages are installed
   ansible.builtin.assert:
-    that: __sap_general_preconfigure_register_packages.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Package '{{ item }}' is not installed!"
-    success_msg: "PASS: Package '{{ item }}' is installed."
+    that: __sap_general_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Package '{{ package_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ package_item }}' is installed."
   loop: "{{ __sap_general_preconfigure_packages_2578899 }}"
+  loop_control:
+    loop_var: package_item
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_general_preconfigure/tasks/sapnote/2578899/configuration.yml
+++ b/roles/sap_general_preconfigure/tasks/sapnote/2578899/configuration.yml
@@ -3,10 +3,12 @@
 
 - name: Ensure that the services are enabled and started
   ansible.builtin.systemd:
-    name: "{{ item }}"
+    name: "{{ service_item }}"
     state: started
     enabled: true
   loop: "{{ __sap_general_preconfigure_services_2578899 }}"
+  loop_control:
+    loop_var: service_item
 
 
 - name: Execute task to update GRUB entries
@@ -23,7 +25,7 @@
     cmd: saptune note verify 2578899
   register: __sap_general_preconfigure_verify_2578899_before
   changed_when: false
-  ignore_errors: true
+  failed_when: false
   when: __sap_general_preconfigure_use_saptune | d(true)
 
 - name: Apply SAP note 2578899 using saptune
@@ -46,11 +48,13 @@
         cmd: saptune note verify --show-non-compliant 2578899
       register: __sap_general_preconfigure_verify_2578899_after
       changed_when: false
-      ignore_errors: true
+      failed_when: false
 
     - name: Display error if saptune verify failed
-      ansible.builtin.debug:
+      ansible.builtin.fail:
         msg: |
+          FAIL: SAP Note 2578899 verification failed after applying the note.
+          Please check the output below:
           {{ __sap_general_preconfigure_verify_2578899_after.stdout_lines }}
           {{ __sap_general_preconfigure_verify_2578899_after.stderr_lines }}
       when:

--- a/roles/sap_hana_preconfigure/tasks/SLES/assert-configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/assert-configuration.yml
@@ -37,10 +37,11 @@
 
     - name: Assert that saptune solution is verified by saptune
       ansible.builtin.assert:
-        that: "{{ __sap_hana_preconfigure_register_saptune_verify.rc == 0 }}"
+        that: __sap_hana_preconfigure_register_saptune_verify.rc == 0
         success_msg: "PASS: saptune solution {{ sap_hana_preconfigure_saptune_solution }} is verified by saptune."
         fail_msg: |
-          "FAIL: active saptune solution is not verified by saptune! See details below:"
+          FAIL: active saptune solution {{ sap_hana_preconfigure_saptune_solution }} verification failed.
+          Please check the output below:
           {{ __sap_hana_preconfigure_register_saptune_verify.stdout_lines }}
           {{ __sap_hana_preconfigure_register_saptune_verify.stderr_lines }}
       when:

--- a/roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml
@@ -4,16 +4,18 @@
 - name: Query installed zypper patterns
   ansible.builtin.command:
     cmd: zypper patterns --installed-only
-  register: __sap_hana_preconfigure_register_patterns
+  register: __sap_hana_preconfigure_register_installed_patterns
   changed_when: false
   ignore_errors: true
 
 - name: Assert that all required zypper patterns are installed
   ansible.builtin.assert:
-    that: "'{{ item }}' in __sap_hana_preconfigure_register_patterns.stdout"
-    fail_msg: "FAIL: Pattern '{{ item }}' is not installed!"
-    success_msg: "PASS: Pattern '{{ item }}' is installed."
+    that: pattern_item in __sap_hana_preconfigure_register_installed_patterns.stdout
+    fail_msg: "FAIL: Pattern '{{ pattern_item }}' is not installed!"
+    success_msg: "PASS: Pattern '{{ pattern_item }}' is installed."
   loop: "{{ sap_hana_preconfigure_patterns }}"
+  loop_control:
+    loop_var: pattern_item
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
 
 
@@ -21,22 +23,26 @@
 - name: Query RPM packages
   ansible.builtin.shell:
     cmd: |
-      if rpm -q {{ item }} &> /dev/null;
-      then rpm -q {{ item }}
-      else rpm -q --whatprovides {{ item }};
+      if rpm -q {{ package_item }} &> /dev/null;
+      then rpm -q {{ package_item }}
+      else rpm -q --whatprovides {{ package_item }};
       fi
   register: __sap_hana_preconfigure_register_packages
+  loop: "{{ sap_hana_preconfigure_packages }}"
+  loop_control:
+    loop_var: package_item
   changed_when: false
   ignore_errors: true
-  loop: "{{ sap_hana_preconfigure_packages }}"
 
 
 - name: Assert that all required packages are installed
   ansible.builtin.assert:
-    that: __sap_hana_preconfigure_register_packages.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Package '{{ item }}' is not installed!"
-    success_msg: "PASS: Package '{{ item }}' is installed."
+    that: __sap_hana_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Package '{{ package_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ package_item }}' is installed."
   loop: "{{ sap_hana_preconfigure_packages }}"
+  loop_control:
+    loop_var: package_item
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
 
 
@@ -77,7 +83,9 @@
 
 - name: Report if checking for possible package updates is not requested
   ansible.builtin.debug:
-    msg: "INFO: Not checking for possible package updates (variable sap_hana_preconfigure_update)."
+    msg: >
+      INFO: Check for latest packages was not executed
+      because the variable 'sap_hana_preconfigure_update' is set to false.
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
   when: not sap_hana_preconfigure_update
 

--- a/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/configuration.yml
@@ -82,6 +82,8 @@
     - name: Display error if saptune verify failed
       ansible.builtin.fail:
         msg: |
+          FAIL: saptune solution {{ sap_hana_preconfigure_saptune_solution }} verification failed after applying the solution.
+          Please check the output below:
           {{ __sap_hana_preconfigure_register_solution_verify_after.stdout_lines }}
           {{ __sap_hana_preconfigure_register_solution_verify_after.stderr_lines }}
       when: __sap_hana_preconfigure_register_solution_verify_after.rc != 0

--- a/roles/sap_hana_preconfigure/tasks/SLES/generic/grub_update.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/generic/grub_update.yml
@@ -6,11 +6,13 @@
 - name: Update existing GRUB entries
   ansible.builtin.lineinfile:
     path: /etc/default/grub
-    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=".*?)(\b{{ item.split("=")[0] }}=[^ ]*\b)(.*")'
-    line: '\1{{ item }}\3'
+    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=".*?)(\b{{ grub_line_item.split("=")[0] }}=[^ ]*\b)(.*")'
+    line: '\1{{ grub_line_item }}\3'
     backrefs: true
   register: __sap_hana_preconfigure_grub_update
   loop: "{{ __sap_hana_preconfigure_grub_cmdline }}"
+  loop_control:
+    loop_var: grub_line_item
 
 
 - name: Get current of GRUB
@@ -23,11 +25,13 @@
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*?)"'
-    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 {{ item }}"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 {{ grub_line_item }}"'
     backrefs: true
   register: __sap_hana_preconfigure_grub_add
   loop: "{{ __sap_hana_preconfigure_grub_cmdline }}"
-  when: item not in (__sap_hana_preconfigure_grub_contents.content | b64decode)
+  loop_control:
+    loop_var: grub_line_item
+  when: grub_line_item not in (__sap_hana_preconfigure_grub_contents.content | b64decode)
 
 
 - name: Trigger grub update if necessary # noqa no-changed-when

--- a/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -22,7 +22,7 @@
         cmd: rpm -q sapconf
       register: __sap_hana_preconfigure_register_sapconf
       changed_when: false
-      ignore_errors: true
+      failed_when: false  # avoid failure in logs if sapconf is not installed
 
     - name: Ensure sapconf is stopped and disabled
       ansible.builtin.systemd:
@@ -43,12 +43,15 @@
         cmd: systemctl is-failed sapconf.service
       register: __sap_hana_preconfigure_register_sapconf_failed
       changed_when: false
-      ignore_errors: true
+      failed_when: false  # avoid failure in logs
+      when: __sap_hana_preconfigure_register_sapconf.rc == 0
 
     - name: Execute systemctl reset-failed sapconf.service  # noqa command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl reset-failed sapconf.service
-      when: __sap_hana_preconfigure_register_sapconf_failed.rc == 0
+      when:
+        - __sap_hana_preconfigure_register_sapconf.rc == 0
+        - __sap_hana_preconfigure_register_sapconf_failed.rc == 0
       changed_when: true
 
 

--- a/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
@@ -29,24 +29,52 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+# This workflow is designed to remove dependency on zypper module.
 # Pattern installation will run only if pattern is not installed
 # This ensures that command module shows correct changed status
 - name: Query installed zypper patterns
   ansible.builtin.command:
     cmd: zypper patterns --installed-only
-  register: __sap_hana_preconfigure_register_patterns
+  register: __sap_hana_preconfigure_register_installed_patterns
   changed_when: false
   ignore_errors: true
 
+# Get only lines starting with "i " or "i+ " and split them into list of installed patterns.
+- name: Parse installed pattern names from stdout into list
+  ansible.builtin.set_fact:
+    __sap_hana_preconfigure_fact_installed_patterns: >
+      {{
+        __sap_hana_preconfigure_fact_installed_patterns | default([]) +
+        [ (pattern_item.split('|')[1]).strip() ]
+      }}
+  loop: "{{ __sap_hana_preconfigure_register_installed_patterns.stdout_lines | default([]) | select('match', '^\\s*i\\+?\\s') | list }}"
+  loop_control:
+    label: "{{ (pattern_item.split('|')[1]).strip() }}"
+    loop_var: pattern_item
+
+# If this '__sap_hana_preconfigure_fact_installed_patterns' is empty,
+# the check falls back to searching the raw stdout of the zypper command which is less accurate.
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
-    cmd: zypper install -y -t pattern {{ item }}
+    cmd: zypper install -y -t pattern {{ pattern_item }}
   loop: "{{ sap_hana_preconfigure_patterns }}"
+  loop_control:
+    loop_var: pattern_item
   # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10
-  when: item not in __sap_hana_preconfigure_register_patterns.stdout
-  changed_when: item not in __sap_hana_preconfigure_register_patterns.stdout
+  when: >
+    (__sap_hana_preconfigure_fact_installed_patterns | length > 0
+      and pattern_item not in __sap_hana_preconfigure_fact_installed_patterns)
+    or (__sap_hana_preconfigure_fact_installed_patterns | length == 0
+      and __sap_hana_preconfigure_register_installed_patterns.stdout is defined
+      and pattern_item not in __sap_hana_preconfigure_register_installed_patterns.stdout)
+  changed_when: >
+    (__sap_hana_preconfigure_fact_installed_patterns | length > 0
+      and pattern_item not in __sap_hana_preconfigure_fact_installed_patterns)
+    or (__sap_hana_preconfigure_fact_installed_patterns | length == 0
+      and __sap_hana_preconfigure_register_installed_patterns.stdout is defined
+      and pattern_item not in __sap_hana_preconfigure_register_installed_patterns.stdout)
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
@@ -83,7 +111,7 @@
 
 - name: Display the output of the reboot requirement check
   ansible.builtin.debug:
-    var: __sap_hana_preconfigure_register_needs_restarting
+    msg: "{{ __sap_hana_preconfigure_register_needs_restarting.stdout }}"
 
 - name: Call Reboot handler if necessary
   ansible.builtin.command:

--- a/roles/sap_hana_preconfigure/tasks/sapnote/1944799/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/1944799/assert-installation.yml
@@ -5,19 +5,23 @@
 - name: Query RPM packages
   ansible.builtin.shell:
     cmd: |
-      if rpm -q {{ item }} &> /dev/null;
-      then rpm -q {{ item }}
-      else rpm -q --whatprovides {{ item }};
+      if rpm -q {{ package_item }} &> /dev/null;
+      then rpm -q {{ package_item }}
+      else rpm -q --whatprovides {{ package_item }};
       fi
   register: __sap_hana_preconfigure_register_packages
+  loop: "{{ __sap_hana_preconfigure_packages_1944799 }}"
+  loop_control:
+    loop_var: package_item
   changed_when: false
   ignore_errors: true
-  loop: "{{ __sap_hana_preconfigure_packages_1944799 }}"
 
 - name: Assert that all required packages are installed
   ansible.builtin.assert:
-    that: __sap_hana_preconfigure_register_packages.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Package '{{ item }}' is not installed!"
-    success_msg: "PASS: Package '{{ item }}' is installed."
+    that: __sap_hana_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Package '{{ package_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ package_item }}' is installed."
   loop: "{{ __sap_hana_preconfigure_packages_1944799 }}"
+  loop_control:
+    loop_var: package_item
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_hana_preconfigure/tasks/sapnote/1944799/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/1944799/installation.yml
@@ -3,6 +3,5 @@
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
+    name: "{{ __sap_hana_preconfigure_packages_1944799 }}"
     state: present
-    name: "{{ item }}"
-  loop: "{{ __sap_hana_preconfigure_packages_1944799 }}"

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/assert-configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/assert-configuration.yml
@@ -14,10 +14,11 @@
 
     - name: Assert that SAP note 2684254 is verified by saptune
       ansible.builtin.assert:
-        that: "{{ __sap_hana_preconfigure_saptune_verify_2684254.rc == 0 }}"
+        that: __sap_hana_preconfigure_saptune_verify_2684254.rc == 0
         success_msg: "PASS: SAP note 2684254 is verified by saptune."
         fail_msg: |
-          "FAIL: SAP note 2684254 is not verified by saptune! See details below:"
+          FAIL: SAP Note 2684254 verification failed.
+          Please check the output below:
           {{ __sap_hana_preconfigure_saptune_verify_2684254.stdout_lines }}
           {{ __sap_hana_preconfigure_saptune_verify_2684254.stderr_lines }}
       ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
@@ -35,9 +36,11 @@
     - name: Assert that GRUB cmdline parameters are set
       ansible.builtin.assert:
         that:
-          - "'{{ item }}' in __sap_hana_preconfigure_grub_contents.content | b64decode | string"
-        fail_msg: "FAIL: GRUB cmdline parameter {{ item }} is not set!"
-        success_msg: "PASS: GRUB cmdline parameter {{ item }} is set."
+          - "'{{ grub_line_item }}' in __sap_hana_preconfigure_grub_contents.content | b64decode | string"
+        fail_msg: "FAIL: GRUB cmdline parameter {{ grub_line_item }} is not set!"
+        success_msg: "PASS: GRUB cmdline parameter {{ grub_line_item }} is set."
       loop: "{{ __sap_hana_preconfigure_grub_cmdline_2684254 }}"
+      loop_control:
+        loop_var: grub_line_item
       when: __sap_hana_preconfigure_grub_cmdline_2684254 | length > 0
       ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/assert-installation.yml
@@ -5,19 +5,23 @@
 - name: Query RPM packages
   ansible.builtin.shell:
     cmd: |
-      if rpm -q {{ item }} &> /dev/null;
-      then rpm -q {{ item }}
-      else rpm -q --whatprovides {{ item }};
+      if rpm -q {{ package_item }} &> /dev/null;
+      then rpm -q {{ package_item }}
+      else rpm -q --whatprovides {{ package_item }};
       fi
   register: __sap_hana_preconfigure_register_packages
+  loop: "{{ __sap_hana_preconfigure_packages_2684254 }}"
+  loop_control:
+    loop_var: package_item
   changed_when: false
   ignore_errors: true
-  loop: "{{ __sap_hana_preconfigure_packages_2684254 }}"
 
 - name: Assert that all required packages are installed
   ansible.builtin.assert:
-    that: __sap_hana_preconfigure_register_packages.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Package '{{ item }}' is not installed!"
-    success_msg: "PASS: Package '{{ item }}' is installed."
+    that: __sap_hana_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Package '{{ package_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ package_item }}' is installed."
   loop: "{{ __sap_hana_preconfigure_packages_2684254 }}"
+  loop_control:
+    loop_var: package_item
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/configuration.yml
@@ -15,7 +15,7 @@
     cmd: saptune note verify 2684254
   register: __sap_hana_preconfigure_verify_2684254_before
   changed_when: false
-  ignore_errors: true
+  failed_when: false
   when: __sap_hana_preconfigure_use_saptune | d(true)
 
 - name: Apply SAP note 2684254 using saptune
@@ -38,11 +38,13 @@
         cmd: saptune note verify --show-non-compliant 2684254
       register: __sap_hana_preconfigure_verify_2684254_after
       changed_when: false
-      ignore_errors: true
+      failed_when: false
 
     - name: Display error if saptune verify failed
-      ansible.builtin.debug:
+      ansible.builtin.fail:
         msg: |
+          FAIL: SAP Note 2684254 verification failed after applying the note.
+          Please check the output below:
           {{ __sap_hana_preconfigure_verify_2684254_after.stdout_lines }}
           {{ __sap_hana_preconfigure_verify_2684254_after.stderr_lines }}
       when:

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2684254/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2684254/installation.yml
@@ -3,6 +3,5 @@
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
+    name: "{{ __sap_hana_preconfigure_packages_2684254 }}"
     state: present
-    name: "{{ item }}"
-  loop: "{{ __sap_hana_preconfigure_packages_2684254 }}"

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/assert-configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/assert-configuration.yml
@@ -37,10 +37,11 @@
 
     - name: Assert that saptune solution is verified by saptune
       ansible.builtin.assert:
-        that: "{{ __sap_netweaver_preconfigure_register_saptune_verify.rc == 0 }}"
+        that: __sap_netweaver_preconfigure_register_saptune_verify.rc == 0
         success_msg: "PASS: saptune solution {{ sap_netweaver_preconfigure_saptune_solution }} is verified by saptune."
         fail_msg: |
-          "FAIL: active saptune solution is not verified by saptune! See details below:"
+          FAIL: active saptune solution {{ sap_netweaver_preconfigure_saptune_solution }} verification failed.
+          Please check the output below:
           {{ __sap_netweaver_preconfigure_register_saptune_verify.stdout_lines }}
           {{ __sap_netweaver_preconfigure_register_saptune_verify.stderr_lines }}
       when:

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml
@@ -4,38 +4,43 @@
 - name: Query installed zypper patterns
   ansible.builtin.command:
     cmd: zypper patterns --installed-only
-  register: __sap_netweaver_preconfigure_register_patterns
+  register: __sap_netweaver_preconfigure_register_installed_patterns
   changed_when: false
   ignore_errors: true
 
 - name: Assert that all required zypper patterns are installed
   ansible.builtin.assert:
-    that: "'{{ item }}' in __sap_netweaver_preconfigure_register_patterns.stdout"
-    fail_msg: "FAIL: Pattern '{{ item }}' is not installed!"
-    success_msg: "PASS: Pattern '{{ item }}' is installed."
+    that: pattern_item in __sap_netweaver_preconfigure_register_installed_patterns.stdout
+    fail_msg: "FAIL: Pattern '{{ pattern_item }}' is not installed!"
+    success_msg: "PASS: Pattern '{{ pattern_item }}' is installed."
   loop: "{{ sap_netweaver_preconfigure_patterns }}"
+  loop_control:
+    loop_var: pattern_item
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 
 # Check rpm --whatprovides only if package cannot be found directly.
 - name: Query RPM packages
   ansible.builtin.shell:
     cmd: |
-      if rpm -q {{ item }} &> /dev/null;
-      then rpm -q {{ item }}
-      else rpm -q --whatprovides {{ item }};
+      if rpm -q {{ package_item }} &> /dev/null;
+      then rpm -q {{ package_item }}
+      else rpm -q --whatprovides {{ package_item }};
       fi
   register: __sap_netweaver_preconfigure_register_packages
+  loop: "{{ sap_netweaver_preconfigure_packages }}"
+  loop_control:
+    loop_var: package_item
   changed_when: false
   ignore_errors: true
-  loop: "{{ sap_netweaver_preconfigure_packages }}"
-
 
 - name: Assert that all required packages are installed
   ansible.builtin.assert:
-    that: __sap_netweaver_preconfigure_register_packages.results | selectattr('item', 'equalto', item) | map(attribute='rc') | first == 0
-    fail_msg: "FAIL: Package '{{ item }}' is not installed!"
-    success_msg: "PASS: Package '{{ item }}' is installed."
+    that: __sap_netweaver_preconfigure_register_packages.results | selectattr('package_item', 'equalto', package_item) | map(attribute='rc') | first == 0
+    fail_msg: "FAIL: Package '{{ package_item }}' is not installed!"
+    success_msg: "PASS: Package '{{ package_item }}' is installed."
   loop: "{{ sap_netweaver_preconfigure_packages }}"
+  loop_control:
+    loop_var: package_item
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 
 
@@ -76,7 +81,9 @@
 
 - name: Report if checking for possible package updates is not requested
   ansible.builtin.debug:
-    msg: "INFO: Not checking for possible package updates (variable sap_netweaver_preconfigure_update)."
+    msg: >
+      INFO: Check for latest packages was not executed
+      because the variable 'sap_netweaver_preconfigure_update' is set to false.
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
   when: not sap_netweaver_preconfigure_update
 

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/configuration.yml
@@ -59,6 +59,8 @@
     - name: Display error if saptune verify failed
       ansible.builtin.fail:
         msg: |
+          FAIL: saptune solution {{ sap_netweaver_preconfigure_saptune_solution }} verification failed after applying the solution.
+          Please check the output below:
           {{ __sap_netweaver_preconfigure_register_solution_verify_after.stdout_lines }}
           {{ __sap_netweaver_preconfigure_register_solution_verify_after.stderr_lines }}
       when: __sap_netweaver_preconfigure_register_solution_verify_after.rc != 0
@@ -70,7 +72,7 @@
 
 - name: Warn if not enough swap space is configured
   ansible.builtin.fail:
-    msg: "The system has only {{ ansible_swaptotal_mb }} MB of swap space configured,
+    msg: "WARN: The system has only {{ ansible_swaptotal_mb }} MB of swap space configured,
       which is less than the minimum required amount of {{ sap_netweaver_preconfigure_min_swap_space_mb
        }} MB for SAP NetWeaver!"
   ignore_errors: true
@@ -80,7 +82,7 @@
 
 - name: Fail if not enough swap space is configured
   ansible.builtin.fail:
-    msg: "The system has only {{ ansible_swaptotal_mb }} MB of swap space configured,
+    msg: "FAIL: The system has only {{ ansible_swaptotal_mb }} MB of swap space configured,
       which is less than the minimum required amount of {{ sap_netweaver_preconfigure_min_swap_space_mb
        }} MB for SAP NetWeaver!"
   when:

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/generic/grub_update.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/generic/grub_update.yml
@@ -6,11 +6,13 @@
 - name: Update existing GRUB entries
   ansible.builtin.lineinfile:
     path: /etc/default/grub
-    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=".*?)(\b{{ item.split("=")[0] }}=[^ ]*\b)(.*")'
-    line: '\1{{ item }}\3'
+    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=".*?)(\b{{ grub_line_item.split("=")[0] }}=[^ ]*\b)(.*")'
+    line: '\1{{ grub_line_item }}\3'
     backrefs: true
   register: __sap_netweaver_preconfigure_grub_update
   loop: "{{ __sap_netweaver_preconfigure_grub_cmdline }}"
+  loop_control:
+    loop_var: grub_line_item
 
 
 - name: Get current of GRUB
@@ -23,11 +25,13 @@
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*?)"'
-    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 {{ item }}"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 {{ grub_line_item }}"'
     backrefs: true
   register: __sap_netweaver_preconfigure_grub_add
   loop: "{{ __sap_netweaver_preconfigure_grub_cmdline }}"
-  when: item not in (__sap_netweaver_preconfigure_grub_contents.content | b64decode)
+  loop_control:
+    loop_var: grub_line_item
+  when: grub_line_item not in (__sap_netweaver_preconfigure_grub_contents.content | b64decode)
 
 
 - name: Trigger grub update if necessary # noqa no-changed-when

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_takeover.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/generic/saptune_takeover.yml
@@ -22,7 +22,7 @@
         cmd: rpm -q sapconf
       register: __sap_netweaver_preconfigure_register_sapconf
       changed_when: false
-      ignore_errors: true
+      failed_when: false  # avoid failure in logs if sapconf is not installed
 
     - name: Ensure sapconf is stopped and disabled
       ansible.builtin.systemd:
@@ -43,12 +43,15 @@
         cmd: systemctl is-failed sapconf.service
       register: __sap_netweaver_preconfigure_register_sapconf_failed
       changed_when: false
-      ignore_errors: true
+      failed_when: false  # avoid failure in logs
+      when: __sap_netweaver_preconfigure_register_sapconf.rc == 0
 
     - name: Execute systemctl reset-failed sapconf.service  # noqa command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl reset-failed sapconf.service
-      when: __sap_netweaver_preconfigure_register_sapconf_failed.rc == 0
+      when:
+        - __sap_netweaver_preconfigure_register_sapconf.rc == 0
+        - __sap_netweaver_preconfigure_register_sapconf_failed.rc == 0
       changed_when: true
 
 

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
@@ -29,24 +29,52 @@
   when: "'packagekit.service' in ansible_facts.services"
 
 
+# This workflow is designed to remove dependency on zypper module.
 # Pattern installation will run only if pattern is not installed
 # This ensures that command module shows correct changed status
 - name: Query installed zypper patterns
   ansible.builtin.command:
     cmd: zypper patterns --installed-only
-  register: __sap_netweaver_preconfigure_register_patterns
+  register: __sap_netweaver_preconfigure_register_installed_patterns
   changed_when: false
   ignore_errors: true
 
+# Get only lines starting with "i " or "i+ " and split them into list of installed patterns.
+- name: Parse installed pattern names from stdout into list
+  ansible.builtin.set_fact:
+    __sap_netweaver_preconfigure_fact_installed_patterns: >
+      {{
+        __sap_netweaver_preconfigure_fact_installed_patterns | default([]) +
+        [ (pattern_item.split('|')[1]).strip() ]
+      }}
+  loop: "{{ __sap_netweaver_preconfigure_register_installed_patterns.stdout_lines | default([]) | select('match', '^\\s*i\\+?\\s') | list }}"
+  loop_control:
+    label: "{{ (pattern_item.split('|')[1]).strip() }}"
+    loop_var: pattern_item
+
+# If this '__sap_netweaver_preconfigure_fact_installed_patterns' is empty,
+# the check falls back to searching the raw stdout of the zypper command which is less accurate.
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
-    cmd: zypper install -y -t pattern {{ item }}
+    cmd: zypper install -y -t pattern {{ pattern_item }}
   loop: "{{ sap_netweaver_preconfigure_patterns }}"
+  loop_control:
+    loop_var: pattern_item
   # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10
-  when: item not in __sap_netweaver_preconfigure_register_patterns.stdout
-  changed_when: item not in __sap_netweaver_preconfigure_register_patterns.stdout
+  when: >
+    (__sap_netweaver_preconfigure_fact_installed_patterns | length > 0
+      and pattern_item not in __sap_netweaver_preconfigure_fact_installed_patterns)
+    or (__sap_netweaver_preconfigure_fact_installed_patterns | length == 0
+      and __sap_netweaver_preconfigure_register_installed_patterns.stdout is defined
+      and pattern_item not in __sap_netweaver_preconfigure_register_installed_patterns.stdout)
+  changed_when: >
+    (__sap_netweaver_preconfigure_fact_installed_patterns | length > 0
+      and pattern_item not in __sap_netweaver_preconfigure_fact_installed_patterns)
+    or (__sap_netweaver_preconfigure_fact_installed_patterns | length == 0
+      and __sap_netweaver_preconfigure_register_installed_patterns.stdout is defined
+      and pattern_item not in __sap_netweaver_preconfigure_register_installed_patterns.stdout)
 
 - name: Ensure that the required packages are installed
   ansible.builtin.package:
@@ -83,7 +111,7 @@
 
 - name: Display the output of the reboot requirement check
   ansible.builtin.debug:
-    var: __sap_netweaver_preconfigure_register_needs_restarting
+    msg: "{{ __sap_netweaver_preconfigure_register_needs_restarting.stdout }}"
 
 - name: Call Reboot handler if necessary
   ansible.builtin.command:


### PR DESCRIPTION
## Changes
- Add zypper pattern check using regex to ensure that we check for exact name and keep existing less accurate method as fallback.
- Replace `ignore_errors: true` with `failed_when: false` in tasks where non-zero return code is expected, hiding "failure" from log output to improve readability and to remove confusion with long 🟥 blocks of text.
- Add `loop_var` for all loops to remove deprecation warning.
- Update assert `that` sections to remove deprecation warning.
- Change debug tasks from `var` to `msg` to remove Ansible formatting and showing internal variable names.

## Tested
- SLES4SAP 15 SP7 on AWS
- SLES4SAP 16 on premise