### PR TITLE
sap_maintain_etc_hosts: Add TAB to etc hosts and fix wrong role name in README

### DIFF
--- a/roles/sap_maintain_etc_hosts/README.md
+++ b/roles/sap_maintain_etc_hosts/README.md
@@ -38,9 +38,9 @@ Example playbook will update `/etc/hosts`:
   hosts: all
   become: true
   tasks:
-    - name: Execute Ansible Role sap_sap_maintain_etc_hosts
+    - name: Execute Ansible Role sap_maintain_etc_hosts
       ansible.builtin.include_role:
-        name: community.sap_install.sap_sap_maintain_etc_hosts
+        name: community.sap_install.sap_maintain_etc_hosts
       vars:
         sap_maintain_etc_hosts_list:
         - node_ip: 10.10.10.10
@@ -62,9 +62,9 @@ Example playbook when executed together with [sap_ha_pacemaker_cluster](https://
   hosts: all
   become: true
   tasks:
-    - name: Execute Ansible Role sap_sap_maintain_etc_hosts
+    - name: Execute Ansible Role sap_maintain_etc_hosts
       ansible.builtin.include_role:
-        name: community.sap_install.sap_sap_maintain_etc_hosts
+        name: community.sap_install.sap_maintain_etc_hosts
       vars:
         sap_maintain_etc_hosts_list: "{{ sap_ha_pacemaker_cluster_cluster_nodes }}"
 ```

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -148,7 +148,7 @@
   ansible.builtin.lineinfile:
     path: "{{ __sap_maintain_etc_hosts_file }}"
     regexp: '^{{ thishost.node_ip }}\s'
-    line: "{{ thishost.node_ip }} {{ thishost.node_name }}.{{ __sap_maintain_etc_hosts_domain }} {{ thishost.node_name }} {{ __sap_maintain_etc_hosts_aliases }} {{ __sap_maintain_etc_hosts_comment }}"
+    line: "{{ thishost.node_ip }}\t{{ thishost.node_name }}.{{ __sap_maintain_etc_hosts_domain }} {{ thishost.node_name }} {{ __sap_maintain_etc_hosts_aliases }} {{ __sap_maintain_etc_hosts_comment }}"
     backup: true
   when:
     - not ansible_check_mode


### PR DESCRIPTION
## Changes
- Add TAB between IP and hostnames to conform with good practices
- Fix wrong role name in README file.

## Tests
Tested on SLES 16.

## Solves
https://github.com/sap-linuxlab/community.sap_install/issues/881