### PR TITLE
collection: Fix linting errors in 2.20 with facts and register var names

### DIFF
--- a/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
@@ -95,9 +95,9 @@
      ([ -f /var/run/zypp.pid ] && [ -s /var/run/zypp.pid ]); do
       sleep 10;
     done'
-  register: __packagekit_service_check
+  register: __sap_general_preconfigure_register_packagekit
   changed_when: false
-  until: __packagekit_service_check.rc == 0
+  until: __sap_general_preconfigure_register_packagekit.rc == 0
   retries: 60
   when: "'packagekit.service' in ansible_facts.services"
 

--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -22,9 +22,9 @@
      ([ -f /var/run/zypp.pid ] && [ -s /var/run/zypp.pid ]); do
       sleep 10;
     done'
-  register: __packagekit_service_check
+  register: __sap_general_preconfigure_register_packagekit
   changed_when: false
-  until: __packagekit_service_check.rc == 0
+  until: __sap_general_preconfigure_register_packagekit.rc == 0
   retries: 60
   when: "'packagekit.service' in ansible_facts.services"
 

--- a/roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml
@@ -58,9 +58,9 @@
      ([ -f /var/run/zypp.pid ] && [ -s /var/run/zypp.pid ]); do
       sleep 10;
     done'
-  register: __packagekit_service_check
+  register: __sap_hana_preconfigure_register_packagekit
   changed_when: false
-  until: __packagekit_service_check.rc == 0
+  until: __sap_hana_preconfigure_register_packagekit.rc == 0
   retries: 60
   when: "'packagekit.service' in ansible_facts.services"
 

--- a/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/SLES/installation.yml
@@ -22,9 +22,9 @@
      ([ -f /var/run/zypp.pid ] && [ -s /var/run/zypp.pid ]); do
       sleep 10;
     done'
-  register: __packagekit_service_check
+  register: __sap_hana_preconfigure_register_packagekit
   changed_when: false
-  until: __packagekit_service_check.rc == 0
+  until: __sap_hana_preconfigure_register_packagekit.rc == 0
   retries: 60
   when: "'packagekit.service' in ansible_facts.services"
 

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml
@@ -56,9 +56,9 @@
      ([ -f /var/run/zypp.pid ] && [ -s /var/run/zypp.pid ]); do
       sleep 10;
     done'
-  register: __packagekit_service_check
+  register: __sap_netweaver_preconfigure_register_packagekit
   changed_when: false
-  until: __packagekit_service_check.rc == 0
+  until: __sap_netweaver_preconfigure_register_packagekit.rc == 0
   retries: 60
   when: "'packagekit.service' in ansible_facts.services"
 

--- a/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml
@@ -22,9 +22,9 @@
      ([ -f /var/run/zypp.pid ] && [ -s /var/run/zypp.pid ]); do
       sleep 10;
     done'
-  register: __packagekit_service_check
+  register: __sap_netweaver_preconfigure_register_packagekit
   changed_when: false
-  until: __packagekit_service_check.rc == 0
+  until: __sap_netweaver_preconfigure_register_packagekit.rc == 0
   retries: 60
   when: "'packagekit.service' in ansible_facts.services"
 

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_local_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_local_filesystems.yml
@@ -8,7 +8,7 @@
     pesize: "{{ vg_item.pesize }}"
     vg_options: "{{ vg_item.vg_opts }}"
     pv_options: "{{ vg_item.pv_opts }}"
-  loop: "{{ volume_map }}"
+  loop: "{{ __sap_storage_setup_fact_volume_map }}"
   loop_control:
     loop_var: vg_item
     label: "{{ vg_item.volume_group }}"
@@ -21,7 +21,7 @@
     size: 100%VG
     state: present
     opts: "{{ lv_item.lv_opts }}"
-  loop: "{{ volume_map }}"
+  loop: "{{ __sap_storage_setup_fact_volume_map }}"
   loop_control:
     loop_var: lv_item
     label: "{{ lv_item.volume_name }}"
@@ -32,7 +32,7 @@
   community.general.filesystem:
     fstype: "{{ fs_item.filesystem_type }}"
     dev: "/dev/{{ fs_item.volume_group }}/{{ fs_item.volume_name }}"
