### PR TITLE
sap_storage_setup/SUSE: Add btrfs support for SLES 16

### DIFF
--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_swap.yml
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+
+# Starting with SLES 16, the default filesystem is 'btrfs' which requires special handling when creating a swap file.
+# Swapon on btrfs filesystems will fail with "swapon: /swapfile: swapon failed: Invalid argument"
+# This is solved by setting the NOCOW attribute on the swap file with 'chattr +C /swapfile'.
+# Fallocate command does not always create empty file, resulting in 'chattr +C' silently failing.
+# Therefore, we first create an empty file with 'touch'.
+
 - name: SAP Storage Setup - Block handling the swap file
   # Block parameters
   vars:
@@ -28,9 +35,63 @@
         path: "{{ swap_file.swap_path }}"
       register: __sap_storage_setup_register_check_swapfile
 
+    - name: SAP Storage Setup - (swap file) Get all active swap files and partitions
+      ansible.builtin.command:
+        cmd: "swapon --show=NAME --noheadings"
+      register: __sap_storage_setup_register_swapfile_active
+      changed_when: false
+
+
+    - name: SAP Storage Setup - (swap file) Create empty file for swap with touch
+      ansible.builtin.file:
+        path: "{{ swap_file.swap_path }}"
+        state: touch
+        mode: '0600'
+      when:
+        - not __sap_storage_setup_register_check_swapfile.stat.exists
+
+    - name: SAP Storage Setup - (swap file) Get the actual mount point and filesystem type
+      # This command returns just the fstype of the mount containing the path
+      ansible.builtin.shell:
+        cmd: "set -o pipefail && df --output=fstype {{ swap_file.swap_path | dirname }} | tail -1"
+      register: __sap_storage_setup_register_swapfile_fstype
+      changed_when: false
+
+
+    - name: Block for btrfs handling
+      when: __sap_storage_setup_register_swapfile_fstype.stdout | trim == 'btrfs'
+      block:
+        - name: SAP Storage Setup - (swap file) - btrfs - Check file attributes
+          ansible.builtin.command:
+            cmd: "lsattr {{ swap_file.swap_path }}"
+          register: __sap_storage_setup_register_swapfile_attributes
+          failed_when: false
+          changed_when: false
+
+        - name: SAP Storage Setup - (swap file) - btrfs - Fail when swap file exists without NOCOW attribute
+          ansible.builtin.fail:
+            msg: |
+              FAIL: The swap file {{ swap_file.swap_path }} exists on a btrfs filesystem but does not have the NOCOW attribute set.
+              This will lead to failure when activating the swap file.
+              Please remove the existing swap file and rerun this Ansible Role to re-create swap file with correct attributes.
+          when:
+            - __sap_storage_setup_register_check_swapfile.stat.exists
+            - __sap_storage_setup_register_swapfile_attributes.rc is defined
+            - __sap_storage_setup_register_swapfile_attributes.rc == 0
+            - "'C' not in __sap_storage_setup_register_swapfile_attributes.stdout"
+
+        - name: SAP Storage Setup - (swap file) - btrfs - Create 0-byte file and set NOCOW
+          ansible.builtin.file:
+            path: "{{ swap_file.swap_path }}"
+            attributes: '+C'
+          when:
+            - not __sap_storage_setup_register_check_swapfile.stat.exists
+            - "'C' not in __sap_storage_setup_register_swapfile_attributes.stdout"
+
+
     - name: SAP Storage Setup - (swap file) Allocate space
-      ansible.builtin.shell: |
-        fallocate -l {{ swap_file.disk_size | int * 1024 }}MB {{ swap_file.swap_path }}
+      ansible.builtin.command:
+        cmd: "fallocate -l {{ swap_file.disk_size | int * 1024 }}MB {{ swap_file.swap_path }}"
       changed_when: true
       when:
         - not __sap_storage_setup_register_check_swapfile.stat.exists
@@ -40,21 +101,49 @@
         path: "{{ swap_file.swap_path }}"
         mode: "0600"
 
-    - name: SAP Storage Setup - (swap file) Create and activate swap
-      ansible.builtin.shell: |
-        mkswap {{ swap_file.swap_path }}
-        swapon {{ swap_file.swap_path }}
+    # We will format swap file only when newly created to avoid touching existing.
+    - name: SAP Storage Setup - (swap file) Format the new swap file
+      ansible.builtin.command:
+        cmd: "mkswap {{ swap_file.swap_path }}"
       changed_when: true
       when:
         - not __sap_storage_setup_register_check_swapfile.stat.exists
 
