### PR TITLE
collection: Update readme formatting to align with galaxy format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Included roles cover range of tasks:
 
 | Component | Control Node | Managed Node |
 | --- | --- | --- |
-| Operating System | Any OS | SUSE Linux Enterprise Server for SAP applications 15 SP5+ (SLE4SAP 15)<br>SUSE Linux Enterprise Server for SAP applications 16 (SLE4SAP 16)<br>Red Hat Enterprise Linux for SAP Solutions 8.x 9.x (RHEL4SAP) |
+| Operating System | Any OS | SUSE Linux Enterprise Server for SAP applications 15 SP5, 15 SP6, 15 SP7 and 16.0<br>Red Hat Enterprise Linux for SAP Solutions 8.x 9.x 10.x |
 | Python | 3.11 or higher | 3.9 or higher |
 | Ansible-Core | 2.18 or higher | N/A |
 | Ansible | 12 or higher | N/A |
@@ -99,9 +99,8 @@ This Ansible Collection was tested across different Operating Systems, SAP produ
 
 Operating systems:
 
-- SUSE Linux Enterprise Server for SAP applications 15 SP5+ (SLE4SAP)
-- SUSE Linux Enterprise Server for SAP applications 16 (SLE4SAP)
-- Red Hat Enterprise Linux for SAP Solutions 8.x 9.x (RHEL4SAP)
+- SUSE Linux Enterprise Server for SAP applications 15 SP5, 15 SP6, 15 SP7 and 16.0
+- Red Hat Enterprise Linux for SAP Solutions 8.x 9.x 10.x
 
 Deployment scenarios:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This Ansible Collection executes various SAP Software installations and configuration tasks for various SAP solutions and deployment scenarios on supported Linux operating systems.
 
 Included roles cover range of tasks:
+
 - Preparation of Operating system and SAP installation media before installation
 - Installation of SAP Database, either SAP HANA or Oracle Database
 - Installation of SAP Products, like SAP S4HANA, SAP BW4HANA, SAP Netweaver, SAP Solution Manager and others.
@@ -15,28 +16,20 @@ Included roles cover range of tasks:
 
 ## Requirements
 
-### Control Nodes
-Operating system:
-- Any operating system with required Python and Ansible versions.
+| Component | Control Node | Managed Node |
+| --- | --- | --- |
+| Operating System | Any OS | SUSE Linux Enterprise Server for SAP applications 15 SP5+ (SLE4SAP 15)<br>SUSE Linux Enterprise Server for SAP applications 16 (SLE4SAP 16)<br>Red Hat Enterprise Linux for SAP Solutions 8.x 9.x (RHEL4SAP) |
+| Python | 3.11 or higher | 3.9 or higher |
+| Ansible-Core | 2.18 or higher | N/A |
+| Ansible | 12 or higher | N/A |
 
-Python: 3.11 or higher
+> **Managed Node Registration**<br>
+> Operating system needs to have access to required package repositories either directly or via subscription registration.
 
-Ansible: 9.9.x
+**Additional notes:**
 
-Ansible-core: 2.16.x
-
-**NOTE: Ansible 10 and ansible-core 2.17.x are not supported, because of breaking changes requiring higher Python version on managed nodes.**
-
-### Managed Nodes
-Operating system:
-- SUSE Linux Enterprise Server for SAP applications 15 SP5+ (SLE4SAP)
-- Red Hat Enterprise Linux for SAP Solutions 8.x 9.x (RHEL4SAP)
-
-**NOTE: Operating system needs to have access to required package repositories either directly or via subscription registration.**
-
-
-Python: 3.6 or higher
-
+- **Version Compatibility:** For a detailed mapping of supported Python versions and Ansible-Core lifecycles, refer to the official [Ansible-Core Support Matrix](https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix).
+- **Control Node Permissions:** Ensure the user executing the playbooks has the necessary SSH keys and sudo privileges configured for the target environment.
 
 ## Installation Instructions
 