-  loop: "{{ volume_map }}"
+  loop: "{{ __sap_storage_setup_fact_volume_map }}"
   loop_control:
     loop_var: fs_item
     label: "{{ fs_item.volume_name }}"
@@ -45,7 +45,7 @@
     src: "/dev/{{ mnt_item.volume_group }}/{{ mnt_item.volume_name }}"
     fstype: "{{ mnt_item.filesystem_type }}"
     state: mounted # performs fstab entry and mount
-  loop: "{{ volume_map }}"
+  loop: "{{ __sap_storage_setup_fact_volume_map }}"
   loop_control:
     loop_var: mnt_item
     label: "{{ mnt_item.volume_name }}"

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_multipathing.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_multipathing.yml
@@ -39,11 +39,11 @@
 # - no "links.uuids"
 # - no "partitions"
 # - "wwn" defined
-# - "size" matching any of the filesystems defined in {{ sap_storage_setup_new_mounts_fact }}
+# - "size" matching any of the filesystems defined in {{ __sap_storage_setup_fact_new_mounts }}
 
 - name: SAP Storage Setup - (Multipathing) Make a list of unused WWNs of the requested sizes
   ansible.builtin.set_fact:
-    available_devices_multipath: |
+    __sap_storage_setup_fact_available_devices_multipath: |
       {% set av_disks = [] %}
       {% set all_disks = (ansible_devices | dict2items) %}
       {% for disk in all_disks %}
@@ -52,7 +52,7 @@
             and disk.value.partitions | length == 0
             and disk.value.holders | length == 0
             %}
-          {%- for fs in sap_storage_setup_new_mounts_fact %}
+          {%- for fs in __sap_storage_setup_fact_new_mounts %}
             {%- if fs.disk_size is defined
                 and (fs.disk_size | string + 'GB') in (disk.value.size | regex_replace('(\.\d+\s*)', '')) %}
               {%- set add_to_list = av_disks.append(disk) %}
@@ -68,7 +68,7 @@
 # !!
 
 # This task assigns device names for each volume to be created.
-# - sap_storage_setup_new_mounts_fact derived from extravars: sap_storage_setup_definition
+# - __sap_storage_setup_fact_new_mounts derived from extravars: sap_storage_setup_definition
 #   and is dynamically generated during runtime to list only unconfigured filesystems
 # - ansible facts: ansible-devices
 
@@ -77,13 +77,14 @@
 
 - name: SAP Storage Setup - (Multipathing) Set fact for target filesystem device mapping
   ansible.builtin.set_fact:
-    filesystem_device_map: "{{ filesystem_device_map | default([]) + __multipath_to_fs_device_map }}"
+    __sap_storage_setup_fact_filesystem_device_map:
+      "{{ __sap_storage_setup_fact_filesystem_device_map | default([]) + __multipath_to_fs_device_map }}"
   vars:
     __multipath_to_fs_device_map: |
       {% set device_map = [] %}
-      {% set av_dev = (available_devices_multipath | dict2items) %}
+      {% set av_dev = (__sap_storage_setup_fact_available_devices_multipath | dict2items) %}
       {% set assigned_dev = [] %}