-    - name: SAP Storage Setup - (swap file) Add fstab entry
+    # Fstab will be always updated even if already existing.
+    # 'path' must be 'none' or 'swap' for swap devices.
+    # 'opts' should contain 'sw' for swap devices.
+    - name: SAP Storage Setup - (swap file) Maintain entry in /etc/fstab
       ansible.posix.mount:
-        path: swap
+        path: none
         src: "{{ swap_file.swap_path }}"
         fstype: swap
-        opts: defaults
+        opts: sw
         state: present
+
+    # Activate swap file if it is not already active.
+    - name: SAP Storage Setup - (swap file) Activate swap file
+      ansible.builtin.command:
+        cmd: "swapon {{ swap_file.swap_path }}"
+      register: __sap_storage_setup_register_swapfile_activate
+      changed_when: true
+      failed_when: false
+      when:
+        - swap_file.swap_path not in __sap_storage_setup_register_swapfile_active.stdout_lines
+
+    - name: SAP Storage Setup - (swap file) Fail if swap file could not be activated
+      ansible.builtin.fail:
+        msg: |
+          FAIL: The swap file {{ swap_file.swap_path }} could not be activated.
+          {% if __sap_storage_setup_register_check_swapfile.stat.exists %}
+          The existing swap file might be corrupted or was not created with correct attributes.
+          {% else %}
+          The newly created swap file could not be activated. Please check the system logs for details.
+          {% endif %}
+
+          Command output: {{ __sap_storage_setup_register_swapfile_activate.stdout }}
+      when:
+        - __sap_storage_setup_register_swapfile_activate.rc is defined
+        - __sap_storage_setup_register_swapfile_activate.rc != 0
 
 
 ### End of swapfile block
@@ -73,6 +162,10 @@
       | first
       -}}
 
+    # Define the full path to the swap partition for easier reference in subsequent tasks.
+    swap_partition_path:
+      "/dev/{{ swap_volume.lvm_vg_name | default('vg_swap') }}/{{ swap_volume.lvm_lv_name | default('lv_swap') }}"
+
   # Block conditional
   when: |
     sap_storage_setup_definition
@@ -83,23 +176,38 @@
 
   block:
 
-    - name: SAP Storage Setup - Check if swap partition exists
+    # TODO: This can be replaced with "swapon --show=NAME --noheadings" if applicable.
+    - name: SAP Storage Setup - (swap partition) Get all existing swap partitions
       ansible.builtin.shell: |
         set -o pipefail && lsblk | grep SWAP || echo "no active swap"
       register: __sap_storage_setup_register_check_swap_partition
       changed_when: false
 
-    - name: SAP Storage Setup - Add fstab entry for swap
+    - name: SAP Storage Setup - (swap partition) Check if LV device exists
+      ansible.builtin.stat:
+        path: "{{ swap_partition_path }}"
+      register: __sap_storage_setup_register_check_swap_partition_stat
+
+    - name: SAP Storage Setup - (swap partition) Fail if LV device does not exist
+      ansible.builtin.fail:
+        msg: |
+          FAIL: The logical volume device '{{ swap_partition_path }}' for the swap partition was not found.
+          This indicates that the LVM creation tasks may have failed. Please check the logs for earlier errors.
+      when:
+        - not __sap_storage_setup_register_check_swap_partition_stat.stat.exists
+        - not ansible_check_mode
+
+    - name: SAP Storage Setup - (swap partition) Maintain entry in /etc/fstab
       ansible.posix.mount:
         path: swap
-        src: "/dev/{{ swap_volume.lvm_vg_name | default('vg_swap') }}/{{ swap_volume.lvm_lv_name | default('lv_swap') }}"
+        src: "{{ swap_partition_path }}"
         fstype: swap
         opts: defaults
         state: present
 
-    - name: SAP Storage Setup - Enable swap
-      ansible.builtin.shell: |
-        swapon /dev/{{ swap_volume.lvm_vg_name | default('vg_swap') }}/{{ swap_volume.lvm_lv_name | default('lv_swap') }}
+    - name: SAP Storage Setup - (swap partition) Enable swap
+      ansible.builtin.command: |
+        swapon {{ swap_partition_path }}
       changed_when: true
       when:
         - not ansible_check_mode


### PR DESCRIPTION
## Changes

SLES 16 default ROOT is now btrfs instead of xfs, which results in failing `swapon` command without C flag.

- Add new `btrfs` specific workflow, without impacting existing `xfs`.
- Add new validations for active snapon to achieve idempotency
- Add extra fail tasks to ensure that we do not change existing files
  - If existing swap file is found, update fstab and attempt to mount it.
  - If no existing swap file is found, create it and proceed as normal.

## Tests
SLES4SAP 16.0 in AWS and on premise
SLES4SAP 15 SP7 in AWS