### PR TITLE
sap_hana_preconfigure: Sync with SAP note 3108302

### DIFF
--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -161,10 +161,10 @@ __sap_hana_preconfigure_min_packages_9_3_x86_64:
 __sap_hana_preconfigure_min_packages_9_3_ppc64le:
 
 __sap_hana_preconfigure_min_packages_9_4_x86_64:
-  - [ 'kernel', '5.14.0-427.16.1.el9_4' ]
+  - [ 'kernel', '5.14.0-427.100.1.el9_4' ]
 
 __sap_hana_preconfigure_min_packages_9_4_ppc64le:
-  - [ 'kernel', '5.14.0-427.16.1.el9_4' ]
+  - [ 'kernel', '5.14.0-427.100.1.el9_4' ]
 
 __sap_hana_preconfigure_min_packages_9_5_x86_64:
 


### PR DESCRIPTION
Installs Linux kernel version of 5.14.0-427.100.1.el9_4 on RHEL 9.4 managed nodes.

Solves issue #1129.