-      {% for fs in sap_storage_setup_new_mounts_fact -%}
+      {% for fs in __sap_storage_setup_fact_new_mounts -%}
         {% set matching_dev = [] -%}
 
         {%- if fs.disk_size is defined

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_nfs_filesystems.yml
@@ -16,17 +16,17 @@
 # Make sure paths and mountpoints are stripped from trailing '/'.
 # The '/' is added explicitly to the constructed paths.
 
-# Parameter: sap_storage_setup_related_directories
+# Parameter: __sap_storage_setup_fact_related_directories
 # Param Type: list of dictionaries
 #
 # Debug sample for a node of host type 'nwas_abap_ascs':
 #
-# sap_storage_setup_related_directories:
+# __sap_storage_setup_fact_related_directories:
 #		- dir_only: /DB1
 #			mount_src: /my_dir/sapmnt
 #			mountpoint: /sapmnt
 #
-# sap_storage_setup_related_directories:
+# __sap_storage_setup_fact_related_directories:
 #   - mount_src: /my_dir/usr/sap/DB1/SYS
 #     mountpoint: /usr/sap/DB1/SYS
 #   - mount_src: /my_dir/usr/sap/DB1/ASCS00
@@ -34,7 +34,7 @@
 
 - name: SAP Storage Setup - ({{ nfs_item.name }}) Set fact for directories
   ansible.builtin.set_fact:
-    sap_storage_setup_related_directories: |
+    __sap_storage_setup_fact_related_directories: |
       {% set mount_list = [] %}
 
       {%- if nfs_item.mountpoint | regex_replace('/$', '') == '/sapmnt' -%}
@@ -136,7 +136,7 @@
       ansible.builtin.stat:
         path: "{{ sap_storage_setup_tmpnfs_register.path }}{{ stat_item.mountpoint }}{{ stat_item.dir_only | default('') }}"
       register: sap_storage_setup_nfs_dir_register
-      loop: "{{ sap_storage_setup_related_directories }}"
+      loop: "{{ __sap_storage_setup_fact_related_directories }}"
       loop_control:
         loop_var: stat_item
         label: "{{ stat_item.mountpoint }}{{ stat_item.dir_only | default('') }}"
@@ -193,7 +193,7 @@
     fstype: "{{ nfs_item.nfs_filesystem_type | default(sap_storage_setup_nfs_filesystem_type) }}"
     opts: "{{ nfs_item.nfs_mount_options | default(sap_storage_setup_nfs_mount_options) }}"
     state: mounted
-  loop: "{{ sap_storage_setup_related_directories }}"
+  loop: "{{ __sap_storage_setup_fact_related_directories }}"
   loop_control:
     loop_var: mount_item
     label: "{{ mount_item.mountpoint }}"

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
@@ -26,14 +26,14 @@
     - name: SAP Storage Setup - (swap file) Check if file exists
       ansible.builtin.stat:
         path: "{{ swap_file.swap_path }}"
-      register: check_swapfile
+      register: __sap_storage_setup_register_check_swapfile
 
     - name: SAP Storage Setup - (swap file) Allocate space
       ansible.builtin.shell: |
         fallocate -l {{ swap_file.disk_size | int * 1024 }}MB {{ swap_file.swap_path }}
       changed_when: true
       when:
-        - not check_swapfile.stat.exists
+        - not __sap_storage_setup_register_check_swapfile.stat.exists
 
     - name: SAP Storage Setup - (swap file) Adjust file permissions
       ansible.builtin.file:
@@ -46,7 +46,7 @@
         swapon {{ swap_file.swap_path }}
       changed_when: true
       when:
-        - not check_swapfile.stat.exists
+        - not __sap_storage_setup_register_check_swapfile.stat.exists
 
     - name: SAP Storage Setup - (swap file) Add fstab entry
       ansible.posix.mount:
@@ -86,7 +86,7 @@
     - name: SAP Storage Setup - Check if swap partition exists
       ansible.builtin.shell: |
         set -o pipefail && lsblk | grep SWAP || echo "no active swap"
-      register: check_swap_partition
+      register: __sap_storage_setup_register_check_swap_partition
       changed_when: false
 
     - name: SAP Storage Setup - Add fstab entry for swap
@@ -103,6 +103,6 @@
       changed_when: true
       when:
         - not ansible_check_mode
-        - swap_volume.lvm_lv_name | default("lv_swap") not in check_swap_partition.stdout
+        - swap_volume.lvm_lv_name | default("lv_swap") not in __sap_storage_setup_register_check_swap_partition.stdout
 
 ### End of block: swap filesystem

--- a/roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml
@@ -2,18 +2,18 @@
 ---
 ##########
 # Creating a list of unused devices that match the requested filesystem sizes, using
-# - definition of unconfigured filesystems: sap_storage_setup_new_mounts_fact
+# - definition of unconfigured filesystems: __sap_storage_setup_fact_new_mounts
 # - ansible facts: ansible_devices
 #
 #########
 
 - name: SAP Storage Setup - Make a list of unused disk devices of the requested sizes
   ansible.builtin.set_fact:
-    available_devices: |
+    __sap_storage_setup_fact_available_devices: |
       {%- set av_disks = [] -%}
       {%- set all_disks = (ansible_devices | dict2items) -%}
       {%- for disk in all_disks -%}
-        {%- for fs in sap_storage_setup_new_mounts_fact -%}
+        {%- for fs in __sap_storage_setup_fact_new_mounts -%}
           {%- if disk.value.size | regex_search('.*TB$') -%}
             {%- set disk_size_gb = (((( disk.value.size | replace(' TB','') | float * 1024) /8) | round(0,'ceil') * 8) | int) -%}
           {%- else -%}
@@ -39,14 +39,14 @@
 
 ##########
 # This task assigns device names for each volume to be created.
-# - sap_storage_setup_new_mounts_fact derived from extravars: sap_storage_setup_definition
+# - __sap_storage_setup_fact_new_mounts derived from extravars: sap_storage_setup_definition
 #   and is dynamically generated during runtime to list only unconfigured filesystems
 # - ansible facts: ansible-devices
 #
 ##########
 
 
-# When multipathing is enabled, there will be a {{ filesystem_device_map }}
+# When multipathing is enabled, there will be a {{ __sap_storage_setup_fact_filesystem_device_map }}
 # defined already that is to be enhanced with single disk definitions, if
 # applicable.
 
@@ -54,19 +54,20 @@
 # Second pass assigns disks based on approximate size -8GB and +8GB
 - name: SAP Storage Setup - Set fact for target filesystem device mapping
   ansible.builtin.set_fact:
-    filesystem_device_map: "{{ filesystem_device_map | default([]) + __single_disk_to_fs_device_map }}"
+    __sap_storage_setup_fact_filesystem_device_map:
+      "{{ __sap_storage_setup_fact_filesystem_device_map | default([]) + __single_disk_to_fs_device_map }}"
   vars:
     __single_disk_to_fs_device_map: |
       {% set device_map = [] %}
-      {% set av_dev = (available_devices | dict2items) %}
+      {% set av_dev = (__sap_storage_setup_fact_available_devices | dict2items) %}
       {% set assigned_dev = [] %}
-      {% for fs in sap_storage_setup_new_mounts_fact -%}
+      {% for fs in __sap_storage_setup_fact_new_mounts -%}
         {% set matching_dev = [] -%}
 
         {%- if fs.disk_size is defined
           and 'nfs' not in fs.filesystem_type | default(sap_storage_setup_local_filesystem_type)
           and fs.swap_path is not defined
-          and fs.name not in filesystem_device_map | default([]) | map(attribute="name")
+          and fs.name not in __sap_storage_setup_fact_filesystem_device_map | default([]) | map(attribute="name")
           -%}
 
           {%- for dev in av_dev -%}
@@ -118,7 +119,7 @@
 
 # This task combines information to create a mapping list of devices to filesystems.
 # Sources:
-# - sap_storage_setup_new_mounts_fact derived from extravars: sap_storage_setup_definition
+# - __sap_storage_setup_fact_new_mounts derived from extravars: sap_storage_setup_definition
 #   and is dynamically generated during runtime to list only unconfigured filesystems
 # - Ansible host facts: hostvars[host_node].ansible_devices
 - name: SAP Storage Setup - Set fact for device to filesystem mapping
@@ -126,19 +127,18 @@
     - map_item.nfs_path is not defined
     - '"nfs" not in map_item.filesystem_type'
     - map_item.swap_path is not defined
-    - filesystem_device_map is defined
-    - filesystem_device_map | length > 0
+    - __sap_storage_setup_fact_filesystem_device_map is defined
+    - __sap_storage_setup_fact_filesystem_device_map | length > 0
   ansible.builtin.set_fact:
-    volume_map: "{{ volume_map + volume_element }}"
+    __sap_storage_setup_fact_volume_map: "{{ __sap_storage_setup_fact_volume_map | d([]) + volume_element }}"
   vars:
-    volume_map: []
     volume_element:
       - filesystem_type: "{{ map_item.filesystem_type | default(sap_storage_setup_local_filesystem_type) }}"
         mountpoint: "{{ map_item.mountpoint | default('') }}"
         volume_group: "{{ map_item.lvm_vg_name | default('vg_' + map_item.name) }}"
         volume_name: "{{ map_item.lvm_lv_name | default('lv_' + map_item.name) }}"
         device: |-
-          {% for entry in filesystem_device_map %}
+          {% for entry in __sap_storage_setup_fact_filesystem_device_map %}
           {%- if map_item.name == entry.name -%}
               {{ entry.device }}
           {%- endif %}
@@ -158,7 +158,7 @@
           {%- endif %}
           {{ lvopts | join(' ') }}
 
-  loop: "{{ sap_storage_setup_new_mounts_fact }}"
+  loop: "{{ __sap_storage_setup_fact_new_mounts }}"
   loop_control:
     label: "{{ map_item.name }}"
     loop_var: map_item
@@ -166,6 +166,6 @@
 
 - name: SAP Storage Setup - Display local disk setup assignment
   ansible.builtin.debug:
-    var: volume_map
+    var: __sap_storage_setup_fact_volume_map
   when:
-    - volume_map is defined
+    - __sap_storage_setup_fact_volume_map is defined

--- a/roles/sap_storage_setup/tasks/main.yml
+++ b/roles/sap_storage_setup/tasks/main.yml
@@ -44,7 +44,7 @@
     # Calculating with 1000 instead of 1024, because existing swaptotal is likely to be
     # reported at a slightly reduced size due to volume/filesystem metadata.
   ansible.builtin.set_fact:
-    sap_storage_setup_new_mounts_fact: "{{ sap_storage_setup_new_mounts_fact | default([]) + [new_mounts_item] }}"
+    __sap_storage_setup_fact_new_mounts: "{{ __sap_storage_setup_fact_new_mounts | default([]) + [new_mounts_item] }}"
   loop: "{{ sap_storage_setup_definition }}"
   loop_control:
     loop_var: new_mounts_item
@@ -67,13 +67,13 @@
 - name: SAP Storage Setup - Configure multipathing and map disks to target filesystems
   when:
     - sap_storage_setup_multipath_enable_and_detect
-    - sap_storage_setup_new_mounts_fact is defined
+    - __sap_storage_setup_fact_new_mounts is defined
   ansible.builtin.include_tasks:
     file: "{{ sap_storage_setup_cloud_type }}_tasks/configure_multipathing.yml"
 
 - name: SAP Storage Setup - Combine single disks and complete mapping definition
   when:
-    - sap_storage_setup_new_mounts_fact is defined
+    - __sap_storage_setup_fact_new_mounts is defined
   ansible.builtin.include_tasks:
     file: "{{ sap_storage_setup_cloud_type }}_tasks/map_single_disks_to_filesystems.yml"
 
@@ -83,8 +83,8 @@
 
 - name: SAP Storage Setup - Configure Volume Groups and Logical Volumes
   when:
-    - volume_map is defined
-    - volume_map | length > 0
+    - __sap_storage_setup_fact_volume_map is defined
+    - __sap_storage_setup_fact_volume_map | length > 0
   ansible.builtin.include_tasks:
     file: "{{ sap_storage_setup_cloud_type }}_tasks/configure_local_filesystems.yml"
 
@@ -96,8 +96,8 @@
   ansible.builtin.include_tasks:
     file: "{{ sap_storage_setup_cloud_type }}_tasks/configure_swap.yml"
   when:
-    - sap_storage_setup_new_mounts_fact is defined
-    - '"swap" in sap_storage_setup_new_mounts_fact
+    - __sap_storage_setup_fact_new_mounts is defined
+    - '"swap" in __sap_storage_setup_fact_new_mounts
       | map(attribute="filesystem_type", default=sap_storage_setup_local_filesystem_type)'
 
 - name: SAP Storage Setup - Configure NFS filesystems

--- a/roles/sap_swpm/tasks/post_install/firewall.yml
+++ b/roles/sap_swpm/tasks/post_install/firewall.yml
@@ -25,7 +25,7 @@
             - sap_swpm_wd_instance_nr is defined
             - sap_swpm_wd_instance_nr | length
           ansible.builtin.set_fact:
-            sap_nw_firewall_ports:
+            __sap_swpm_fact_sap_nw_firewall_ports:
               - "3200-3399"
               - "36{{ sap_swpm_pas_instance_nr }}"
               - "80{{ sap_swpm_pas_instance_nr }}"
@@ -39,7 +39,7 @@
 
         - name: SAP SWPM Post Install - Add Ports Based on NR - {{ sap_swpm_pas_instance_nr }}
           ansible.builtin.include_tasks: update_firewall.yml
-          loop: "{{ sap_nw_firewall_ports }}"
+          loop: "{{ __sap_swpm_fact_sap_nw_firewall_ports }}"
           loop_control:
             loop_var: passed_port
 

--- a/roles/sap_swpm/tasks/post_install/sum_push_to_finish.yml
+++ b/roles/sap_swpm/tasks/post_install/sum_push_to_finish.yml
@@ -7,11 +7,11 @@
 # Check if the SUMup process is running, give it 5 minutes to start
 - name: Check if SAPup_real process is running (wait for 5 minutes until it starts)
   ansible.builtin.command: pgrep -c -u "{{ sap_swpm_sid | lower }}adm" -f SAPup_real
-  register: _sapup_process
+  register: __sap_swpm_register_sapup_process
   retries: 5
   delay: 60
-  until: _sapup_process.rc == 0 and _sapup_process.stdout|int > 0
-  failed_when: _sapup_process.rc != 0
+  until: __sap_swpm_register_sapup_process.rc == 0 and __sap_swpm_register_sapup_process.stdout|int > 0
+  failed_when: __sap_swpm_register_sapup_process.rc != 0
   changed_when: false
 
 - name: Print SUM monitoring and action URLs

--- a/roles/sap_swpm/tasks/pre_install/firewall.yml
+++ b/roles/sap_swpm/tasks/pre_install/firewall.yml
@@ -29,7 +29,7 @@
 
         - name: SAP SWPM Pre Install - Generate SAP HANA Ports Based on NR - {{ sap_swpm_db_instance_nr }}
           ansible.builtin.set_fact:
-            sap_hana_firewall_ports:
+            __sap_swpm_fact_sap_hana_firewall_ports:
               - "1128"
               - "1129"
               - "43{{ sap_swpm_db_instance_nr }}"
@@ -58,7 +58,7 @@
 
         - name: SAP SWPM Pre Install - Add Ports Based on NR - {{ sap_swpm_db_instance_nr }}
           ansible.builtin.include_tasks: update_firewall.yml
-          loop: "{{ sap_hana_firewall_ports }}"
+          loop: "{{ __sap_swpm_fact_sap_hana_firewall_ports }}"
           loop_control:
             loop_var: passed_port
           when:

--- a/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
+++ b/roles/sap_swpm/tasks/pre_install/generate_inifile.yml
@@ -130,7 +130,7 @@
           loop: "{{ sap_swpm_inifile_parameters_dict | dict2items }}"
           loop_control:
             loop_var: sap_swpm_line_item
-          register: replace_result
+          register: __sap_swpm_register_replace_result
 
         - name: SAP SWPM Pre Install, create inifile - Detect variables again if 'sap_swpm_inifile_parameters_dict' had been used
           ansible.builtin.import_tasks:


### PR DESCRIPTION
## Changes
- Replace all facts and register variable names to conform with linting rules.
- Private variables are using naming we use across project:
  - `__<role>_register_<variable>`
  - `__<role>_fact_<variable>`

## Tests
Tested on SLE 15 SP7 using ansible-core 2.20 to install `sap_s4hana_sandbox` on AWS.

## Issues solved by these changes are
```bash
WARNING  Listing 17 violation(s) that are fatal
var-naming[no-role-prefix]: Variables names from within roles should use sap_general_preconfigure_ as a prefix. (register: __packagekit_service_check)
roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml:91:13 Task/Handler: Wait for stop of packagekit.service

var-naming[no-role-prefix]: Variables names from within roles should use sap_general_preconfigure_ as a prefix. (register: __packagekit_service_check)
roles/sap_general_preconfigure/tasks/SLES/installation.yml:18:13 Task/Handler: Wait for stop of packagekit.service

var-naming[no-role-prefix]: Variables names from within roles should use sap_hana_preconfigure_ as a prefix. (register: __packagekit_service_check)
roles/sap_hana_preconfigure/tasks/SLES/assert-installation.yml:54:13 Task/Handler: Wait for stop of packagekit.service

var-naming[no-role-prefix]: Variables names from within roles should use sap_hana_preconfigure_ as a prefix. (register: __packagekit_service_check)
roles/sap_hana_preconfigure/tasks/SLES/installation.yml:18:13 Task/Handler: Wait for stop of packagekit.service

var-naming[no-role-prefix]: Variables names from within roles should use sap_netweaver_preconfigure_ as a prefix. (register: __packagekit_service_check)
roles/sap_netweaver_preconfigure/tasks/SLES/assert-installation.yml:52:13 Task/Handler: Wait for stop of packagekit.service

var-naming[no-role-prefix]: Variables names from within roles should use sap_netweaver_preconfigure_ as a prefix. (register: __packagekit_service_check)
roles/sap_netweaver_preconfigure/tasks/SLES/installation.yml:18:13 Task/Handler: Wait for stop of packagekit.service

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (set_fact: available_devices_multipath)
roles/sap_storage_setup/tasks/generic_tasks/configure_multipathing.yml:44:5 Task/Handler: SAP Storage Setup - (Multipathing) Make a list of unused WWNs of the requested sizes

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (set_fact: filesystem_device_map)
roles/sap_storage_setup/tasks/generic_tasks/configure_multipathing.yml:78:5 Task/Handler: SAP Storage Setup - (Multipathing) Set fact for target filesystem device mapping

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (register: check_swapfile)
roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml:26:17 Task/Handler: SAP Storage Setup - (swap file) Check if file exists

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (register: check_swap_partition)
roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml:86:17 Task/Handler: SAP Storage Setup - Check if swap partition exists

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (set_fact: available_devices)
roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml:10:5 Task/Handler: SAP Storage Setup - Make a list of unused disk devices of the requested sizes

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (set_fact: filesystem_device_map)
roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml:55:5 Task/Handler: SAP Storage Setup - Set fact for target filesystem device mapping

var-naming[no-role-prefix]: Variables names from within roles should use sap_storage_setup_ as a prefix. (set_fact: volume_map)
roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml:124:5 Task/Handler: SAP Storage Setup - Set fact for device to filesystem mapping

var-naming[no-role-prefix]: Variables names from within roles should use sap_swpm_ as a prefix. (set_fact: sap_nw_firewall_ports)
roles/sap_swpm/tasks/post_install/firewall.yml:23:13 Task/Handler: SAP SWPM Post Install - Firewall Setup

var-naming[no-role-prefix]: Variables names from within roles should use sap_swpm_ as a prefix. (register: _sapup_process)
roles/sap_swpm/tasks/post_install/sum_push_to_finish.yml:8:13 Task/Handler: Check if SAPup_real process is running (wait for 5 minutes until it starts)

var-naming[no-role-prefix]: Variables names from within roles should use sap_swpm_ as a prefix. (set_fact: sap_hana_firewall_ports)
roles/sap_swpm/tasks/pre_install/firewall.yml:30:13 Task/Handler: SAP SWPM Pre Install - Generate SAP HANA Ports Based on NR - {{ sap_swpm_db_instance_nr }}

var-naming[no-role-prefix]: Variables names from within roles should use sap_swpm_ as a prefix. (register: replace_result)
roles/sap_swpm/tasks/pre_install/generate_inifile.yml:120:21 Task/Handler: SAP SWPM Pre Install, create inifile - Configure entries in 'inifile.params' from 'sap_swpm_inifile_parameters_dict'

Read documentation for instructions on how to ignore specific rule violations.

# Rule Violation Summary

 17 var-naming profile:basic tags:idiom

Failed: 17 failure(s), 0 warning(s) in 592 files processed of 634 encountered.
```