@@ -73,6 +66,7 @@ See [Installing collections](https://docs.ansible.com/ansible/latest/collections
 ## Use Cases
 
 ### Example Scenarios
+
 - Preparation of Operating system for SAP installation
 - Preparation of SAP installation media for SAP installation
 - Installation of SAP HANA (including High Availability with replication) or Oracle Database
@@ -85,7 +79,7 @@ More deployment scenarios are available in [ansible.playbooks_for_sap](https://g
 All included roles can be executed independently or as part of [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) playbooks.
 
 | Name | Summary |
-| :--- | :--- |
+| --- | --- |
 | [sap_anydb_install_oracle](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_anydb_install_oracle) | Install Oracle DB 19.x for SAP |
 | [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure) | Configure general OS settings for SAP software |
 | [sap_ha_install_hana_hsr](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_ha_install_hana_hsr) | Configure and enable SAP HANA System Replication |
@@ -104,20 +98,26 @@ All included roles can be executed independently or as part of [ansible.playbook
 This Ansible Collection was tested across different Operating Systems, SAP products and scenarios. You can find examples of some of them below.
 
 Operating systems:
+
 - SUSE Linux Enterprise Server for SAP applications 15 SP5+ (SLE4SAP)
+- SUSE Linux Enterprise Server for SAP applications 16 (SLE4SAP)
 - Red Hat Enterprise Linux for SAP Solutions 8.x 9.x (RHEL4SAP)
 
 Deployment scenarios:
+
 - All scenarios included in [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) repository
 
 SAP Products:
+
 - SAP S/4HANA AnyPremise (1809, 1909, 2020, 2021, 2022, 2023) with setup as Standard, Distributed, High Availability and optional Maintenance Planner or Restore System Copy
 - SAP Business Suite (ECC) on HANA and SAP Business Suite (ECC) with SAP AnyDB - SAP ASE, SAP MaxDB, IBM Db2, Oracle DB
 - SAP BW/4HANA (2021, 2023) with setup as Standard or Scale-Out
 - SAP HANA 2.0 (SPS04+) with setup as Scale-Up, Scale-Out, High Availability
 - Other SAP installation activities; such as System Rename, System Copy Export, SAP Solution Manager and SAP Web Dispatcher
 
-**NOTE: It is not possible to test every Operating System and SAP Product combination with every release. Testing is regularly done for common scenarios: SAP HANA, SAP HANA HA, SAP S4HANA Distributed HA**
+> **Testing Disclaimer**<br>
+> It is not possible to test every Operating System and SAP Product combination with every release.<br>
+> Testing is regularly done for common scenarios: SAP HANA, SAP HANA HA, SAP S4HANA Distributed HA**
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Included roles cover range of tasks:
 
 | Component | Control Node | Managed Node |
 | --- | --- | --- |
-| Operating System | Any OS | SUSE Linux Enterprise Server for SAP applications 15 SP5, 15 SP6, 15 SP7 and 16.0<br>Red Hat Enterprise Linux for SAP Solutions 8.x 9.x 10.x |
+| Operating System | Any OS | Red Hat Enterprise Linux for SAP Solutions 8.x, 9.x and 10.x<br>SUSE Linux Enterprise Server for SAP applications 15 SP5, 15 SP6, 15 SP7 and 16.0 |
 | Python | 3.11 or higher | 3.9 or higher |
 | Ansible-Core | 2.18 or higher | N/A |
 | Ansible | 12 or higher | N/A |
@@ -99,8 +99,8 @@ This Ansible Collection was tested across different Operating Systems, SAP produ
 
 Operating systems:
 
+- Red Hat Enterprise Linux for SAP Solutions 8.x, 9.x and 10.x
 - SUSE Linux Enterprise Server for SAP applications 15 SP5, 15 SP6, 15 SP7 and 16.0
-- Red Hat Enterprise Linux for SAP Solutions 8.x 9.x 10.x
 
 Deployment scenarios:
 

--- a/docs/getting_started/secure-your-passwords.md
+++ b/docs/getting_started/secure-your-passwords.md
@@ -29,7 +29,7 @@ Use ansible-vault to encrypt the string, which it reads from the file. Adding th
 ansible-vault encrypt_string $(cat passfile) -n my_secret_var
 ```
 
-Ansible-vault will ask to enter a vault password, which is required to decrypt the value during ansible runtime afterwards.  
+Ansible-vault will ask to enter a vault password, which is required to decrypt the value during ansible runtime afterwards.<br>
 Consider this the "master key" for your vault-encrypted credentials.
 
 ```text
@@ -45,7 +45,7 @@ my_secret_var: !vault |
 Encryption successful
 ```
 
-Save the `my_secret_var` and encrypted multi-line value in your variable definitions and include the definition file as usual.  
+Save the `my_secret_var` and encrypted multi-line value in your variable definitions and include the definition file as usual.<br>
 The variable can as well be referenced and used by other variables for more flexibility.
 
 ```yaml
@@ -62,7 +62,7 @@ rm passfile
 
 ## Run playbook which uses vault-encrypted content
 
-As soon as a vault-encrypted value is present in your playbook, ansible will require the vault password to be entered for playbook execution.  
+As soon as a vault-encrypted value is present in your playbook, ansible will require the vault password to be entered for playbook execution.<br>
 Add `--ask-vault` to your `ansible-playbook` command to prompt for this "master key" password and allow secure decryption.
 
 ```bash
@@ -75,7 +75,7 @@ _When encrypting multiple values that will be used together, you have to make su
 
 You can also encrypt an entire file, e.g. containing multiple secrets.
 
-However, if variables are defined in the file it will encrypt the variable names as well and makes it harder to identify the source definition of a referenced variable.  
+However, if variables are defined in the file it will encrypt the variable names as well and makes it harder to identify the source definition of a referenced variable.<br>
 Also, encrypting the entire file will require ansible-vault commands to view or edit the contents of the file. A file containing individually encrypted values can be viewed and edited as any other file without uncovering the actual secret value.
 
 `ansible-vault` will prompt for the vault password - either to be created for a new encrypted file, or to be used for decrypting existing content (for view or edit operations).
@@ -87,7 +87,7 @@ ansible-vault view file_containing_secrets.yml
 ansible-vault edit file_containing_secrets.yml
 ```
 
-This file can be included into a playbook similar to any other file include.  
+This file can be included into a playbook similar to any other file include.<br>
 The playbook will only be usable when the correct vault password is provided to `ansible-playbook` for the runtime, see above.
 
 ## More features and information

--- a/roles/sap_anydb_install_oracle/README.md
+++ b/roles/sap_anydb_install_oracle/README.md
@@ -13,6 +13,7 @@ The Ansible role `sap_anydb_install_oracle` is used to install Oracle Database 1
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed Nodes:
+
 - Directory with installation media is present and `sap_anydb_install_oracle_extract_path` updated.</br>
   Download can be completed using [community.sap_launchpad](https://github.com/sap-linuxlab/community.sap_launchpad) Ansible Collection.
 <!-- END Prerequisites -->

--- a/roles/sap_general_preconfigure/README.md
+++ b/roles/sap_general_preconfigure/README.md
@@ -26,6 +26,7 @@ Install required collections by `ansible-galaxy collection install -vv -r meta/c
 ## Prerequisites
 
 (Red Hat specific) Ensure system is installed according to:
+
 - RHEL 8: SAP note 2772999, Red Hat Enterprise Linux 8.x: Installation and Configuration, section `Installing Red Hat Enterprise Linux 8`.
 - RHEL 9: SAP note 3108316, Red Hat Enterprise Linux 9.x: Installation and Configuration, section `Installing Red Hat Enterprise Linux 9`.
 
@@ -64,7 +65,9 @@ Further referenced as `example.yml`
 
 <!-- BEGIN Role Tags -->
 ### Role Tags
+
 With the following tags, the role can be called to perform certain activities only:
+
 - tag `sap_general_preconfigure_installation`: Perform only the installation tasks
 - tag `sap_general_preconfigure_configuration`: Perform only the configuration tasks
 - tag `sap_general_preconfigure_3108316`: Perform only the tasks(s) related to this SAP note.
@@ -72,44 +75,42 @@ With the following tags, the role can be called to perform certain activities on
 - tag `sap_general_preconfigure_etc_hosts`: Perform only the tasks(s) related to this step. This step might be one of multiple
   configuration activities of a SAP note. Also this step might be valid for multiple RHEL major releases.
 
-<details>
-  <summary><b>How to run sap_general_preconfigure with tags</b></summary>
+#### How to run sap_general_preconfigure with tags
 
-  #### Perform only installation tasks:
-  ```console
-  ansible-playbook sap.yml --tags=sap_general_preconfigure_installation
-  ```
+Perform only installation tasks:
+```console
+ansible-playbook sap.yml --tags=sap_general_preconfigure_installation
+```
 
-  #### Perform only configuration tasks:
-  ```console
-  ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration
-  ```
+Perform only configuration tasks:
+```console
+ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration
+```
 
-  #### Verify and modify /etc/hosts file:
-  ```console
-  ansible-playbook sap.yml --tags=sap_general_preconfigure_etc_hosts
-  ```
+Verify and modify /etc/hosts file:
+```console
+ansible-playbook sap.yml --tags=sap_general_preconfigure_etc_hosts
+```
 
-  #### Perform all configuration steps except verifying and modifying the /etc/hosts file
-  ```
-  ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_etc_hosts
-  ```
+Perform all configuration steps except verifying and modifying the /etc/hosts file
+```
+ansible-playbook sap.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_etc_hosts
+```
 
-  #### (Red Hat) Perform configuration activities related to SAP note 3108316 (RHEL 9)
-  ```
-  ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316
-  ```
+(Red Hat) Perform configuration activities related to SAP note 3108316 (RHEL 9)
+```
+ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316
+```
 
-  #### (Red Hat) Perform configuration activities related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9)
-  ```
-  ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316_02
-  ```
+(Red Hat) Perform configuration activities related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9)
+```
+ansible-playbook sap.yml --tags=sap_general_preconfigure_3108316_02
+```
 
-  #### (Red Hat) Perform all configuration activities except those related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific)
-  ```
-  ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_3108316_02
-  ```
-</details>
+(Red Hat) Perform all configuration activities except those related to step 2 (SELinux settings) of SAP note 3108316 (RHEL 9 specific)
+```
+ansible-playbook sap-general-preconfigure.yml --tags=sap_general_preconfigure_configuration --skip_tags=sap_general_preconfigure_3108316_02
+```
 <!-- END Role Tags -->
 
 <!-- BEGIN Further Information -->

--- a/roles/sap_ha_install_anydb_ibmdb2/README.md
+++ b/roles/sap_ha_install_anydb_ibmdb2/README.md
@@ -8,6 +8,7 @@
 The Ansible Role for instantiation of IBM Db2 'Integrated Linux Pacemaker' HADR cluster.
 
 **NOTE:** IBM Db2 with 'Integrated Linux Pacemaker' can use two deployment models:
+
 - Mutual Failover option, **not** covered by this Ansible Role
 - High Availability and Disaster Recovery (HADR) option for Idle Standby, initialized by this Ansible Role
 <!-- END Description -->
@@ -17,10 +18,13 @@ The Ansible Role for instantiation of IBM Db2 'Integrated Linux Pacemaker' HADR 
 
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
+
 Managed nodes:
+
 - Directory with installation media is present and `sap_ha_install_anydb_ibmdb2_software_directory` updated. Download can be completed using [community.sap_launchpad](https://github.com/sap-linuxlab/community.sap_launchpad) Ansible Collection.
 
 Software compatibility:
+
 - This Ansible Role is applicable to IBM Db2 11.5 certified for SAP.
 - It is applicable to 11.5.9 and later, which provides `db2cm` binary compatibility for AWS, GCP and MS Azure.
 <!-- END Prerequisites -->

--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -14,6 +14,7 @@ The Ansible Role `sap_ha_install_hana_hsr` is used to configure and enable SAP H
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed nodes:
+
 - Same Operating system version
 - SAP HANA is installed with same version on both nodes.
 <!-- END Prerequisites -->
@@ -25,6 +26,7 @@ Managed nodes:
 <!-- BEGIN Execution Recommended -->
 ### Recommended
 It is recommended to execute this role together with other roles in this collection, in the following order:
+
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. [sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_preconfigure)
 3. [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect)

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -20,6 +20,7 @@ Install required collections by `ansible-galaxy collection install -vv -r meta/c
 ## Prerequisites
 <!-- BEGIN Prerequisites -->
 Managed nodes:
+
 - Directory with SAP Installation media is present and `sap_install_media_detect_source_directory` updated. Download can be completed using [community.sap_launchpad](https://github.com/sap-linuxlab/community.sap_launchpad).
 - Ensure that servers are configured for SAP HANA. See [Recommended](#recommended) section.
 - Ensure that volumes and filesystems are configured correctly. See [Recommended](#recommended) section.
@@ -31,6 +32,7 @@ Managed nodes:
 ### Prepare SAP HANA installation media
 Place the following files in directory /software/hana or in any other directory specified by variable
 `sap_hana_install_software_directory`:
+
 1. The SAPCAR executable for the correct hardware architecture
 2. The SAP HANA Installation .SAR file
     - SAP HANA 2.0 Server - `IMDB_SERVER*.SAR` file
@@ -52,23 +54,23 @@ Example of `sap_hana_install_software_directory` content for SAP HANA installati
 ```
 
 **Considerations:**
-- If more than one SAPCAR EXE file is present in the software directory, the role will select the latest version
-  for the current hardware architecture. Alternatively, the file name of the SAPCAR EXE file can also be set with
-  variable `sap_hana_install_sapcar_filename`. Example:
-  ```
-  sap_hana_install_sapcar_filename: SAPCAR_1115-70006178.EXE
-  ```
+
+- If more than one SAPCAR EXE file is present in the software directory, the role will select the latest version for the current hardware architecture.<br>
+  Alternatively, the file name of the SAPCAR EXE file can also be set with variable `sap_hana_install_sapcar_filename`.<br>
+  Example:<br>
+```yaml
+sap_hana_install_sapcar_filename: SAPCAR_1115-70006178.EXE
+```
 - If more than one SAR file for a certain software product is present in the software directory, the automatic
   handling of such SAR files will fail after extraction, when moving the newly created product directories
-  (like `SAP_HOST_AGENT`) to already existing destinations.
-  For avoiding such situations, use following variable to provide a list of SAR files to extract: `sap_hana_install_sarfiles`.
-
-  Example:
-  ```
-  sap_hana_install_sarfiles:
-    - SAPHOSTAGENT54_54-80004822.SAR
-    - IMDB_SERVER20_060_0-80002031.SAR
-  ```
+  (like `SAP_HOST_AGENT`) to already existing destinations.<br>
+  For avoiding such situations, use following variable to provide a list of SAR files to extract: `sap_hana_install_sarfiles`.<br>
+  Example:<br>
+```yaml
+sap_hana_install_sarfiles:
+  - SAPHOSTAGENT54_54-80004822.SAR
+  - IMDB_SERVER20_060_0-80002031.SAR
+```
 
 - If there is a file named `<filename>.sha256` in the software download directory
   `sap_hana_install_software_directory` which contains the checksum and the file name similar to the output
@@ -97,6 +99,7 @@ these cleanup actions are false.
 
 
 - Example of directory `sap_hana_install_software_extract_directory` containing extracted SAP HANA software installation files
+
 ```console
 [root@hanahost extracted]# ll -lrt
 drwxr-xr-x 4 root root 4096 Sep 30 04:55 SAP_HANA_AFL
@@ -147,6 +150,7 @@ of this file will not be reflected.
 ## Execution
 <!-- BEGIN Execution -->
 This Ansible Role can be executed in following scenarios:
+
 1. Install new SAP HANA System on one host.
     - `sap_hana_install_new_system` is `true`.
     - `sap_hana_install_addhosts` is not defined or empty String.
@@ -172,6 +176,7 @@ This Ansible Role can be executed in following scenarios:
 <!-- BEGIN Execution Recommended -->
 ### Recommended
 It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. [sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_preconfigure)
 3. [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect)
@@ -192,6 +197,7 @@ It is recommended to execute this role together with other roles in this collect
 
 #### Check existing installation
 This part is performed when:
+
 - Always, unless `sap_hana_install_force` is set to `true`.
 
 - If the file `/usr/sap/hostctrl/exe/saphostctrl` is present, get a list of instances with `saphostctrl -function ListInstances`:
@@ -210,11 +216,13 @@ This part is performed when:
 
 #### Check Addhosts
 This part is performed when:
+
 - The variable `sap_hana_install_addhosts` is defined and not empty String.
 
 **Addhosts are relevant to both Installation and Addhosts operations, because we need to delegate Pre-Tasks and Post-Tasks to them.**
 
 Steps:
+
 1. If the variable `sap_hana_install_addhosts` does not contain hosts, abort the role with failure.
     - This list of the `all hosts` is used for all Post-Tasks steps for idempotency.
 2. Gather list of all Instance profiles in `/hana/shared/<SID>/profile/`.
@@ -225,10 +233,12 @@ Steps:
 
 #### Pre-Tasks for Installation
 This part is performed when:
+
 - The variable `sap_hana_install_new_system` is set to `true`.
 - Existing SAP HANA was not detected.
 
 Steps:
+
 1. If the variable `sap_hana_install_configure_fapolicyd` is set to `true` and operating system is `RedHat`, install and disable `fapolicyd` on all new hosts.
 2. Configure permissions for the SAP HANA directories on all new hosts.
 3. If the variable `sap_hana_install_configure_selinux` is set to `true`, configure `SELinux` on all new hosts.
@@ -243,11 +253,13 @@ Steps:
 
 #### Pre-Tasks for Addhosts
 This part is performed when:
+
 - The variable `sap_hana_install_new_system` is set to `false`.
 - Existing SAP HANA was detected.
 - New hosts identified in the variable `sap_hana_install_addhosts`.
 
 Steps:
+
 1. Gather details of user `<sid>adm` and group `sapsys` on managed node.
     - If the user or group is not present, abort the role with failure.
     - Generate password hash for `sapadm` user using the value of `sap_hana_install_sapadm_password` variable.
@@ -262,29 +274,35 @@ Steps:
 
 #### Installation
 This part is performed when:
+
 - The variable `sap_hana_install_new_system` is set to `true`.
 - Existing SAP HANA was not detected.
 
 Steps:
+
 1. Execute the `hdblcm` executable in the directory `sap_hana_install_software_directory` using the configfile prepared in pre-tasks.
 
 
 #### Addhosts
 This part is performed when:
+
 - The variable `sap_hana_install_new_system` is set to `false`.
 - Existing SAP HANA was detected.
 - New hosts identified in the variable `sap_hana_install_addhosts`.
 
 Steps:
+
 1. Prepare new addhosts string only with new hosts and update `configfile.cfg`.
 2. Execute the `hdblcm` executable in the directory `/hana/shared/<SID>/hdblcm/` using the configfile prepared in pre-tasks.
 
 
 #### Post-Tasks for Installation
 This part is performed when:
+
 - The variable `sap_hana_install_new_system` is set to `true`.
 
 Steps:
+
 1. Update Secure User Store configuration (`hdbuserstore`) for `<sid>adm` user, for new installations.
 2. Set Log Mode key to overwrite value and apply to system, for new installations.
 3. Apply SAP HANA license if the variable `sap_hana_install_apply_license` is set to `true`, for new installations.
@@ -299,9 +317,11 @@ Additionally, if `sap_hana_install_enable_fapolicyd` is set to `true`, also enab
 
 #### Post-Tasks for Addhosts
 This part is performed when:
+
 - The variable `sap_hana_install_new_system` is set to `false`.
 
 Steps:
+
 1. Update Secure User Store configuration (`hdbuserstore`) for `<sid>adm` user, for new hosts.
 5. Set expiration of unix users to `never` if the variable `sap_hana_install_set_sidadm_noexpire` is set to `true`, for new hosts.
 6. Apply firewall rules if the variable `sap_hana_install_update_firewall` is set to `true`.
@@ -380,6 +400,7 @@ Installs SAP HANA on `host1` and `host2`, while running on host `host0` where ex
 Note: When using tags, only one tag at a time is possible.
 
 With the following tags, the role can be called to perform certain activities only:
+
 - tag `sap_hana_install_hdblcm_commandline`: Only show the hdblcm command line, without processing
   the hdblcm template. This can be useful for checking the hdblcm command line options, especially
   when using the `addhosts` function.
@@ -388,6 +409,7 @@ With the following tags, the role can be called to perform certain activities on
   desired SID and instance number.
 
 The following tags have been removed in this release:
+
 - tag `sap_hana_install_preinstall`
 - tag `sap_hana_install_chown_hana_directories`
 - tag `sap_hana_install_prepare_sapcar`
@@ -400,26 +422,22 @@ The following tags have been removed in this release:
 - tag `sap_hana_install_set_log_mode`
 - tag `sap_hana_install_check_installation`
 
-<details>
-  <summary><b>How to run sap_hana_install with tags</b></summary>
+#### How to run sap_hana_install with tags
 
-  #### Display SAP HANA hdblcm command line without performing an installation:
-  ```
-  ansible-playbook sap-hana-install.yml --tags=sap_hana_install_hdblcm_commandline
-  ```
+Display SAP HANA hdblcm command line without performing an installation:
+```
+ansible-playbook sap-hana-install.yml --tags=sap_hana_install_hdblcm_commandline
+```
 
-  #### Only create the hdblcm configfile:
-  ```console
-  ansible-playbook sap-hana-install.yml --tags=sap_hana_install_create_configfile
-  ```
+Only create the hdblcm configfile:
+```console
+ansible-playbook sap-hana-install.yml --tags=sap_hana_install_create_configfile
+```
 
-  #### Perform a SAP HANA existence check:
-  ```console
-  ansible-playbook sap-hana-install.yml --tags=sap_hana_install_check_hana_exists
-  ```
-</details>
-
-
+Perform a SAP HANA existence check:
+```console
+ansible-playbook sap-hana-install.yml --tags=sap_hana_install_check_hana_exists
+```
 <!-- END Role Tags -->
 
 <!-- BEGIN Further Information -->

--- a/roles/sap_hana_preconfigure/README.md
+++ b/roles/sap_hana_preconfigure/README.md
@@ -20,63 +20,10 @@ Install required collections by `ansible-galaxy collection install -vv -r meta/c
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed nodes:
+
 - Ensure that general operating system configuration for SAP is performed by [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure). See [Recommended](#recommended) section.
 
-<details>
-  <summary><b>(Red Hat) Ensure required repositories are available</b></summary>
-
-  Managed nodes need to be properly registered to a repository source and have at least the following Red Hat repositories accessible:
-
-  for RHEL 7.x:
-  - rhel-7-[server|for-power-le]-e4s-rpms
-  - rhel-sap-hana-for-rhel-7-[server|for-power-le]-e4s-rpms
-
-  for RHEL 8.x:
-  - rhel-8-for-[x86_64|ppc64le]-baseos-e4s-rpms
-  - rhel-8-for-[x86_64|ppc64le]-appstream-e4s-rpms
-  - rhel-8-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
-
-  for RHEL 9.x:
-  - rhel-9-for-[x86_64|ppc64le]-baseos-e4s-rpms
-  - rhel-9-for-[x86_64|ppc64le]-appstream-e4s-rpms
-  - rhel-9-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
-
-  For details on configuring Red Hat, see the knowledge base article: [How to subscribe SAP HANA systems to the Update Services for SAP Solutions](https://access.redhat.com/solutions/3075991)). If you set role parameter sap_hana_preconfigure_enable_sap_hana_repos to `yes`, the role can enable these repos.
-
-  To install HANA on Red Hat Enterprise Linux 7, 8, or 9, you need some additional packages which are contained in one of following repositories
-  - rhel-sap-hana-for-rhel-7-[server|for-power-le]-e4s-rpms
-  - rhel-8-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
-  - rhel-9-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
-
-  To get this repository you need to have one of the following products:
-  - [RHEL for SAP Solutions](https://access.redhat.com/solutions/3082481) (premium, standard)
-  - RHEL for Business Partner NFRs
-  - [RHEL Developer Subscription](https://developers.redhat.com/products/sap/download/)
-
-  To get a personal developer edition of RHEL for SAP solutions, please register as a developer and download the developer edition.
-
-  - [Registration Link](http://developers.redhat.com/register) :
-    Here you can either register a new personal account or link it to an already existing
-    **personal** Red Hat Network account.
-  - [Download Link](https://access.redhat.com/downloads/content/69/ver=/rhel---7/7.2/x86_64/product-software):
-    Here you can download the Installation DVD for RHEL with your previously registered
-    account
-
-  *NOTE:* This is a regular RHEL installation DVD as RHEL for SAP Solutions is no additional
-  product but only a special bundling. The subscription grants you access to the additional
-  packages through our content delivery network (CDN) after installation.
-
-  For supported RHEL releases [click here](https://access.redhat.com/solutions/2479121).
-
-  It is also important that your disks are setup according to the [SAP storage requirements for SAP HANA](https://www.sap.com/documents/2015/03/74cdb554-5a7c-0010-8F2c7-eda71af511fa.html). This [BLOG](https://blogs.sap.com/2017/03/07/the-ultimate-guide-to-effective-sizing-of-sap-hana/) is also quite helpful when sizing HANA systems.
-  You can use the [storage](https://galaxy.ansible.com/linux-system-roles/storage) role to automate this process
-
-  If you want to use this system in production, make sure that the time service is configured correctly. You can use [rhel-system-roles](https://access.redhat.com/articles/3050101) to automate this.
-
-  Note
-  ----
-  For finding out which SAP notes will be used by this role for Red Hat systems, please check the contents of variable `__sap_hana_preconfigure_sapnotes` in files `vars/*.yml` (choose the file which matches your OS distribution and version). 
-</details>
+- (Red Hat) Ensure required repositories are available. See [Further Information Section](#red-hat-ensure-required-repositories-are-available)
 <!-- END Prerequisites -->
 
 ## Execution
@@ -89,6 +36,7 @@ Managed nodes:
 <!-- BEGIN Execution Recommended -->
 ### Recommended
 It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. *`sap_hana_preconfigure`*
 <!-- END Execution Recommended -->
@@ -128,6 +76,61 @@ Example of execution together with prerequisite role [sap_general_preconfigure](
 <!-- BEGIN Further Information -->
 ## Further Information
 For more examples on how to use this role in different installation scenarios, refer to the [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) playbooks.
+
+### (Red Hat) Ensure required repositories are available
+
+Managed nodes need to be properly registered to a repository source and have at least the following Red Hat repositories accessible:
+
+- RHEL 7.x:
+    - rhel-7-[server|for-power-le]-e4s-rpms
+    - rhel-sap-hana-for-rhel-7-[server|for-power-le]-e4s-rpms
+
+- RHEL 8.x:
+    - rhel-8-for-[x86_64|ppc64le]-baseos-e4s-rpms
+    - rhel-8-for-[x86_64|ppc64le]-appstream-e4s-rpms
+    - rhel-8-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
+
+- RHEL 9.x:
+    - rhel-9-for-[x86_64|ppc64le]-baseos-e4s-rpms
+    - rhel-9-for-[x86_64|ppc64le]-appstream-e4s-rpms
+    - rhel-9-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
+
+For details on configuring Red Hat, see the knowledge base article: [How to subscribe SAP HANA systems to the Update Services for SAP Solutions](https://access.redhat.com/solutions/3075991).<br>
+If you set role parameter sap_hana_preconfigure_enable_sap_hana_repos to `yes`, the role can enable these repos.
+
+To install HANA on Red Hat Enterprise Linux 7, 8, or 9, you need some additional packages which are contained in one of following repositories
+
+- rhel-sap-hana-for-rhel-7-[server|for-power-le]-e4s-rpms
+- rhel-8-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
+- rhel-9-for-[x86_64|ppc64le]-sap-solutions-e4s-rpms
+
+To get this repository you need to have one of the following products:
+
+- [RHEL for SAP Solutions](https://access.redhat.com/solutions/3082481) (premium, standard)
+- RHEL for Business Partner NFRs
+- [RHEL Developer Subscription](https://developers.redhat.com/products/sap/download/)
+
+To get a personal developer edition of RHEL for SAP solutions, please register as a developer and download the developer edition.
+
+- [Registration Link](http://developers.redhat.com/register):<br>
+  Here you can either register a new personal account or link it to an already existing **personal** Red Hat Network account.
+- [Download Link](https://access.redhat.com/downloads/content/69/ver=/rhel---7/7.2/x86_64/product-software):<br>
+  Here you can download the Installation DVD for RHEL with your previously registered account.<br>
+
+**NOTE:** This is a regular RHEL installation DVD as RHEL for SAP Solutions is no additional<br>
+product but only a special bundling. The subscription grants you access to the additional<br>
+packages through our content delivery network (CDN) after installation.<br>
+
+For supported RHEL releases [click here](https://access.redhat.com/solutions/2479121).<br>
+
+It is also important that your disks are setup according to the [SAP storage requirements for SAP HANA](https://www.sap.com/documents/2015/03/74cdb554-5a7c-0010-8F2c7-eda71af511fa.html).<br>
+This [BLOG](https://blogs.sap.com/2017/03/07/the-ultimate-guide-to-effective-sizing-of-sap-hana/) is also quite helpful when sizing HANA systems.<br>
+You can use the [storage](https://galaxy.ansible.com/linux-system-roles/storage) role to automate this process.<br>
+
+If you want to use this system in production, make sure that the time service is configured correctly.<br>
+You can use [rhel-system-roles](https://access.redhat.com/articles/3050101) to automate this.<br>
+
+**NOTE:** For finding out which SAP notes will be used by this role for Red Hat systems, please check the contents of variable `__sap_hana_preconfigure_sapnotes` in files `vars/*.yml` (choose the file which matches your OS distribution and version). 
 <!-- END Further Information -->
 
 ## License
@@ -287,8 +290,8 @@ The SAP HANA directories will always be created if `sap_hana_preconfigure_modify
 ### sap_hana_preconfigure_hana_directories
 - _Type:_ `list` with elements of type `str`
 - _Default:_
-  - /hana
-  - /lss/shared
+    - /hana
+    - /lss/shared
 
 List of SAP HANA directories to be created.<br>
 
@@ -393,8 +396,7 @@ List of interfaces for which the MTU size will be set to `9000`.<br>
 
 ### sap_hana_preconfigure_ppcle_tso_if
 - _Type:_ `list` with elements of type `str`
-- _Default:_
-  '{{ ansible_interfaces | difference([''lo'']) }}'
+- _Default:_ `'{{ ansible_interfaces | difference([''lo'']) }}'`
 
 List of interfaces for which the tso flag will be set.<br>
 

--- a/roles/sap_hostagent/README.md
+++ b/roles/sap_hostagent/README.md
@@ -9,6 +9,7 @@ The Ansible Role `sap_hostagent` is used install SAP Host Agent.
 SAP Host Agent is an agent that can accomplish several life-cycle management tasks, such as operating system monitoring, database monitoring, system instance control and provisioning.
 
 This role installs SAP Host Agent with following source methods:
+
 - SAP SAR file
 - SAP Bundle
 - RPM package (Red Hat only)
@@ -20,6 +21,7 @@ This role installs SAP Host Agent with following source methods:
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed nodes:
+
 - Ensure that servers are configured for SAP Systems. See [Recommended](#recommended) section.
 <!-- END Prerequisites -->
 
@@ -30,6 +32,7 @@ Managed nodes:
 <!-- BEGIN Execution Recommended -->
 ### Recommended
 It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. *`sap_hostagent`*
 <!-- END Execution Recommended -->
@@ -54,7 +57,7 @@ It is recommended to execute this role together with other roles in this collect
     - name: Execute Ansible Role sap_hostagent
       ansible.builtin.include_role:
         name: community.sap_install.sap_hostagent
-      vars:  
+      vars:
         sap_hostagent_installation_type: "sar"
         sap_hostagent_sar_local_path: "/software/SAPHOSTAGENT"
         sap_hostagent_sar_file_name: "SAPHOSTAGENT44_44-20009394.SAR"
@@ -72,7 +75,7 @@ It is recommended to execute this role together with other roles in this collect
     - name: Execute Ansible Role sap_hostagent
       ansible.builtin.include_role:
         name: community.sap_install.sap_hostagent
-      vars:  
+      vars:
         sap_hostagent_installation_type: "sar"
         sap_hostagent_sar_remote_path: "/software/SAPHOSTAGENT"
         sap_hostagent_sar_file_name: "SAPHOSTAGENT44_44-20009394.SAR"
@@ -90,7 +93,7 @@ It is recommended to execute this role together with other roles in this collect
     - name: Execute Ansible Role sap_hostagent
       ansible.builtin.include_role:
         name: community.sap_install.sap_hostagent
-      vars:  
+      vars:
         sap_hostagent_installation_type: "bundle"
         sap_hostagent_bundle_path: "/usr/local/src/HANA-BUNDLE/51053381"
         sap_hostagent_clean_tmp_directory: true
@@ -105,7 +108,7 @@ It is recommended to execute this role together with other roles in this collect
     - name: Execute Ansible Role sap_hostagent
       ansible.builtin.include_role:
         name: community.sap_install.sap_hostagent
-      vars:  
+      vars:
         sap_hostagent_installation_type: "rpm"
         sap_hostagent_rpm_local_path: "/mylocaldir/SAPHOSTAGENT"
         sap_hostagent_rpm_file_name: "saphostagentrpm_44-20009394.rpm"

--- a/roles/sap_install_media_detect/README.md
+++ b/roles/sap_install_media_detect/README.md
@@ -7,9 +7,18 @@
 <!-- BEGIN Description -->
 The Ansible Role `sap_install_media_detect` is used to detect and extract SAP installation media.
 
-This role searches provided source directory, sorts files based on type and extracts them to target directory. Extraction can be further adjusted to create individual folders based on defined inputs.
+This role searches provided source directory, sorts files based on type and extracts them to target directory.<br>
+Extraction can be further adjusted to create individual folders based on defined inputs.
 
-Detection of supported installation media is available for SAP HANA and wide range of SAP Applications (example: SAP S/4HANA, SAP BW/4HANA, SAP ECC, SAP BW, SAP WebDispatcher, SAP Business Applications based upon SAP NetWeaver, etc).
+Detection of supported installation media is available for SAP HANA and wide range of SAP Applications like:
+
+- SAP S/4HANA
+- SAP BW/4HANA
+- SAP ECC
+- SAP BW
+- SAP WebDispatcher
+- SAP Business Applications based upon SAP NetWeaver
+- Other SAP products based on SAP NetWeaver
 <!-- END Description -->
 
 <!-- BEGIN Dependencies -->
@@ -18,6 +27,7 @@ Detection of supported installation media is available for SAP HANA and wide ran
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed nodes:
+
 - Directory with SAP Installation media is present and `sap_install_media_detect_source_directory` updated. Download can be completed using [community.sap_launchpad](https://github.com/sap-linuxlab/community.sap_launchpad) Ansible Collection.
 <!-- END Prerequisites -->
 
@@ -62,14 +72,13 @@ It is recommended to execute this role together with other roles in this collect
 12. The last step is to fill all required `sap_swpm` parameters from the result of the previous find step, and display all the variables.
     - Once detection (e.g. using `zipinfo -1` and `unrar lb`) and extraction are completed, the file paths are shown and stored as variables for subsequent use by other Ansible Tasks.
 
-<details>
-  <summary><b>(Red Hat) Additional steps for RAR files</b></summary>
+#### (Red Hat) Additional steps for RAR files
 
-  RAR files can be either handled by the unar package from EPEL or by another package which can list the contents of, and extract files from, RAR files. See the comments and examples for the RAR file handling in `defaults/main.yml`.
+RAR files can be either handled by the unar package from EPEL or by another package which can list the contents of, and extract files from, RAR files.<br>
+See the comments and examples for the RAR file handling in `defaults/main.yml`.
 
-  - If the EPEL repo had been enabled at the time when the role was run, it will remain enabled.
-  - If the EPEL repo was not present, the associated GPG key will be removed and the EPEL repo will be disabled as the last task.
-</details>
+- If the EPEL repo had been enabled at the time when the role was run, it will remain enabled.
+- If the EPEL repo was not present, the associated GPG key will be removed and the EPEL repo will be disabled as the last task.
 <!-- END Execution Flow -->
 
 ### Example
@@ -99,6 +108,7 @@ Example playbook to extract SAP Installation media for SAP ASCS Netweaver.
 <!-- BEGIN Role Tags -->
 ### Role Tags
 With the following tags, the role can be called to perform certain activities only:
+
 - tag `sap_install_media_detect_zip_handling`: Only perform the task for enabling the listing and extracting of files of type `ZIP`.
 - tag `sap_install_media_detect_rar_handling`: Only perform the tasks for enabling the listing and extracting of files of type `RAR`. This
   includes enabling and disabling the EPEL repo for RHEL systems, if desired.
@@ -112,8 +122,13 @@ With the following tags, the role can be called to perform certain activities on
 - tag `sap_install_media_detect_find_files_after_extraction`: Finds all required files after they have been extracted so the final variables can be filled in the next step.
 - tag `sap_install_media_detect_set_global_vars`: Set all final variables for later use by Ansible roles or tasks.
 
-Note: After running the role with the following four tags, the SAP archive files will be in the same place as before running the role the first time. The directories with pattern `*_extracted` will remain in place.
-`sap_install_media_detect_provide_sapfile_utility,sap_install_media_detect_check_directories,sap_install_media_detect_create_file_list_phase_1,sap_install_media_detect_move_files_to_main_directory`
+**Note:** After running the role with the following four tags, the SAP archive files will be in the same place as before running the role the first time.<br>
+The directories with pattern `*_extracted` will remain in place.
+
+- `sap_install_media_detect_provide_sapfile_utility`
+- `sap_install_media_detect_check_directories`
+- `sap_install_media_detect_create_file_list_phase_1`
+- `sap_install_media_detect_move_files_to_main_directory`
 <!-- END Role Tags -->
 
 <!-- BEGIN Further Information -->

--- a/roles/sap_maintain_etc_hosts/README.md
+++ b/roles/sap_maintain_etc_hosts/README.md
@@ -30,6 +30,7 @@ The Ansible role `sap_maintain_etc_hosts` is used to maintain the `/etc/hosts` f
 ### Example
 <!-- BEGIN Execution Example -->
 Example playbook will update `/etc/hosts`:
+
 - Remove node with IP `10.10.10.10`.
 - Remove node with name `host2`.
 - Add node with IP `10.10.10.11`, name `host1`, aliases `alias1, alias2` and comment `host1 comment`.
@@ -106,6 +107,7 @@ If the value `sap_hana_cluster_nodes`or `sap_ha_pacemaker_cluster_cluster_nodes`
 Mandatory list of nodes in form of dictionaries to be added or removed in `/etc/hosts` file.
 
 Following dictionary keys can be defined:
+
 - **node_ip**<br>
     IP address of the managed node.<br>
     **Required** for adding new entries to `/etc/hosts`.</br>
@@ -141,7 +143,7 @@ Following dictionary keys can be defined:
     _Optional_ for adding new entries to `/etc/hosts`.
 
     - _Type:_ `string`
-    - _Default:_ `merge`    
+    - _Default:_ `merge`
 
 - **node_comment**<br>
     Node comment is appended at end of line of managed node.<br>
@@ -166,5 +168,5 @@ Following dictionary keys can be defined:
     **Required** for removing entries, otherwise default `present` is used.
 
     - _Type:_ `string`
-    - _Default:_ `present`   
+    - _Default:_ `present`
 <!-- END Role Variables -->

--- a/roles/sap_netweaver_preconfigure/README.md
+++ b/roles/sap_netweaver_preconfigure/README.md
@@ -13,6 +13,7 @@ The Ansible role `sap_netweaver_preconfigure` installs additional required packa
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed nodes:
+
 - Ensure that general operating system configuration for SAP is performed by [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure). See [Recommended](#recommended) section.
 <!-- END Prerequisites -->
 
@@ -25,7 +26,8 @@ Managed nodes:
 
 <!-- BEGIN Execution Recommended -->
 ### Recommended
-It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+It is recommended to execute this role together with other roles in this collection, in the following order:
+
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. *`sap_netweaver_preconfigure`*
 <!-- END Execution Recommended -->
@@ -35,10 +37,10 @@ It is recommended to execute this role together with other roles in this collect
 1. Assert that required inputs were provided.
 2. Install required packages
 3. Apply configurations
-  - Execute configuration tasks based on SAP Notes
-  - (SUSE) Execute saptune with solution `sap_netweaver_preconfigure_saptune_solution` (Default: `NETWEAVER`)
+    - Execute configuration tasks based on SAP Notes
+    - (SUSE) Execute saptune with solution `sap_netweaver_preconfigure_saptune_solution` (Default: `NETWEAVER`)
 
-**Note: (Red Hat) Due to SAP notes 2002167, 2772999, and 3108316, the role will switch to tuned profile sap-netweaver no matter if another tuned profile (e.g. virtual-guest) had been active before or not.**
+**NOTE:** (Red Hat) Due to SAP notes 2002167, 2772999, and 3108316, the role will switch to tuned profile sap-netweaver no matter if another tuned profile (e.g. virtual-guest) had been active before or not.
 <!-- END Execution Flow -->
 
 ### Example

--- a/roles/sap_storage_setup/README.md
+++ b/roles/sap_storage_setup/README.md
@@ -8,6 +8,7 @@
 The Ansible Role `sap_storage_setup` is used to prepare a host with the storage requirements of an SAP System (prior to software installation).
 
 This role can prepare host with:
+
 - Local block storage volume setup as LVM Logical Volumes, Filesystem formatting and mount to defined directory path
 - Remote file storage mount (and subdirectories as required)
 - SWAP file or SWAP partition
@@ -22,24 +23,32 @@ This Ansible Role is agnostic, and will run on any Infrastructure Platform. Only
         - `lvg`
         - `lvol`
         - `filesystem`
+
 Install required collection by `ansible-galaxy collection install community.general`.
 <!-- END Dependencies -->
 
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Managed nodes:
-- All local/block storage volumes must be attached to the host
+
+- All local/block storage volumes must be attached to the host.
 - All remote/file storage mounts must be available with host accessibility (e.g. port 2049).
 <!-- END Prerequisites -->
 
 ## Execution
 <!-- BEGIN Execution -->
 **:warning: Do not execute this Ansible Role against existing SAP systems unless you know what you are doing and you prepare inputs to avoid unintended changes caused by default inputs.**</br>
-:warning: While this Ansible Role has protection against overwrite of existing disks and filesystems - sensible review and care is required for any automation of disk storage. Please review the documentation and samples/examples carefully. It is strongly suggested to initially execute the Ansible Playbook calling this Ansible Role, with `ansible-playbook --check` for Check Mode - this will perform no changes to the host and show which changes would be made.
+
+:warning: While this Ansible Role has protection against overwrite of existing disks and filesystems - sensible review and care is required for any automation of disk storage.</br>
+Please review the documentation and samples/examples carefully. It is strongly suggested to initially execute the Ansible Playbook calling this Ansible Role,</br>
+with `ansible-playbook --check` for Check Mode - this will perform no changes to the host and show which changes would be made.
 
 **Considerations**
-- This role does not permit static definition for mountpoint to use a specific device (e.g. `/dev/sdk`). The definition will define the disk size to use for the mountpoint, and match accordingly.
-- This role enforces that 1 mountpoint will use 1 LVM Logical Volume (LV) that consumes 100% of an LVM Volume Group (VG), with the LVM Volume Group (VG) consuming 100% of 1..n LVM Physical Volumes (PV).
+
+- This role does not permit static definition for mountpoint to use a specific device (e.g. `/dev/sdk`).<br>
+  The definition will define the disk size to use for the mountpoint, and match accordingly.
+- This role enforces that 1 mountpoint will use 1 LVM Logical Volume (LV) that consumes 100% of an LVM Volume Group (VG),<br>
+  with the LVM Volume Group (VG) consuming 100% of `1..n` LVM Physical Volumes (PV).
     - Following roles and modules offer alternative for more granular control of LVM setup:
         - Role `storage` from [fedora.linux_system_roles](https://github.com/linux-system-roles/storage)
         - Modules `filesystem`, `lvg`, `lvol` from [community.general](https://galaxy.ansible.com/ui/repo/published/community/general/)
@@ -60,6 +69,7 @@ Managed nodes:
 
 <!-- BEGIN Execution Example -->
 Example playbook to configure SAP HANA OneHost node on AWS that includes:
+
 - 3 disks for `/hana/data`, `/hana/log` and ` /hana/shared`
 - Remote filesystem for `/software`
 - SWAP
@@ -197,10 +207,10 @@ Describes list of the filesystems to be configured.<br>
 
     - _Type:_ `str`
     - _Default:_ `hard,acl`
-    
+
 - **nfs_path**<br>
     When defining an NFS filesystem, this is the directory path of the filesystem to be mounted.
-    
+
     - _Type:_ `str`
 
 - **nfs_server**<br>

--- a/roles/sap_swpm/README.md
+++ b/roles/sap_swpm/README.md
@@ -14,6 +14,7 @@ The Ansible role `sap_swpm` installs various SAP Systems installable by SAP Soft
 ## Prerequisites
 <!-- BEGIN Prerequisites -->
 Managed nodes:
+
 - Directory with SAP Installation media is present and `sap_swpm_software_path` updated. Download can be completed using [community.sap_launchpad](https://github.com/sap-linuxlab/community.sap_launchpad).
 - Ensure that servers are configured for SAP Systems. See [Recommended](#recommended) section.
 - Ensure that volumes and filesystems are configured correctly. See [Recommended](#recommended) section.
@@ -24,6 +25,7 @@ Place a valid SAPCAR executable file in a directory specified by variable `sap_s
 Place a valid SWPM SAR file in a directory specified by variable `sap_swpm_swpm_path` (e.g. /software/sap_swpm). Example: `SWPM20SP18_3-80003424.SAR`
 
 Place the following files in a directory specified by variable `sap_swpm_software_path` (e.g. /software/sap_swpm_download_basket):
+
   - For a new installation
       - Download the appropriate software from SAP Software Download Center, Maintenance Planner, etc.
   - For a restore or new installation
@@ -34,7 +36,8 @@ Place the following files in a directory specified by variable `sap_swpm_softwar
       - SAP Kernel DB Independent - `SAPEXE_*SAR`
       - SAP HANA Client           - `IMDB_CLIENT*SAR`
 
-Alternatively, you can place all the files mentioned above into a single directory and use the role [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect) to identify the required files and set the role variables automatically so that the role `sap_swpm` has access to all the files needed for a successful installation of SAP System.
+Alternatively, you can place all the files mentioned above into a single directory and use the role [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect) to identify the required files<br>
+and set the role variables automatically so that the role `sap_swpm` has access to all the files needed for a successful installation of SAP System.
 <!-- END Prerequisites -->
 
 ## Execution
@@ -43,13 +46,14 @@ Alternatively, you can place all the files mentioned above into a single directo
 
 <!-- BEGIN Execution Recommended -->
 ### Recommended
-It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+It is recommended to execute this role together with other roles in this collection, in the following order:
+
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. [sap_netweaver_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_netweaver_preconfigure)
 3. [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect)
 4. *`sap_swpm`*
 
-Note: For most scenarios, a database like SAP HANA must be available. Use the role [sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_install) for installing the SAP HANA database.
+**NOTE:** For most scenarios, a database like SAP HANA must be available. Use the role [sap_hana_install](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_install) for installing the SAP HANA database.
 <!-- END Execution Recommended -->
 
 ### Execution Flow
@@ -78,22 +82,26 @@ Note: For most scenarios, a database like SAP HANA must be available. Use the ro
 
 - At this stage, the role is searching for a sapinst inifile on the managed node, or it will create one:
 
-  - If a file `inifile.params` is located on the managed node in the directory specified in `sap_swpm_inifile_directory`,
-    the role will not create a new one but rather download this file to the control node.
+    - If a file `inifile.params` is located on the managed node in the directory specified in `sap_swpm_inifile_directory`,
+      the role will not create a new one but rather download this file to the control node.
 
-  - If such a file does *not* exist, the role will create an SAP SWPM `inifile.params` file by one of the following methods:
+    - If such a file does *not* exist, the role will create an SAP SWPM `inifile.params` file by one of the following methods:<br>
 
-    Method 1: Predefined sections of the file `inifile_params.j2` will be used to create the file `inifile.params`. The variable `sap_swpm_inifile_sections_list` contains a list of sections which will part of the file `inifile.params`. All other sections will be ignored. The inifile parameters themselves will be set according to other role parameters. Example: The inifile parameter `archives.downloadBasket` will be set to the content of the role parameter `sap_swpm_software_path`.
+        - It is also possible to use method 1 for creating the inifile and then replace or set additional variables using method 2:<br>
+          Define both of the related parameters, `sap_swpm_inifile_sections_list` and `sap_swpm_inifile_parameters_dict`.
 
-    Method 2: The file `inifile.params` will be configured from the content of the dictionary `sap_swpm_inifile_parameters_dict`. This dictionary is defined like in the following example:
+        - Method 1: Predefined sections of the file `inifile_params.j2` will be used to create the file `inifile.params`.<br>
+          The variable `sap_swpm_inifile_sections_list` contains a list of sections which will part of the file `inifile.params`.<br>
+          All other sections will be ignored. The inifile parameters themselves will be set according to other role parameters.<br>
+          Example: The inifile parameter `archives.downloadBasket` will be set to the content of the role parameter `sap_swpm_software_path`.
 
-```
+        - Method 2: The file `inifile.params` will be configured from the content of the dictionary `sap_swpm_inifile_parameters_dict`.<br>
+          This dictionary is defined like in the following example:<br>
+```yaml
 sap_swpm_inifile_parameters_dict:
   archives.downloadBasket: /software/download_basket
   NW_getFQDN.FQDN: example.com
 ```
-
-It is also possible to use method 1 for creating the inifile and then replace or set additional variables using method 2: Define both of the related parameters, `sap_swpm_inifile_sections_list` and `sap_swpm_inifile_parameters_dict`.
 
 - The file `inifile.params` is then transferred to a temporary directory on the managed node, to be used by the sapinst process.
 
@@ -114,7 +122,8 @@ It is also possible to use method 1 for creating the inifile and then replace or
 <!-- BEGIN Execution Example -->
 
 #### Playbook for installing a SAP ABAP ASCS instance in distributed system with [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect) role
-Example shows execution together with [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect) role, which sets required variables for `sap_swpm` role.</br>
+Example shows execution together with [sap_install_media_detect](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_install_media_detect) role, which sets required variables for `sap_swpm` role.
+
 ```yaml
 ---
 - name: Ansible Play for SAP ABAP ASCS installation in distributed system
@@ -165,12 +174,12 @@ Example shows execution together with [sap_install_media_detect](https://github.
         sap_swpm_role_parameters_dict:
           sap_swpm_install_saphostagent: 'true'
 ```
-
 <!-- END Execution Example -->
 
 <!-- BEGIN Role Tags -->
 ### Role Tags
 With the following tags, the role can be called to perform certain activities only:
+
 - tag `sap_swpm_generate_inifile`: Only create the sapinst inifile, without running most of the preinstall steps.
   This can be useful for checking if the inifile is created as desired.
 - tag `sap_swpm_sapinst_commandline`: Only show the sapinst command line.
@@ -182,9 +191,10 @@ With the following tags, the role can be called to perform certain activities on
 ## Additional information
 <!-- BEGIN UDI -->
 ### Up-To-Date Installation (UDI)
-The Software Update Manager can run on any host with an Application Server instance (e.g. NWAS ABAP PAS/AAS, NWAS JAVA CI/AAS) with correct permissions to access /usr/sap/ and /sapmnt/ directories.
+The Software Update Manager can run on any host with an Application Server instance (e.g. NWAS ABAP PAS/AAS, NWAS JAVA CI/AAS) with correct permissions to access `/usr/sap/` and `/sapmnt/` directories.
 
-When using the Software Provisioning Manager (SWPM) with a Maintenance Planner Stack XML file to perform an "up-to-date installation" (UDI) - it will start the Software Update Manager (SUM) automatically at the end of the installation process. This UDI feature applies only to SAP ABAP Platform / SAP NetWeaver, and must be performed from the Primary Application Server instance (i.e. NWAS ABAP PAS, or a OneHost installation).
+When using the Software Provisioning Manager (SWPM) with a Maintenance Planner Stack XML file to perform an "up-to-date installation" (UDI) - it will start the Software Update Manager (SUM) automatically at the end of the installation process.<br>
+This UDI feature applies only to SAP ABAP Platform / SAP NetWeaver, and must be performed from the Primary Application Server instance (i.e. NWAS ABAP PAS, or a OneHost installation).
 
 Furthermore, during SWPM variable selection the enabling of Transport Management System (TMS) is required, see SAP Note 2522253 - SWPM can not call SUM automatically when doing the up-to-date installation.
 <!-- END UDI -->
@@ -203,6 +213,7 @@ Apache 2.0
 ## Role Variables
 <!-- BEGIN Role Variables -->
 **NOTE: Discontinued variables:**
+
 - `sap_swpm_ansible_role_mode`
 
 ### Variables for creating sapinst inifile
@@ -421,9 +432,9 @@ Define DDIC user password in client 000 for new install, or existing for restore
 #### sap_swpm_virtual_hostname
 - _Type:_ `string`
 
-Define virtual hostname when installing High Available instances (e.g. SAP ASCS/ERS cluster).
-The role attempts to resolve `sap_swpm_virtual_hostname` on the managed node, using DNS and /etc/hosts, and will fail
-if this hostname resolution fails. The role will also fail if the IPv4 address for `sap_swpm_virtual_hostname` is
+Define virtual hostname when installing High Available instances (e.g. SAP ASCS/ERS cluster).<br>
+The role attempts to resolve `sap_swpm_virtual_hostname` on the managed node, using DNS and /etc/hosts, and will fail<br>
+if this hostname resolution fails. The role will also fail if the IPv4 address for `sap_swpm_virtual_hostname` is<br>
 not part of the IPv4 addresses of the managed node.
 
 ### Variables specific to SAP HANA Database Installation


### PR DESCRIPTION
## Changes
- All README.md documents were updated to align with formatting in Ansible Galaxy to avoid broken tables and lists.
- Markdown `  ` newline was replaced with `<br>`. Following command can be used to find them `grep -rnE "  $" --include="*.md" .`
- Update collection requirements table for better formatting.

**NOTE:** `sap_ha_pacemaker_cluster` role will be updated in upcoming PR along with STONITH improvements.