### PR TITLE
sap_swpm:  Improve SUM handling behaviour for slower systems

### DIFF
--- a/roles/sap_swpm/tasks/post_install/sum_push_to_finish.yml
+++ b/roles/sap_swpm/tasks/post_install/sum_push_to_finish.yml
@@ -108,7 +108,7 @@
   register: _sap_swpm_sum_push
   until: _sap_swpm_sum_push.status == 200 and ('<dialogId>SUM4ABAP|POST-EXECUTE|MAIN_POSTPROC|SPAUINFO|FinishSPAU</dialogId>' in _sap_swpm_sum_push.content or '<dialogId>SUM4ABAP|MAIN_POSTCLEAN|EXIT|UnitWizard</dialogId>' in _sap_swpm_sum_push.content)
   retries: 240 # 20 hours
-  delay: 300   # 5 minutes
+  delay: 300  # 5 minutes
   failed_when: _sap_swpm_sum_push.status != 200 or ('<dialogId>SUM4ABAP|POST-EXECUTE|MAIN_POSTPROC|SPAUINFO|FinishSPAU</dialogId>' not in _sap_swpm_sum_push.content and '<dialogId>SUM4ABAP|MAIN_POSTCLEAN|EXIT|UnitWizard</dialogId>' not in _sap_swpm_sum_push.content)
 
 # If SUM is already in MAIN_POSTCLEAN|EXIT phase it has skipped SPAUINFO and has finished


### PR DESCRIPTION
Updated task names  to make it clearer that it will look for SPAU or EXIT step.
Changed the time we are waiting for SPAU or EXIT phases to happen to 240*5 minutes = 20 hours

Improve SUM task names for better readability as discussed in https://github.com/sap-linuxlab/community.sap_install/issues/1139