### PR TITLE
sap_hana_install: Revert wrong conditional from PR#1138

### DIFF
--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -70,7 +70,6 @@
     - name: SAP HANA - Install - Post-tasks
       ansible.builtin.include_tasks:
         file: post_install.yml
-      when: __sap_hana_install_fact_is_installed
 
 
 - name: Block for Addhosts tasks


### PR DESCRIPTION
## Changes 
https://github.com/sap-linuxlab/community.sap_install/pull/1138 was reworking tags, but it also touched conditional by mistake.
Post tasks should always execute, not only on existing installations.

**NOTE: This is breaking bug which will require 1.8.1 Release with other new bugs identified**

## Ref
https://github.com/sap-linuxlab/community.sap_install/blame/dev/roles/sap_hana_install/tasks/main.yml#L73