### PR TITLE
sap_ha_pacemaker_cluster: Add fence_aws for SLES 16 and remove Tech Debt

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/DEPRECATED_VARIABLES.md
+++ b/roles/sap_ha_pacemaker_cluster/DEPRECATED_VARIABLES.md
@@ -46,6 +46,9 @@ All deprecated variables offer time limited backwards compatibility that will be
 | ~~sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ascs_id~~<br>sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_id | :heavy_check_mark: | Removal of `_abap_` |
 | ~~sap_ha_pacemaker_cluster_healthcheck_nwas_abap_ers_id~~<br>sap_ha_pacemaker_cluster_healthcheck_nwas_ers_id | :heavy_check_mark: | Removal of `_abap_` |
 | ~~sap_ha_pacemaker_cluster_storage_nfs_filesytem_type~~<br>sap_ha_pacemaker_cluster_storage_nfs_filesystem_type | :heavy_check_mark: | Typo |
+| ~~sap_ha_pacemaker_cluster_fence_agent_minimal_packages~~ | :x: | Replaced with `sap_ha_pacemaker_cluster_fence_agent_packages` |
+| ~~sap_ha_pacemaker_cluster_stonith_custom.name~~ | :x: | Replaced with `sap_ha_pacemaker_cluster_stonith_custom.id` | 
+| ~~sap_ha_pacemaker_cluster_stonith_custom.options~~ | :x: | Removed in favor of `instance_attrs` and `meta_attrs` |
 
 
 ## Status explanation:

--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -20,9 +20,12 @@ Install required collections by `ansible-galaxy collection install -vv -r meta/c
 <!-- BEGIN Prerequisites -->
 ## Prerequisites
 Infrastructure:
-- It is required to create them manually or using [sap_vm_provision](https://github.com/sap-linuxlab/community.sap_infrastructure/tree/main/roles/sap_vm_provision) role, because this role does not create any Cloud platform resources that are required by Resource Agents.
+
+- It is required to create them manually or using [sap_vm_provision](https://github.com/sap-linuxlab/community.sap_infrastructure/tree/main/roles/sap_vm_provision) role,<br>
+  because this role does not create any Cloud platform resources that are required by Resource Agents.
 
 Managed nodes:
+
 - Supported SAP system is installed. See [Recommended](#recommended) section.
 - SAP HANA System Replication is configured for SAP HANA HA cluster. See [Recommended](#recommended) section.
 - Operating system has access to all required packages
@@ -62,8 +65,7 @@ Managed nodes:
 | IBM PowerVC hypervisor Virtual Machine | :heavy_check_mark: | |
 | OVirt VM | :heavy_check_mark: | |
 
-### Supported scenarios
-
+### Supported Scenarios
 | Platform | Variant | Status |
 | -------- | --------- | --------- |
 | SAP HANA scale-up (performance-optimized) 2 nodes | SAPHanaSR Classic | :heavy_check_mark: |
@@ -74,11 +76,34 @@ Managed nodes:
 | SAP NetWeaver (JAVA) SCS and ERS 2 nodes | Simple Mount | :heavy_check_mark: |
 
 **NOTE: SAP Netweaver ASCS/ERS and SCS/ERS are ENSA2 by default, but ENSA1 is also supported.**
+
+### Fence Agents
+All supported platforms and scenarios are configured with default fencing agent configuration based on official documentation.<br>
+
+> **NOTE**: You can override this default agent by setting the `sap_ha_pacemaker_cluster_stonith_custom` variable.<br>
+
+> **SUSE NOTE**: While the fencing agents listed below are configured by default according to cloud provider documentation, SUSE recommends using STONITH Block Device (SBD) for its lower latency and improved cluster stability, which can be enabled via the `sap_ha_pacemaker_cluster_sbd_*` variables.
+
+| Platform | RHEL | SLES 15 | SLES 16 |
+| --- | --- | --- | --- |
+| AWS | stonith:fence_aws | stonith:external/ec2 | stonith:fence_aws |
+| Google Cloud | stonith:fence_gcp | stonith:fence_gcp | stonith:fence_gcp |
+| Azure | stonith:fence_azure_arm | stonith:fence_azure_arm | stonith:fence_azure_arm |
+| IBM Cloud VS | stonith:fence_ibm_vpc | stonith:fence_ibm_vpc | stonith:fence_ibm_vpc |
+| IBM Power VS | stonith:fence_ibm_powervs | stonith:fence_ibm_powervs | stonith:fence_ibm_powervs |
+| IBM PowerVC | stonith:fence_lpar | stonith:fence_lpar | stonith:fence_lpar |
+| Physical server | N/A | N/A | N/A |
+| OVirt VM | N/A | N/A | N/A |
+
+You can find detailed configuration for each agent in the variable `__sap_ha_pacemaker_cluster_stonith_default_dict` under each platform vars file<br>
+and use it as template for defining your custom configuration with the variable `sap_ha_pacemaker_cluster_stonith_custom`.
+
 <!-- END Execution -->
 
 <!-- BEGIN Execution Recommended -->
 ### Recommended
-It is recommended to execute this role together with other roles in this collection, in the following order:</br>
+It is recommended to execute this role together with other roles in this collection, in the following order:
+
 #### SAP HANA cluster
 1. [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure)
 2. [sap_hana_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_hana_preconfigure)
@@ -148,7 +173,8 @@ It is recommended to execute this role together with other roles in this collect
 ## Further Information
 For more examples on how to use this role in different installation scenarios, refer to the [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) playbooks.
 
-Cluster can be further customized with inputs available from underlying role [ha_cluster](https://github.com/linux-system-roles/ha_cluster/blob/main/README.md), which will take precedence over `sap_ha_pacemaker_cluster` inputs.
+Cluster can be further customized with inputs available from underlying role [ha_cluster](https://github.com/linux-system-roles/ha_cluster/blob/main/README.md),<br>
+which will take precedence over `sap_ha_pacemaker_cluster` inputs.
 <!-- END Further Information -->
 
 ## License
@@ -164,14 +190,13 @@ Apache 2.0
 
 ## Role Variables
 <!-- BEGIN Role Variables -->
-Minimum required parameters for all clusters:
+Minimum required parameters for all clusters:<br>
+- [sap_ha_pacemaker_cluster_hacluster_user_password](#sap_ha_pacemaker_cluster_hacluster_user_password)<br>
 
-- [sap_ha_pacemaker_cluster_hacluster_user_password](#sap_ha_pacemaker_cluster_hacluster_user_password)
-
-Additional minimum requirements depend on the type of cluster setup and on the target platform.
+Additional minimum requirements depend on the type of cluster setup and on the target platform.<br>
 
 ### sap_ha_pacemaker_cluster_aws_access_key_id
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 AWS access key to allow control of instances (for example for fencing operations).<br>
 Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
@@ -179,7 +204,7 @@ Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
 2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`<br>
 
 ### sap_ha_pacemaker_cluster_aws_credentials_setup
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Set this parameter to 'true' to store AWS credentials into /root/.aws/credentials.<br>
 Requires: `sap_ha_pacemaker_cluster_aws_access_key_id` and `sap_ha_pacemaker_cluster_aws_secret_access_key`<br>
@@ -187,13 +212,13 @@ Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
 1. IAM Role or Instance profile is not attached to EC2 instance.<br>
 
 ### sap_ha_pacemaker_cluster_aws_region
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The AWS region in which the instances to be used for the cluster setup are located.<br>
 Mandatory for cluster nodes setup on AWS EC2 instances.<br>
 
 ### sap_ha_pacemaker_cluster_aws_secret_access_key
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 AWS secret key, paired with the access key for instance control.<br>
 Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
@@ -201,35 +226,38 @@ Mandatory for the cluster nodes setup on AWS EC2 instances, when:<br>
 2. `sap_ha_pacemaker_cluster_aws_credentials_setup` is `true`<br>
 
 ### sap_ha_pacemaker_cluster_aws_vip_update_rt
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 List one more routing table IDs for managing Virtual IP failover through routing table changes.<br>
 Multiple routing tables must be defined as a comma-separated string (no spaces).<br>
 Mandatory for the VIP resource configuration in AWS EC2 environments.<br>
 
 ### sap_ha_pacemaker_cluster_cluster_name
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The name of the pacemaker cluster.<br>
 Inherits the `ha_cluster` LSR native parameter `ha_cluster_cluster_name` if not defined.<br>
 If not defined, the `ha_cluster` Linux System Role default will be used.<br>
 
 ### sap_ha_pacemaker_cluster_cluster_nodes
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 List of cluster nodes and associated attributes to describe the target SAP HA environment.<br>
 This is required for the HANA System Replication configuration.<br>
 Synonym for this parameter is `sap_hana_cluster_nodes`.<br>
 Mandatory to be defined for HANA clusters.<br>
 
-- **hana_site**<br>
+- **hana_site**
 Site of the cluster and/or SAP HANA System Replication node (for example 'DC01').<br>Mandatory for HANA clusters (sudo config for system replication).
-- **node_ip**<br>
+
+- **node_ip**
 IP address of the node used for HANA System Replication.<br>_Optional. Currently not needed/used in cluster configuration._
-- **node_name**<br>
+
+- **node_name**
 Hostname of the cluster node.<br>_Optional. Currently not needed/used in cluster configuration._
-- **node_role**<br>
-_Choices:_ `primary, secondary`<br>
+
+- **node_role**
+_Choices:_ `primary, secondary`
 Role of the defined `node_name` in the SAP HANA cluster setup.<br>There must be only **one** primary, but there can be multiple secondary nodes.<br>_Optional. Currently not needed/used in cluster configuration._
 
 Example:
@@ -241,13 +269,13 @@ sap_ha_pacemaker_cluster_cluster_nodes:
     node_role: primary
   - hana_site: DC02
 ```
-### sap_ha_pacemaker_cluster_cluster_properties
-- _Type:_ `dict`<br>
 
-Standard pacemaker cluster properties are configured with recommended settings for cluster node fencing.<br>
+### sap_ha_pacemaker_cluster_cluster_properties
+- _Type:_ `dict`
+
+Optional configuration of cluster properties (cib-bootstrap-options).<br>
+Default values are applied by Operating System and Platform, if the variable is not defined.<br>
 When no STONITH resource is defined, STONITH will be disabled and a warning displayed.<br>
-Default values are predefined by OS and Platform if the variable is not defined.<br>
-Some mandatory properties are appended, if not defined.<br>
 
 Example:
 ```yaml
@@ -255,9 +283,10 @@ sap_ha_pacemaker_cluster_cluster_properties:
   stonith-enabled: true
   stonith-timeout: 150
 ```
+
 ### sap_ha_pacemaker_cluster_corosync_totem
-- _Type:_ `dict`<br>
-- _Default:_ `Specified in Operating System and Platform variables.`<br>
+- _Type:_ `dict`
+- _Default:_ `Specified in Operating System and Platform variables.`
 
 Define dictionary of options for corosync totem configuration.<br>
 
@@ -271,9 +300,10 @@ sap_ha_pacemaker_cluster_corosync_totem:
     token: 5000
     token_retransmits_before_loss_const: 10
 ```
+
 ### sap_ha_pacemaker_cluster_corosync_transport
-- _Type:_ `dict`<br>
-- _Default:_ `Specified in Operating System variables.`<br>
+- _Type:_ `dict`
+- _Default:_ `Specified in Operating System variables.`
 
 Define dictionary of options for corosync transport configuration.<br>
 Available options are defined in (LSR `ha_cluster` documentation)[https://github.com/linux-system-roles/ha_cluster/blob/main/README.md].<br>
@@ -288,9 +318,10 @@ sap_ha_pacemaker_cluster_corosync_transport:
       value: aes256
   type: knet
 ```
+
 ### sap_ha_pacemaker_cluster_create_config_dest
-- _Type:_ `string`<br>
-- _Default:_ `review_resource_config.yml`<br>
+- _Type:_ `string`
+- _Default:_ `review_resource_config.yml`
 
 The pacemaker cluster resource configuration optionally created by this role will be saved in a Yaml file in the current working directory.<br>
 Requires `sap_ha_pacemaker_cluster_create_config_varfile` to be enabled for generating the output file.<br>
@@ -298,8 +329,8 @@ Specify a path/filename to save the file in a custom location.<br>
 The file can be used as input vars file for an Ansible playbook running the 'ha_cluster' Linux System Role.<br>
 
 ### sap_ha_pacemaker_cluster_create_config_varfile
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 When enabled, all cluster configuration parameters this role constructs for executing the 'ha_cluster' Linux System role will be written into a file in Yaml format.<br>
 This allows using the output file later as input file for additional custom steps using the 'ha_cluster' role and covering the resource configuration in a cluster that was set up using this 'sap_ha_pacemaker_cluster' role.<br>
@@ -307,40 +338,38 @@ When enabled this parameters file is also created when the playbook is run in ch
 WARNING! This report may include sensitive details like secrets required for certain cluster resources!<br>
 
 ### sap_ha_pacemaker_cluster_enable_cluster_connector
-- _Type:_ `bool`<br>
-- _Default:_ `True`<br>
+- _Type:_ `bool`
+- _Default:_ `true`
 
 Enables/Disables the SAP HA Interface for SAP ABAP application server instances, also known as `sap_cluster_connector`.<br>
 Set this parameter to 'false' if the SAP HA interface should not be installed and configured.<br>
 
 ### sap_ha_pacemaker_cluster_extra_packages
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 Additional extra packages to be installed, for instance specific resource packages.<br>
 For SAP clusters configured by this role, the relevant standard packages for the target scenario are automatically included.<br>
 
 ### sap_ha_pacemaker_cluster_fence_agent_packages
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 Additional fence agent packages to be installed.<br>
-This is automatically combined with default packages in:<br>
-`__sap_ha_pacemaker_cluster_fence_agent_packages_minimal`<br>
-`__sap_ha_pacemaker_cluster_fence_agent_packages_platform`<br>
+This is automatically combined with default OS and Platform specific packages.<br>
 
 ### sap_ha_pacemaker_cluster_gcp_project
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Google Cloud project name in which the target instances are installed.<br>
 Mandatory for the cluster setup on GCP instances.<br>
 
 ### sap_ha_pacemaker_cluster_gcp_region_zone
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Google Cloud Platform region zone ID.<br>
 Mandatory for the cluster setup on GCP instances.<br>
 
 ### sap_ha_pacemaker_cluster_ha_cluster
-- _Type:_ `dict`<br>
+- _Type:_ `dict`
 
 The `ha_cluster` LSR native parameter `ha_cluster` can be used as a synonym.<br>
 Optional _**host_vars**_ parameter - if defined it must be set for each node.<br>
@@ -356,35 +385,36 @@ sap_ha_pacemaker_cluster_ha_cluster:
     - 192.168.2.10
   node_name: nodeA
 ```
+
 ### sap_ha_pacemaker_cluster_hacluster_user_password <sup>required</sup>
-- **Required**<br>
-- _Type:_ `string`<br>
+- **Required**
+- _Type:_ `string`
 
 The password of the `hacluster` user which is created during pacemaker installation.<br>
 Inherits the value of `ha_cluster_hacluster_password`, when defined.<br>
 
 ### sap_ha_pacemaker_cluster_hana_automated_register
-- _Type:_ `bool`<br>
-- _Default:_ `True`<br>
+- _Type:_ `bool`
+- _Default:_ `true`
 
 Parameter for the 'SAPHana' cluster resource.<br>
 Define if a former primary should be re-registered automatically as secondary.<br>
 
 ### sap_ha_pacemaker_cluster_hana_colocation_hana_vip_primary_name
-- _Type:_ `string`<br>
-- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_primary`<br>
+- _Type:_ `string`
+- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_primary`
 
 Customize the cluster constraint name for VIP and SAPHana primary clone colocation.<br>
 
 ### sap_ha_pacemaker_cluster_hana_colocation_hana_vip_secondary_name
-- _Type:_ `string`<br>
-- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_readonly`<br>
+- _Type:_ `string`
+- _Default:_ `col_saphana_vip_<SID>_HDB<Instance Number>_readonly`
 
 Customize the cluster constraint name for VIP and SAPHana secondary clone colocation.<br>
 
 ### sap_ha_pacemaker_cluster_hana_duplicate_primary_timeout
-- _Type:_ `int`<br>
-- _Default:_ `7200`<br>
+- _Type:_ `int`
+- _Default:_ `7200`
 
 Parameter for the 'SAPHana' cluster resource.<br>
 Time difference needed between to primary time stamps, if a dual-primary situation occurs.<br>
@@ -392,40 +422,40 @@ If the time difference is less than the time gap, then the cluster holds one or 
 This is to give an admin a chance to react on a failover. A failed former primary will be registered after the time difference is passed.<br>
 
 ### sap_ha_pacemaker_cluster_hana_filesystem_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `cln_SAPHanaFil_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `cln_SAPHanaFil_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Filesystem clone.<br>
 
 ### sap_ha_pacemaker_cluster_hana_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPHanaFil_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPHanaFil_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Filesystem.<br>
 
 ### sap_ha_pacemaker_cluster_hana_global_ini_path
-- _Type:_ `string`<br>
-- _Default:_ `/usr/sap/<SID>/SYS/global/hdb/custom/config/global.ini`<br>
+- _Type:_ `string`
+- _Default:_ `/usr/sap/<SID>/SYS/global/hdb/custom/config/global.ini`
 
 Path with location of global.ini for srHook update<br>
 
 ### sap_ha_pacemaker_cluster_hana_hook_chksrv
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 Controls if ChkSrv srHook is enabled during srHook creation.<br>
 It is ignored when sap_ha_pacemaker_cluster_hana_hooks is defined.<br>
 
 ### sap_ha_pacemaker_cluster_hana_hook_tkover
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 Controls if TkOver srHook is enabled during srHook creation.<br>
 It is ignored when sap_ha_pacemaker_cluster_hana_hooks is defined.<br>
 
 ### sap_ha_pacemaker_cluster_hana_hooks
-- _Type:_ `list`<br>
-- _Default:_ `[]`<br>
+- _Type:_ `list`
+- _Default:_ `[]`
 
 Customize required list of SAP HANA Hooks<br>
 Mandatory to include SAPHanaSR srHook in list.<br>
@@ -436,77 +466,78 @@ Example:
 ```yaml
 sap_ha_pacemaker_cluster_hana_hooks:
   - options:
-    - name: execution_order
-      value: 1
+      - name: execution_order
+        value: 1
     path: /usr/share/SAPHanaSR/
     provider: SAPHanaSR
   - options:
-    - name: execution_order
-      value: 2
+      - name: execution_order
+        value: 2
     path: /usr/share/SAPHanaSR/
     provider: susTkOver
   - options:
-    - name: execution_order
-      value: 3
-    - name: action_on_lost
-      value: stop
+      - name: execution_order
+        value: 3
+      - name: action_on_lost
+        value: stop
     path: /usr/share/SAPHanaSR/
     provider: susChkSrv
 ```
+
 ### sap_ha_pacemaker_cluster_hana_instance_nr
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The instance number of the SAP HANA database which this role will configure in the cluster.<br>
 Inherits the value of `sap_hana_instance_number`, when defined.<br>
 Mandatory for SAP HANA cluster scenarios.<br>
 
 ### sap_ha_pacemaker_cluster_hana_order_hana_vip_primary_name
-- _Type:_ `string`<br>
-- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_primary`<br>
+- _Type:_ `string`
+- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_primary`
 
 Customize the cluster constraint name for VIP and SAPHana primary clone order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_order_hana_vip_secondary_name
-- _Type:_ `string`<br>
-- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_readonly`<br>
+- _Type:_ `string`
+- _Default:_ `ord_saphana_vip_<SID>_HDB<Instance Number>_readonly`
 
 Customize the cluster constraint name for VIP and SAPHana secondary clone order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_order_topology_hana_name
-- _Type:_ `string`<br>
-- _Default:_ `ord_saphana_saphanatop_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `ord_saphana_saphanatop_<SID>_HDB<Instance Number>`
 
 Customize the cluster constraint name for SAPHana and Topology order.<br>
 
 ### sap_ha_pacemaker_cluster_hana_prefer_site_takeover
-- _Type:_ `bool`<br>
-- _Default:_ `True`<br>
+- _Type:_ `bool`
+- _Default:_ `true`
 
 Parameter for the 'SAPHana' cluster resource.<br>
 Set to "false" if the cluster should first attempt to restart the instance on the same node.<br>
 When set to "true" (default) a failover to secondary will be initiated on resource failure.<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_clone_msl_name
-- _Type:_ `string`<br>
-- _Default:_ `msl_SAPHana_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `msl_SAPHana_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA DB resource master slave clone.<br>
 Master Slave clone is specific to Classic SAPHana resource on SUSE (non-angi).<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `cln_SAPHana_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `cln_SAPHana_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA DB resource clone.<br>
 
 ### sap_ha_pacemaker_cluster_hana_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPHana_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPHana_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA DB resource.<br>
 
 ### sap_ha_pacemaker_cluster_hana_sid
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The SAP HANA System ID (SID) of the instance that will be configured in the cluster.<br>
 The SID must follow SAP specifications - see SAP Note 1979280.<br>
@@ -514,383 +545,383 @@ Inherits the value of `sap_hana_sid`, when defined.<br>
 Mandatory for SAP HANA cluster scenarios.<br>
 
 ### sap_ha_pacemaker_cluster_hana_topology_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `cln_SAPHanaTop_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `cln_SAPHanaTop_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Topology resource clone.<br>
 
 ### sap_ha_pacemaker_cluster_hana_topology_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPHanaTop_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPHanaTop_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Topology resource.<br>
 
 ### sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `<cln|mst>_SAPHanaCon_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `<cln|mst>_SAPHanaCon_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Controller clone.<br>
 
 ### sap_ha_pacemaker_cluster_hanacontroller_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPHanaCon_<SID>_HDB<Instance Number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPHanaCon_<SID>_HDB<Instance Number>`
 
 Customize the cluster resource name of the SAP HANA Controller.<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_hana_primary_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_HDB<Instance Number>_primary`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_HDB<Instance Number>_primary`
 
 Name of the Virtual IP Health Check resource for primary HANA instance.<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_HDB<Instance Number>_readonly`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_HDB<Instance Number>_readonly`
 
 Name of the Virtual IP Health Check resource for read-only HANA instance.<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_nwas_abap_aas_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_AAS<AAS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_AAS<AAS-instance-number>`
 
 Name of the Virtual IP Health Check resource for NetWeaver AAS.<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_nwas_abap_pas_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_PAS<PAS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_PAS<PAS-instance-number>`
 
 Name of the Virtual IP Health Check resource for NetWeaver PAS.<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_nwas_ascs_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_ASCS<ASCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the Virtual IP Health Check resource for NetWeaver ABAP Central Services (ASCS).<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_nwas_ers_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_ERS<ERS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_ERS<ERS-instance-number>`
 
 Name of the Virtual IP Health Check resource for NetWeaver Enqueue Replication Service (ERS).<br>
 
 ### sap_ha_pacemaker_cluster_healthcheck_nwas_scs_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_health_check_<SID>_SCS<SCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_health_check_<SID>_SCS<SCS-instance-number>`
 
 Name of the Virtual IP Health Check resource for NetWeaver Central Services (SCS).<br>
 
 ### sap_ha_pacemaker_cluster_host_type
-- _Type:_ `list`<br>
-- _Default:_ `hana_scaleup_perf`<br>
-- _Choices:_ `hana_scaleup_perf, nwas_abap_ascs_ers, nwas_java_scs_ers`<br>
+- _Type:_ `list`
+- _Default:_ `hana_scaleup_perf`
+- _Choices:_ `hana_scaleup_perf, nwas_abap_ascs_ers, nwas_java_scs_ers`
 
 The SAP landscape to for which the cluster is to be configured.<br>
 The default is a 2-node SAP HANA scale-up cluster.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_api_key
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The API key which is required to allow the control of instances (for example for fencing operations).<br>
 Mandatory for the cluster setup on IBM Cloud Virtual Server instances or IBM Power Virtual Server on IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_powervs_api_type
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 IBM Power Virtual Server API Endpoint type (public or private) dependent on network interface attachments for the target instances.<br>
 Mandatory for the cluster setup on IBM Power Virtual Server from IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_powervs_forward_proxy_url
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 IBM Power Virtual Server forward proxy url when IBM Power Virtual Server API Endpoint type is set to private.<br>
 When public network interface, can be ignored.<br>
 When private network interface, mandatory for the cluster setup on IBM Power Virtual Server from IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_powervs_workspace_crn
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 IBM Power Virtual Server Workspace service cloud resource name (CRN) identifier which contains the target instances<br>
 Mandatory for the cluster setup on IBM Power Virtual Server from IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_ibmcloud_region
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The IBM Cloud VS region name in which the instances are running.<br>
 Mandatory for the cluster setup on IBM Cloud Virtual Server instances or IBM Power Virtual Server on IBM Cloud.<br>
 
 ### sap_ha_pacemaker_cluster_msazure_resource_group
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Resource group name/ID in which the target instances are defined.<br>
 Mandatory for the cluster setup on MS Azure instances.<br>
 
 ### sap_ha_pacemaker_cluster_msazure_subscription_id
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Subscription ID of the MS Azure environment containing the target instances.<br>
 Mandatory for the cluster setup on MS Azure instances.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_aas_instance_nr
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Instance number of the NetWeaver ABAP AAS instance.<br>
 Mandatory for NetWeaver AAS cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_abap_pas_instance_nr
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Instance number of the NetWeaver ABAP PAS instance.<br>
 Mandatory for NetWeaver PAS cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ascs_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_fs_<SID>_ASCS<ASCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_fs_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the filesystem resource for the ASCS instance.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ascs_instance_nr
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Instance number of the NetWeaver ABAP Central Services (ASCS) instance.<br>
 Mandatory for NetWeaver ASCS/ERS cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The name of the ASCS instance, typically the profile name.<br>
 Mandatory for the NetWeaver ASCS/ERS cluster setup<br>
 Recommended format <SID>_ASCS<ASCS-instance-number>_<ASCS-hostname><br>
 
 ### sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPInstance_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the ASCS instance resource.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_start_profile_string
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The full path and name of the ASCS instance profile.<br>
 Mandatory for the NetWeaver ASCS/ERS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ascs_sapstartsrv_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPStartSrv_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the ASCS SAPStartSrv resource for simple mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_colocation_ascs_no_ers_name
-- _Type:_ `string`<br>
-- _Default:_ `col_ascs_separate_<SID>`<br>
+- _Type:_ `string`
+- _Default:_ `col_ascs_separate_<SID>`
 
 Customize the cluster constraint name for ASCS and ERS separation colocation.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_colocation_scs_no_ers_name
-- _Type:_ `string`<br>
-- _Default:_ `col_ascs_separate_<SID>`<br>
+- _Type:_ `string`
+- _Default:_ `col_ascs_separate_<SID>`
 
 Customize the cluster constraint name for SCS and ERS separation colocation.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_ensa1
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 The standard NetWeaver Central Services cluster will be set up as ENSA2.<br>
 Set this parameter to 'true' to configure it as ENSA1.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_ers_simple_mount
-- _Type:_ `bool`<br>
-- _Default:_ `True`<br>
+- _Type:_ `bool`
+- _Default:_ `true`
 
 Enables preferred method for Central Services (ASCS or SCS) ENSA2 clusters - Simple Mount.<br>
 Set this parameter to 'true' to configure ENSA2 Simple Mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_group_stickiness
-- _Type:_ `string`<br>
-- _Default:_ `3000`<br>
+- _Type:_ `string`
+- _Default:_ `3000`
 
 NetWeaver Central Services (ASCS and SCS) resource group stickiness.<br>
 Defines how sticky is Central Services group to the node it was started on.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_automatic_recover_bool
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 NetWeaver Central Services (ASCS and SCS) instance resource option "AUTOMATIC_RECOVER".<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_failure_timeout
-- _Type:_ `string`<br>
-- _Default:_ `60`<br>
+- _Type:_ `string`
+- _Default:_ `60`
 
 NetWeaver Central Services (ASCS and SCS) instance failure-timeout attribute.<br>
 Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_ensa1_migration_threshold
-- _Type:_ `string`<br>
-- _Default:_ `1`<br>
+- _Type:_ `string`
+- _Default:_ `1`
 
 NetWeaver Central Services (ASCS and SCS) instance migration-threshold setting attribute.<br>
 Only used for ENSA1 setups (see `sap_ha_pacemaker_cluster_nwas_cs_ensa1`). Default setup is ENSA2.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_cs_sapinstance_resource_stickiness
-- _Type:_ `string`<br>
-- _Default:_ `5000`<br>
+- _Type:_ `string`
+- _Default:_ `5000`
 
 NetWeaver Central Services (ASCS and SCS) instance resource stickiness attribute.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_fs_<SID>_ERS<ERS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_fs_<SID>_ERS<ERS-instance-number>`
 
 Name of the filesystem resource for the ERS instance.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_instance_nr
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Instance number of the NetWeaver Enqueue Replication Service (ERS) instance.<br>
 Mandatory for NetWeaver ASCS/ERS and SCS/ERS cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_automatic_recover_bool
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 NetWeaver ERS instance resource option "AUTOMATIC_RECOVER".<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_instance_name
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The name of the ERS instance, typically the profile name.<br>
 Mandatory for the NetWeaver ASCS/ERS and SCS/ERS clusters.<br>
 Recommended format <SID>_ERS<ERS-instance-number>_<ERS-hostname>.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPInstance_<SID>_ERS<ERS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPInstance_<SID>_ERS<ERS-instance-number>`
 
 Name of the ERS instance resource.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_sapinstance_start_profile_string
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The full path and name of the ERS instance profile.<br>
 Mandatory for the NetWeaver ASCS/ERS and SCS/ERS clusters.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_ers_sapstartsrv_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPStartSrv_<SID>_ERS<ERS-instance-number>`
 
 Name of the ERS SAPstartSrv resource for simple mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_order_ascs_first_name
-- _Type:_ `string`<br>
-- _Default:_ `ord_ascs_first_<SID>`<br>
+- _Type:_ `string`
+- _Default:_ `ord_ascs_first_<SID>`
 
 Customize the cluster constraint name for ASCS starting before ERS order.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_order_scs_first_name
-- _Type:_ `string`<br>
-- _Default:_ `ord_ascs_first_<SID>`<br>
+- _Type:_ `string`
+- _Default:_ `ord_ascs_first_<SID>`
 
 Customize the cluster constraint name for SCS starting before ERS order.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `cln_fs_<SID>_sapmnt`<br>
+- _Type:_ `string`
+- _Default:_ `cln_fs_<SID>_sapmnt`
 
 Filesystem resource clone name for the shared filesystem /sapmnt.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sapmnt_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_fs_<SID>_sapmnt`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_fs_<SID>_sapmnt`
 
 Filesystem resource name for the shared filesystem /sapmnt.<br>
 Optional, this is typically managed by the OS, but can as well be added to the cluster configuration.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_scs_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_fs_<SID>_SCS<SCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_fs_<SID>_SCS<SCS-instance-number>`
 
 Name of the filesystem resource for the SCS instance.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_scs_instance_nr
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Instance number of the NetWeaver Central Services (SCS) instance.<br>
 Mandatory for NetWeaver SCS/ERS cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_scs_sapinstance_instance_name
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The name of the SCS instance, typically the profile name.<br>
 Mandatory for the NetWeaver SCS/ERS cluster setup<br>
 Recommended format <SID>_SCS<SCS-instance-number>_<SCS-hostname><br>
 
 ### sap_ha_pacemaker_cluster_nwas_scs_sapinstance_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPInstance_<SID>_SCS<SCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPInstance_<SID>_SCS<SCS-instance-number>`
 
 Name of the SCS instance resource.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_scs_sapinstance_start_profile_string
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The full path and name of the SCS instance profile.<br>
 Mandatory for the NetWeaver SCS/ERS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_scs_sapstartsrv_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_SAPStartSrv_<SID>_SCS<SCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_SAPStartSrv_<SID>_SCS<SCS-instance-number>`
 
 Name of the SCS SAPStartSrv resource for simple mount.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed
-- _Type:_ `bool`<br>
-- _Default:_ `False`<br>
+- _Type:_ `bool`
+- _Default:_ `false`
 
 Change this parameter to 'true' if the 3 shared filesystems `/usr/sap/trans`, `/usr/sap/<SID>/SYS` and '/sapmnt' shall be configured as cloned cluster resources.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sid
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 System ID (SID) of the NetWeaver instances in Capital letters.<br>
 Defaults to `sap_swpm_sid` if defined.<br>
 Mandatory for NetWeaver cluster scenarios.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `cln_fs_<SID>_sys`<br>
+- _Type:_ `string`
+- _Default:_ `cln_fs_<SID>_sys`
 
 Filesystem resource clone name for the shared filesystem /usr/sap/<SID>/SYS.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_sys_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_fs_<SID>_sys`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_fs_<SID>_sys`
 
 Filesystem resource name for the transports filesystem /usr/sap/<SID>/SYS.<br>
 Optional, this is typically managed by the OS, but can as well be added to the cluster configuration.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_clone_name
-- _Type:_ `string`<br>
-- _Default:_ `cln_fs_<SID>_trans`<br>
+- _Type:_ `string`
+- _Default:_ `cln_fs_<SID>_trans`
 
 Filesystem resource clone name for the shared filesystem /usr/sap/trans.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_nwas_transports_filesystem_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_fs_<SID>_trans`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_fs_<SID>_trans`
 
 Filesystem resource name for the transports filesystem /usr/sap/trans.<br>
 Optional, this is typically managed by the OS, but can as well be added to the cluster configuration.<br>
 Enable this resource setup using `sap_ha_pacemaker_cluster_nwas_shared_filesystems_cluster_managed`.<br>
 
 ### sap_ha_pacemaker_cluster_operation_defaults
-- _Type:_ `dict`<br>
-- _Default:_ `{'record-pending': True, 'timeout': 600}`<br>
+- _Type:_ `dict`
+- _Default:_ `{'record-pending': True, 'timeout': 600}`
 
 Set default operation parameters that will be valid for all pacemaker resources.<br>
 
@@ -900,9 +931,10 @@ sap_ha_pacemaker_cluster_operation_defaults:
   record-pending: true
   timeout: 600
 ```
+
 ### sap_ha_pacemaker_cluster_resource_defaults
-- _Type:_ `dict`<br>
-- _Default:_ `{'migration-threshold': 5000, 'resource-stickiness': 3000}`<br>
+- _Type:_ `dict`
+- _Default:_ `{'migration-threshold': 5000, 'resource-stickiness': 3000}`
 
 Set default parameters that will be valid for all pacemaker resources.<br>
 
@@ -912,15 +944,16 @@ sap_ha_pacemaker_cluster_resource_defaults:
   migration-threshold: 5000
   resource-stickiness: 1000
 ```
+
 ### sap_ha_pacemaker_cluster_saphanasr_angi_detection
-- _Type:_ `string`<br>
-- _Default:_ `True`<br>
+- _Type:_ `string`
+- _Default:_ `true`
 
 Disabling this variable enables to use Classic SAPHanaSR agents even on server, where SAPHanaSR-angi is available.<br>
 Value `false` (Classic) is ignored when only SAPHanaSR-angi packages are available.<br>
 
 ### sap_ha_pacemaker_cluster_sbd_devices
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 Required if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of block devices for Stonith SBD agent<br>
@@ -930,8 +963,9 @@ Example:
 sap_ha_pacemaker_cluster_sbd_devices:
   - /dev/disk/by-id/scsi-3600
 ```
+
 ### sap_ha_pacemaker_cluster_sbd_enabled
-- _Type:_ `bool`<br>
+- _Type:_ `bool`
 
 Set this parameter to 'true' to enable workflow to add Stonith SBD resource.<br>
 Stonith SBD resource has to be provided as part of `sap_ha_pacemaker_cluster_stonith_custom`.<br>
@@ -947,11 +981,12 @@ sap_ha_pacemaker_cluster_stonith_custom:
     id: stonith_sbd
     instance_attrs:
       - attrs:
-        - name: pcmk_delay_max
-          value: 15
+          - name: pcmk_delay_max
+            value: 15
 ```
+
 ### sap_ha_pacemaker_cluster_sbd_options
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of SBD specific options that are added into SBD configuration file.<br>
@@ -962,15 +997,16 @@ sap_ha_pacemaker_cluster_sbd_options:
   - name: startmode
     value: clean
 ```
+
 ### sap_ha_pacemaker_cluster_sbd_watchdog
-- _Type:_ `str`<br>
-- _Default:_ `/dev/watchdog`<br>
+- _Type:_ `str`
+- _Default:_ `/dev/watchdog`
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide watchdog name to override default /dev/watchdog<br>
 
 ### sap_ha_pacemaker_cluster_sbd_watchdog_modules
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 Optional if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of watchdog kernel modules to be loaded (creates /dev/watchdog* devices).<br>
@@ -980,35 +1016,35 @@ Example:
 sap_ha_pacemaker_cluster_sbd_watchdog_modules:
   - softdog
 ```
+
 ### sap_ha_pacemaker_cluster_stonith_custom
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 Custom list of STONITH resource(s) to be configured in the cluster.<br>
 This definition override any defaults the role would apply otherwise.<br>
 Definition follows structure of ha_cluster_resource_primitives in linux-system-roles/ha_cluster<br>
 
-- **agent**<br>
+- **agent**
 **Required**<br>
-_Type:_ `str`<br>
+_Type:_ `str`
 Resource agent name, must contain the prefix "stonith:" to avoid mismatches or failures.
-- **id**<br>
-_Type:_ `str`<br>
+
+- **id**
+**Required**<br>
+_Type:_ `str`
 Parameter `id` is required.<br>Name that will be used as the resource ID (name).
-- **instance_attrs**<br>
-_Type:_ `list`<br>
+
+- **instance_attrs**
+_Type:_ `list`
 Defines resource agent params as list of name/value pairs.<br>Requires the mandatory options for the particular stonith resource agent to be defined, otherwise the setup will fail.<br>Example: stonith:fence_sbd agent requires devices option with list of SBD disks.<br>Example: stonith:external/sbd agent does not require devices option, but `sap_ha_pacemaker_cluster_sbd_devices`.
-- **meta_attrs**<br>
-_Type:_ `list`<br>
+
+- **meta_attrs**
+_Type:_ `list`
 Defines meta attributes as list of name/value pairs.
-- **name**<br>
-_Type:_ `str`<br>
-WARNING! This option will be removed in future release.
-- **operations**<br>
-_Type:_ `list`<br>
+
+- **operations**
+_Type:_ `list`
 Defines list of resource agent operations.
-- **options**<br>
-_Type:_ `dict`<br>
-WARNING! This option will be removed in future release.
 
 Example:
 ```yaml
@@ -1017,30 +1053,31 @@ sap_ha_pacemaker_cluster_stonith_custom:
     id: my-fence-resource
     instance_attrs:
       - attrs:
-        - name: ip
-          value: rhevm-server
-        - name: username
-          value: login-user
-        - name: password
-          value: login-user-password
-        - name: pcmk_host_list
-          value: node1,node2
-        - name: power_wait
-          value: 3
+          - name: ip
+            value: rhevm-server
+          - name: username
+            value: login-user
+          - name: password
+            value: login-user-password
+          - name: pcmk_host_list
+            value: node1,node2
+          - name: power_wait
+            value: 3
     meta_attrs:
       - attrs:
-        - name: target-role
-          value: Started
+          - name: target-role
+            value: Started
     operations:
       - action: start
         attrs:
-        - name: interval
-          value: 0
-        - name: timeout
-          value: 180
+          - name: interval
+            value: 0
+          - name: timeout
+            value: 180
 ```
+
 ### sap_ha_pacemaker_cluster_storage_definition
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 List of filesystem definitions used for filesystem cluster resources.<br>
 Options relevant, see example.<br>
@@ -1068,33 +1105,34 @@ sap_ha_pacemaker_cluster_storage_definition:
     nfs_path: /sapmnt
     nfs_server: nfs-server.example.com:/
 ```
+
 ### sap_ha_pacemaker_cluster_storage_nfs_filesystem_type
-- _Type:_ `string`<br>
-- _Default:_ `nfs`<br>
+- _Type:_ `string`
+- _Default:_ `nfs`
 
 Filesystem type of the NFS filesystems that are part of the cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_storage_nfs_mount_options
-- _Type:_ `string`<br>
-- _Default:_ `defaults`<br>
+- _Type:_ `string`
+- _Default:_ `defaults`
 
 Mount options of the NFS filesystems that are part of the cluster configuration.<br>
 
 ### sap_ha_pacemaker_cluster_storage_nfs_server
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Default address of the NFS server, if not defined individually by filesystem.<br>
 
 ### sap_ha_pacemaker_cluster_system_roles_collection
-- _Type:_ `string`<br>
-- _Default:_ `fedora.linux_system_roles`<br>
+- _Type:_ `string`
+- _Default:_ `fedora.linux_system_roles`
 
 Reference to the Ansible Collection used for the Linux System Roles.<br>
 For community/upstream, use 'fedora.linux_system_roles'.<br>
 For RHEL System Roles for SAP, or Red Hat Automation Hub, use 'redhat.rhel_system_roles'.<br>
 
 ### sap_ha_pacemaker_cluster_vip_client_interface
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 OS device name of the network interface to use for the Virtual IP configuration.<br>
 When there is only one interface on the system, its name will be used by default.<br>
@@ -1102,109 +1140,109 @@ Ensure that same network interface is present on all cluster nodes.<br>
 IPaddr2 resource agent does not require network interface defined (except Google Cloud).<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_primary_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The virtual IP of the primary HANA instance.<br>
 Mandatory parameter for HANA clusters.<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_primary_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_primary`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_primary`
 
 Name of the Virtual IP resource for primary HANA instance.<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_secondary_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 The virtual IP for read-only access to the secondary HANA instance.<br>
 Optional parameter in HANA clusters.<br>
 
 ### sap_ha_pacemaker_cluster_vip_hana_secondary_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_readonly`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_HDB<Instance Number>_readonly`
 
 Name of the Virtual IP resource for read-only HANA instance.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_aas_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Virtual IP of the NetWeaver AAS instance.<br>
 Mandatory for NetWeaver AAS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_aas_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_AAS<AAS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_AAS<AAS-instance-number>`
 
 Name of the Virtual IP resource for NetWeaver AAS.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_pas_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Virtual IP of the NetWeaver PAS instance.<br>
 Mandatory for NetWeaver PAS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_abap_pas_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_PAS<PAS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_PAS<PAS-instance-number>`
 
 Name of the Virtual IP resource for NetWeaver PAS.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_ascs_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Virtual IP of the NetWeaver ABAP Central Services (ASCS) instance.<br>
 Mandatory for NetWeaver ASCS/ERS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_group_name
-- _Type:_ `string`<br>
-- _Default:_ `grp_<SID>_ASCS<ASCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `grp_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the NetWeaver ASCS resource group.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_ascs_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_ASCS<ASCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_ASCS<ASCS-instance-number>`
 
 Name of the Virtual IP resource for NetWeaver ABAP Central Services (ASCS).<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_ers_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Virtual IP of the NetWeaver Enqueue Replication Service (ERS) instance.<br>
 Mandatory for NetWeaver ASCS/ERS and SCS/ERS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_ers_resource_group_name
-- _Type:_ `string`<br>
-- _Default:_ `grp_<SID>_ERS<ERS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `grp_<SID>_ERS<ERS-instance-number>`
 
 Name of the NetWeaver ERS resource group.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_ers_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_ERS<ERS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_ERS<ERS-instance-number>`
 
 Name of the Virtual IP resource for NetWeaver Enqueue Replication Service (ERS).<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_scs_ip_address
-- _Type:_ `string`<br>
+- _Type:_ `string`
 
 Virtual IP of the NetWeaver Central Services (SCS) instance.<br>
 Mandatory for NetWeaver SCS/ERS cluster setup.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_scs_resource_group_name
-- _Type:_ `string`<br>
-- _Default:_ `grp_<SID>_SCS<SCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `grp_<SID>_SCS<SCS-instance-number>`
 
 Name of the NetWeaver SCS resource group.<br>
 
 ### sap_ha_pacemaker_cluster_vip_nwas_scs_resource_name
-- _Type:_ `string`<br>
-- _Default:_ `rsc_vip_<SID>_SCS<SCS-instance-number>`<br>
+- _Type:_ `string`
+- _Default:_ `rsc_vip_<SID>_SCS<SCS-instance-number>`
 
 Name of the Virtual IP resource for NetWeaver Central Services (SCS).<br>
 
 ### sap_ha_pacemaker_cluster_zypper_patterns
-- _Type:_ `list`<br>
+- _Type:_ `list`
 
 (SUSE Specific) Additional zypper patterns to be installed.<br>
 

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -65,7 +65,8 @@ sap_ha_pacemaker_cluster_vip_client_interface: ''
 #       pcmk_host_list: ""
 
 ## The variable 'sap_ha_pacemaker_cluster_cluster_properties' is used to configure cluster properties (e.g. cib-bootstrap-options).
-# NOTE: Default values are defined by Operating System and Platforms, if the variable is not defined.
+# NOTE 1: Default values are defined by Operating System and Platforms, if the variable is not defined.
+# NOTE 2: Configuring wrong properties or disabling fencing can have adverse effects on cluster stability and data integrity.
 # Simpler definition format here which gets transformed into the 'ha_cluster' LSR native 'ha_cluster_cluster_properties' parameter.
 # sap_ha_pacemaker_cluster_cluster_properties:
 #   stonith-enabled: true

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -9,6 +9,12 @@ argument_specs:
 
   main:
     short_description: SAP HA automated cluster setup requirements
+    # This is used to populate beginning of the Role Variables section in README.md
+    description: |
+      Minimum required parameters for all clusters:
+      - [sap_ha_pacemaker_cluster_hacluster_user_password](#sap_ha_pacemaker_cluster_hacluster_user_password)
+
+      Additional minimum requirements depend on the type of cluster setup and on the target platform.
     options:
 
 # Take this template and copy it to the desired place.
@@ -170,8 +176,7 @@ argument_specs:
             description:
               - Parameter `id` is required.
               - Name that will be used as the resource ID (name).
-            # TODO: Enable to remove Tech debt after name and options are removed!
-            # required: true
+            required: true
           agent:
             type: str
             description:
@@ -199,16 +204,6 @@ argument_specs:
             type: list
             description:
               - Defines meta attributes as list of name/value pairs.
-          # TODO: Tech Debt: Remove name and options in next release
-          name:
-            type: str
-            description:
-              - WARNING! This option will be removed in future release.
-          # TODO: Tech Debt: Remove name and options in next release
-          options:
-            type: dict
-            description:
-              - WARNING! This option will be removed in future release.
 
         example:
           sap_ha_pacemaker_cluster_stonith_custom:
@@ -298,11 +293,9 @@ argument_specs:
       sap_ha_pacemaker_cluster_cluster_properties:
         type: dict
         description:
-          - Standard pacemaker cluster properties are configured with recommended settings for
-            cluster node fencing.
+          - Optional configuration of cluster properties (cib-bootstrap-options).
+          - Default values are applied by Operating System and Platform, if the variable is not defined.
           - When no STONITH resource is defined, STONITH will be disabled and a warning displayed.
-          - Default values are predefined by OS and Platform if the variable is not defined.
-          - Some mandatory properties are appended, if not defined.
 
         example:
           sap_ha_pacemaker_cluster_cluster_properties:
@@ -380,9 +373,7 @@ argument_specs:
         type: list
         description:
           - Additional fence agent packages to be installed.
-          - "This is automatically combined with default packages in:"
-          - "`__sap_ha_pacemaker_cluster_fence_agent_packages_minimal`"
-          - "`__sap_ha_pacemaker_cluster_fence_agent_packages_platform`"
+          - "This is automatically combined with default OS and Platform specific packages."
 
       sap_ha_pacemaker_cluster_zypper_patterns:
         type: list

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -79,7 +79,7 @@
       | unique }}"
 
 # Prepare cluster properties variable with either:
-# - User provided 'sap_ha_pacemaker_cluster_cluster_properties' if defined and not empty.
+# - User provided 'sap_ha_pacemaker_cluster_cluster_properties' if defined.
 # - Platform specific defaults, if defined.
 # - OS specific defaults.
 # Combine prioritizes platform specific over OS specific.
@@ -87,7 +87,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_properties:
       "{{ sap_ha_pacemaker_cluster_cluster_properties
-        if sap_ha_pacemaker_cluster_cluster_properties is defined and sap_ha_pacemaker_cluster_cluster_properties | length > 0
+        if sap_ha_pacemaker_cluster_cluster_properties is defined
         else __sap_ha_pacemaker_cluster_cluster_properties_default | d({})
           | combine(__sap_ha_pacemaker_cluster_cluster_properties_platform | d({})) }}"
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_common.yml
@@ -70,39 +70,26 @@
 
 # __sap_ha_pacemaker_cluster_fence_agent_packages loaded from ha_cluster is not included,
 # because it would still not be used due to precedence.
-# TODO: Remove Tech debt conditionals in future for deprecated var 'sap_ha_pacemaker_cluster_fence_agent_minimal_packages'
 - name: "SAP HA Prepare Pacemaker - Combine fence agent packages lists"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_fence_agent_packages: "{{
-      (__sap_ha_pacemaker_cluster_fence_agent_packages_minimal_combined
+      (__sap_ha_pacemaker_cluster_fence_agent_packages_minimal
       + __sap_ha_pacemaker_cluster_fence_agent_packages_platform
       + sap_ha_pacemaker_cluster_fence_agent_packages)
       | unique }}"
-  vars:
-    # Tech debt for sap_ha_pacemaker_cluster_fence_agent_minimal_packages
-    __sap_ha_pacemaker_cluster_fence_agent_packages_minimal_combined:
-      "{{ __sap_ha_pacemaker_cluster_fence_agent_packages_minimal
-       + sap_ha_pacemaker_cluster_fence_agent_minimal_packages
-        if (sap_ha_pacemaker_cluster_fence_agent_minimal_packages is defined
-          and sap_ha_pacemaker_cluster_fence_agent_minimal_packages | length > 0
-          and sap_ha_pacemaker_cluster_fence_agent_minimal_packages is iterable)
-        else __sap_ha_pacemaker_cluster_fence_agent_packages_minimal }}"
-
 
 # Prepare cluster properties variable with either:
 # - User provided 'sap_ha_pacemaker_cluster_cluster_properties' if defined and not empty.
 # - Platform specific defaults, if defined.
 # - OS specific defaults.
-# If the variable 'ha_cluster_properties' is defined, it will append only missing keys.
+# Combine prioritizes platform specific over OS specific.
 - name: "SAP HA Prepare Pacemaker - Prepare cluster properties variable"
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_properties:
       "{{ sap_ha_pacemaker_cluster_cluster_properties
         if sap_ha_pacemaker_cluster_cluster_properties is defined and sap_ha_pacemaker_cluster_cluster_properties | length > 0
-        else (__sap_ha_pacemaker_cluster_cluster_properties_platform
-          if __sap_ha_pacemaker_cluster_cluster_properties_platform is defined
-          else __sap_ha_pacemaker_cluster_cluster_properties_default) }}"
-
+        else __sap_ha_pacemaker_cluster_cluster_properties_default | d({})
+          | combine(__sap_ha_pacemaker_cluster_cluster_properties_platform | d({})) }}"
 
 # Prepare corosync totem variable with either:
 # - User provided 'sap_ha_pacemaker_cluster_corosync_totem' if present

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -1,17 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-# Show warning and disable fencing if either user or default STONITH resources are not defined.
-- name: Block when no STONITH resources are defined
-  when:
-    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length == 0
-    - __sap_ha_pacemaker_cluster_stonith_default | d({}) | length == 0
+# Default STONITH is predefined by platform, but it can be controlled by 'sap_ha_pacemaker_cluster_cluster_properties'.
+
+# Show warning and disable fencing if default STONITH resources are not defined.
+# NOTE: This block will never trigger for default STONITH unless dictionary is missing from platform vars.
+- name: Block when STONITH list is empty
+  when: __sap_ha_pacemaker_cluster_stonith_default | d({}) | length == 0
   block:
 
     # Ensure that property 'stonith-enabled' is set to 'false' if no Stonith resources are defined.
-    # NOTE: We cannot allow user set 'stonith-enabled' 'true' if there are no fencing resources.
+    # STONITH property will be disabled only if 'sap_ha_pacemaker_cluster_cluster_properties' is not defined.
     - name: "SAP HA Prepare Pacemaker - (STONITH) Set to disabled when no fencing resource is defined"
-      when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+      when:
+        - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+        - sap_ha_pacemaker_cluster_cluster_properties is not defined  # We cannot append to user defined properties.
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_cluster_properties:
           "{{ __sap_ha_pacemaker_cluster_cluster_properties | combine({'stonith-enabled': false}) }}"
@@ -30,13 +33,12 @@
 # We will be adding properties only if user defined no custom cluster properties.
 # This enables us to allow even test scenarios, with overrides of cluster properties.
 # NOTE: Reversed combine ensures that OS and platform defaults are retained.
-- name: Block when no sap_ha_pacemaker_cluster_cluster_properties is not defined or empty
+- name: Block when sap_ha_pacemaker_cluster_cluster_properties is undefined
   when:
     - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
-    - sap_ha_pacemaker_cluster_cluster_properties | d([]) | length == 0
+    - sap_ha_pacemaker_cluster_cluster_properties is not defined  # We cannot append to user defined properties.
     # Ensure that we do not set it when STONITH resources are not defined.
-    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
-      or __sap_ha_pacemaker_cluster_stonith_default | d({}) | length > 0
+    - __sap_ha_pacemaker_cluster_stonith_default | d({}) | length > 0
   block:
     ### SAP HANA Scale-Out
     # TODO: Enable and update during implementation of Scale-Out.
@@ -78,29 +80,23 @@
         __sap_ha_pacemaker_cluster_cluster_properties:
           "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
 
+    - name: "SAP HA Prepare Pacemaker - Warning when pcmk_delay_max is missing"
+      when:
+        - __sap_ha_pacemaker_cluster_stonith_default['instance_attrs'][0]['attrs'] | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0
+      ansible.builtin.debug:
+        msg: |
+          WARNING: The STONITH resource is missing 'pcmk_delay_max'!
 
-# This complicated conditional will check if 'pcmk_delay_max' is defined in either:
-# - custom list of dictionaries, flattened to check all instance_attrs and first attrs keys.
-# - default dictionary under instance_attrs and first attrs key.
-- name: "SAP HA Prepare Pacemaker - Warning when pcmk_delay_max is missing"
-  when:
-    - (sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
-      and sap_ha_pacemaker_cluster_stonith_custom | map(attribute='instance_attrs', default=[]) | flatten
-        | map(attribute='attrs', default=[]) | flatten | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0)
-      or (__sap_ha_pacemaker_cluster_stonith_default | d([]) | length > 0
-        and __sap_ha_pacemaker_cluster_stonith_default['instance_attrs'][0]['attrs'] | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0)
-  ansible.builtin.debug:
-    msg: |
-      WARNING: The STONITH resource is missing 'pcmk_delay_max'!
-
-      Without a delay, both cluster nodes may attempt to fence each other simultaneously
-      during a split-brain event ("Double STONITH"), leading to a total cluster outage.
-      Add pcmk_delay_max=15 (or similar) to STONITH resource defined in the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+          Without a delay, both cluster nodes may attempt to fence each other simultaneously
+          during a split-brain event ("Double STONITH"), leading to a total cluster outage.
+          Add pcmk_delay_max=15 (or similar) to STONITH resource defined in the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
 
 
 # Prepare structure compatible with the variable 'ha_cluster_cluster_properties'.
 - name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
-  when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+  when:
+    - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+    - sap_ha_pacemaker_cluster_cluster_properties is not defined  # We cannot append to user defined properties.
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_properties:
       - attrs: |-
@@ -120,9 +116,7 @@
 # and create location constraint for them.
 - name: Block for combining default STONITH resources and creating constraints
   when:
-    - __sap_ha_pacemaker_cluster_stonith_default is mapping
-    - __sap_ha_pacemaker_cluster_stonith_default | length > 0
-    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length == 0
+    - __sap_ha_pacemaker_cluster_stonith_default | d({}) | length > 0
   block:
 
     - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resource definition from platform default"
@@ -163,84 +157,6 @@
         - __port_name is defined
         - __port_name | length > 0
         - __port_name in ansible_play_hosts_all
-
-
-# SBD Configuration is executed only when all conditions are met:
-# sap_ha_pacemaker_cluster_sbd_enabled is true
-# sap_ha_pacemaker_cluster_sbd_devices is defined, list and not empty
-# sap_ha_pacemaker_cluster_stonith_custom is defined, list and not empty
-# __sap_ha_pacemaker_cluster_sbd_enabled is not defined
-- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Prepare SBD configuration"
-  when:
-    - ha_cluster_sbd_enabled is not defined  # We cannot overwrite due to precedence.
-    - sap_ha_pacemaker_cluster_sbd_enabled | d(false)
-    - sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0
-    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
-  block:
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create sbd_options"
-      when:
-        - ha_cluster_sbd_options is not defined
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_sbd_options: >-
-          {%- if sap_ha_pacemaker_cluster_sbd_options | d([]) | length > 0 -%}
-            {{ sap_ha_pacemaker_cluster_sbd_options }}
-          {%- else -%}
-            {{ [{'name': 'startmode', 'value': __sbd_startmode}] }}
-          {%- endif -%}
-      vars:
-        __sbd_startmode: "{{ 'clean' if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0 else 'always' }}"
-
-
-    # Create dictionary with SBD specific parameters for ha_cluster
-    # Omit parameters if they are already present in provided dictionary sap_ha_pacemaker_cluster_ha_cluster
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
-          {{
-            dict(
-              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices
-                if sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0 and not __ha_cluster_sbd_devices_exists
-                else omit),
-              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
-                if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
-                else omit),
-              sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
-                if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
-                else omit)
-            )
-          }}
-      vars:
-        # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
-        __ha_cluster_sbd_devices_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | d([]) | length > 0 else false }}"
-        __ha_cluster_sbd_watchdog_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | d([]) | length > 0 else false }}"
-        __ha_cluster_sbd_watchdog_modules_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | d([]) | length > 0 else false }}"
-
-
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_fence_agent_packages:
-          "{{ __sap_ha_pacemaker_cluster_fence_agent_packages + ['sbd'] }}"
-
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set __sap_ha_pacemaker_cluster_sbd_enabled"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_sbd_enabled: true
-
-
-- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
-  when:
-    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
-    - stonith_item.id | d('') | length > 0
-    - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_stonith_resource:
-      "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [stonith_item] }}"
-  loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
-  loop_control:
-    label: "{{ stonith_item.id }}"
-    loop_var: stonith_item
 
 
 # The STONITH resource is an element in the cluster_resource_primitives list

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith.yml
@@ -1,38 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# The following variables are constructed here in order to be provided as
-# input for the included 'ha_cluster' system role.
 
-### Block for disabling stonith when no stonith resource definition is found
-#
-# This block is entered when
-# - no default stonith resource is defined and no custom is defined either
-# - an empty custom is defined to override any default (defined or not)
-- name: "SAP HA Prepare Pacemaker - (STONITH) Block when no STONITH resource is defined"
+# Show warning and disable fencing if either user or default STONITH resources are not defined.
+- name: Block when no STONITH resources are defined
   when:
-    - (
-        sap_ha_pacemaker_cluster_stonith_custom is defined
-        and
-        (
-          sap_ha_pacemaker_cluster_stonith_custom == ''
-          or sap_ha_pacemaker_cluster_stonith_custom | length == 0
-        )
-      )
-      or
-      (
-        sap_ha_pacemaker_cluster_stonith_custom is not defined
-        and __sap_ha_pacemaker_cluster_stonith_default is defined
-        and
-        (
-          __sap_ha_pacemaker_cluster_stonith_default == ''
-          or __sap_ha_pacemaker_cluster_stonith_default | length == 0
-        )
-      )
-      or
-      (
-        sap_ha_pacemaker_cluster_stonith_custom is not defined
-        and __sap_ha_pacemaker_cluster_stonith_default is not defined
-      )
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length == 0
+    - __sap_ha_pacemaker_cluster_stonith_default | d({}) | length == 0
   block:
 
     # Ensure that property 'stonith-enabled' is set to 'false' if no Stonith resources are defined.
@@ -43,65 +16,90 @@
         __sap_ha_pacemaker_cluster_cluster_properties:
           "{{ __sap_ha_pacemaker_cluster_cluster_properties | combine({'stonith-enabled': false}) }}"
 
-    - name: "SAP HA Prepare Pacemaker - Warn that there is no STONITH configured"
+    - name: "SAP HA Prepare Pacemaker - Warning when no STONITH resources are defined"
       ansible.builtin.pause:
         seconds: 5
         prompt: |
+          WARNING: No STONITH resources are defined and STONITH will be disabled!
 
-          WARNING: No STONITH resource is defined and STONITH is disabled!
-
-          Recommendation: Add a STONITH resource and set cluster property
-                          "stonith-enabled=true"
-                          before using this cluster for production services.
-
-# END of block for disabling stonith
-
-# Stonith cluster properties
-# Property 'concurrent-fencing' is 'false' by default, but Scale-Out requires 'true'.
-# NOTE: Reversed combine ensures that user defined values are retained.
-# TODO: Enable during implementation of Scale-Out.
-# - name: "SAP HA Prepare Pacemaker - Disable concurrent-fencing in properties"
-#   when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
-#   ansible.builtin.set_fact:
-#     __sap_ha_pacemaker_cluster_cluster_properties:
-#       "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
-#   when:
-#     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleout') | length > 0
+          Please configure appropriate fencing resources for your environment by following steps:
+          - Add a STONITH resource(s) using the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+          - Add a cluster property "stonith-enabled: true" to 'sap_ha_pacemaker_cluster_cluster_properties'.
 
 
-# Property 'priority-fencing-delay' is required to ensure proper fencing order.
-# The value is based on 'pcmk_delay_max', if it is defined in '__sap_ha_pacemaker_cluster_stonith_default'.
-# This task will not change property if it is already defined.
-# NOTE: Reversed combine ensures that user defined values are retained.
-- name: "SAP HA Prepare Pacemaker - (STONITH) Add priority-fencing-delay property"
-  when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_cluster_properties:
-      "{{ {'priority-fencing-delay': (__pcmk_delay_max | int * 2
-          if __pcmk_delay_max is defined and __pcmk_delay_max | int != 0
-          else 30)} | combine(__sap_ha_pacemaker_cluster_cluster_properties)
-        if __sap_ha_pacemaker_cluster_cluster_properties['priority-fencing-delay'] is not defined
-        else __sap_ha_pacemaker_cluster_cluster_properties }}"
-  vars:
-    __pcmk_delay_max:
-      "{{ (__sap_ha_pacemaker_cluster_stonith_default['instance_attrs'][0]['attrs']
-        | selectattr('name', 'equalto', 'pcmk_delay_max') | first).value }}"
-
-# Ensure that property 'concurrent-fencing' is set to 'true' for Azure.
-# Source: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#create-a-fencing-device-on-the-pacemaker-cluster
-# NOTE: Reversed combine ensures that user defined values are retained.
-- name: "SAP HA Prepare Pacemaker - (STONITH) - MSAZURE VM - Add cluster property 'concurrent-fencing'"
+# We will be adding properties only if user defined no custom cluster properties.
+# This enables us to allow even test scenarios, with overrides of cluster properties.
+# NOTE: Reversed combine ensures that OS and platform defaults are retained.
+- name: Block when no sap_ha_pacemaker_cluster_cluster_properties is not defined or empty
   when:
     - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
-    - __sap_ha_pacemaker_cluster_platform == "cloud_msazure_vm"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_cluster_properties:
-      "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
+    - sap_ha_pacemaker_cluster_cluster_properties | d([]) | length == 0
+    # Ensure that we do not set it when STONITH resources are not defined.
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
+      or __sap_ha_pacemaker_cluster_stonith_default | d({}) | length > 0
+  block:
+    ### SAP HANA Scale-Out
+    # TODO: Enable and update during implementation of Scale-Out.
+    # Property 'concurrent-fencing' is 'false' by default, but Scale-Out requires 'true'.
+    # - name: "SAP HA Prepare Pacemaker - Disable concurrent-fencing in properties"
+    #   when:
+    #     - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleout') | length > 0
+    #   ansible.builtin.set_fact:
+    #     __sap_ha_pacemaker_cluster_cluster_properties:
+    #       "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
+
+    ### SAP HANA Scale-Up
+    # Property 'priority-fencing-delay' is required to ensure proper fencing order.
+    # The value is based on 'pcmk_delay_max', if it is defined in '__sap_ha_pacemaker_cluster_stonith_default'.
+    - name: "SAP HA Prepare Pacemaker - (STONITH) Add priority-fencing-delay property"
+      when:
+        - sap_ha_pacemaker_cluster_host_type | select('search', 'hana_scaleup') | length > 0
+          or sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_.*_ers') | length > 0
+        # Do not set fencing delay if pcmk_delay_max is not defined.
+        # We cannot trust that default 'pcmk_delay_max' will be 15 to ensure rule of
+        # having 'priority-fencing-delay' = 2 * 'pcmk_delay_max'.
+        - __pcmk_delay_max is defined and __pcmk_delay_max | int != 0
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_cluster_properties:
+          "{{ {'priority-fencing-delay': __pcmk_delay_max | int * 2} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
+      vars:
+        __pcmk_delay_max:
+          "{{ (__sap_ha_pacemaker_cluster_stonith_default['instance_attrs'][0]['attrs']
+            | selectattr('name', 'equalto', 'pcmk_delay_max') | first).value }}"
+
+    ### Azure
+    # Ensure that property 'concurrent-fencing' is set to 'true' for Azure.
+    # Source: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#create-a-fencing-device-on-the-pacemaker-cluster
+    # NOTE: Reversed combine ensures that user defined values are retained.
+    - name: "SAP HA Prepare Pacemaker - (STONITH) - MSAZURE VM - Add cluster property 'concurrent-fencing'"
+      when:
+        - __sap_ha_pacemaker_cluster_platform == "cloud_msazure_vm"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_cluster_properties:
+          "{{ {'concurrent-fencing': true} | combine(__sap_ha_pacemaker_cluster_cluster_properties) }}"
+
+
+# This complicated conditional will check if 'pcmk_delay_max' is defined in either:
+# - custom list of dictionaries, flattened to check all instance_attrs and first attrs keys.
+# - default dictionary under instance_attrs and first attrs key.
+- name: "SAP HA Prepare Pacemaker - Warning when pcmk_delay_max is missing"
+  when:
+    - (sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
+      and sap_ha_pacemaker_cluster_stonith_custom | map(attribute='instance_attrs', default=[]) | flatten
+        | map(attribute='attrs', default=[]) | flatten | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0)
+      or (__sap_ha_pacemaker_cluster_stonith_default | d([]) | length > 0
+        and __sap_ha_pacemaker_cluster_stonith_default['instance_attrs'][0]['attrs'] | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0)
+  ansible.builtin.debug:
+    msg: |
+      WARNING: The STONITH resource is missing 'pcmk_delay_max'!
+
+      Without a delay, both cluster nodes may attempt to fence each other simultaneously
+      during a split-brain event ("Double STONITH"), leading to a total cluster outage.
+      Add pcmk_delay_max=15 (or similar) to STONITH resource defined in the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
 
 
 # Prepare structure compatible with the variable 'ha_cluster_cluster_properties'.
 - name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
-  # This task is skipped if 'ha_cluster_cluster_properties' is defined, as both structures are different.
   when: ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_properties:
@@ -118,15 +116,13 @@
           {{ attrs }}
 
 
-# Prepare default stonith method based on __sap_ha_pacemaker_cluster_stonith_default loaded
-# from platform __sap_ha_pacemaker_cluster_stonith_default_dict dictionary.
-
-- name: "SAP HA Prepare Pacemaker - (STONITH) Default configuration"
+# Create list of default stonith resources for all hosts in the cluster
+# and create location constraint for them.
+- name: Block for combining default STONITH resources and creating constraints
   when:
-    - __sap_ha_pacemaker_cluster_stonith_default is defined
+    - __sap_ha_pacemaker_cluster_stonith_default is mapping
     - __sap_ha_pacemaker_cluster_stonith_default | length > 0
-    - sap_ha_pacemaker_cluster_stonith_custom is not defined
-      or sap_ha_pacemaker_cluster_stonith_custom | length == 0
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length == 0
   block:
 
     - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resource definition from platform default"
@@ -142,11 +138,11 @@
         - (hostvars[stonith_host_item].__sap_ha_pacemaker_cluster_stonith_default).id
           not in (__sap_ha_pacemaker_cluster_stonith_resource | d([])| map(attribute='id'))
 
-    # The location constraints are needed, when the fence resource is configured
-    # per host and must not run on the host it targets.
+    # GCP Specific configuration where port contains hostname instead of pcmk_host_map.
     - name: "SAP HA Prepare Pacemaker - (STONITH) Add location constraints"
       ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_constraints_location: "{{ __sap_ha_pacemaker_cluster_constraints_location + [__constraint_location_stonith] }}"
+        __sap_ha_pacemaker_cluster_constraints_location:
+          "{{ __sap_ha_pacemaker_cluster_constraints_location + [__constraint_location_stonith] }}"
       vars:
         # get host name from port definition
         __port_name: "{{ (stonith_item.instance_attrs[0].attrs | selectattr('name', 'equalto', 'port'))[0].value }}"
@@ -168,49 +164,26 @@
         - __port_name | length > 0
         - __port_name in ansible_play_hosts_all
 
-### End of default stonith configuration block
 
-
-# Requirements to run SBD block:
+# SBD Configuration is executed only when all conditions are met:
 # sap_ha_pacemaker_cluster_sbd_enabled is true
 # sap_ha_pacemaker_cluster_sbd_devices is defined, list and not empty
 # sap_ha_pacemaker_cluster_stonith_custom is defined, list and not empty
 # __sap_ha_pacemaker_cluster_sbd_enabled is not defined
 - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Prepare SBD configuration"
   when:
-    - sap_ha_pacemaker_cluster_sbd_enabled is defined
-     and sap_ha_pacemaker_cluster_sbd_enabled
-    - sap_ha_pacemaker_cluster_sbd_devices is defined
-     and sap_ha_pacemaker_cluster_sbd_devices | length > 0
-     and sap_ha_pacemaker_cluster_sbd_devices is iterable
-     and sap_ha_pacemaker_cluster_sbd_devices is not string
-    - sap_ha_pacemaker_cluster_stonith_custom is defined
-     and sap_ha_pacemaker_cluster_stonith_custom | length > 0
-     and sap_ha_pacemaker_cluster_stonith_custom is iterable
-     and sap_ha_pacemaker_cluster_stonith_custom is not string
-    - __sap_ha_pacemaker_cluster_sbd_enabled is not defined
+    - ha_cluster_sbd_enabled is not defined  # We cannot overwrite due to precedence.
+    - sap_ha_pacemaker_cluster_sbd_enabled | d(false)
+    - sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
   block:
-    # Create sbd_options for ha_cluster_sbd_options when
-    # ha_cluster_sbd_options is not defined or it is empty or not List
-    # ha_cluster_sbd_options is defined but it does not contain required startmode
     - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create sbd_options"
       when:
-        - not sap_ha_pacemaker_cluster_sbd_options is defined
-          or sap_ha_pacemaker_cluster_sbd_options | length == 0
-          or not sap_ha_pacemaker_cluster_sbd_options is iterable
-          or (sap_ha_pacemaker_cluster_sbd_options is defined
-           and sap_ha_pacemaker_cluster_sbd_options | selectattr('name', 'equalto', 'startmode') | list | length == 0)
-        # Skip if startmode is already present
-        - not (sap_ha_pacemaker_cluster_sbd_options is defined
-            and sap_ha_pacemaker_cluster_sbd_options | selectattr('name', 'equalto', 'startmode') | list | length > 0)
-        # Skip if ha_cluster_sbd_options are provided
-        - __sap_ha_pacemaker_cluster_sbd_options is not defined
-          or __sap_ha_pacemaker_cluster_sbd_options | length == 0
+        - ha_cluster_sbd_options is not defined
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_sbd_options: >-
-          {%- if sap_ha_pacemaker_cluster_sbd_options is defined
-           and (sap_ha_pacemaker_cluster_sbd_options | selectattr('name', 'equalto', 'startmode') | list | length == 0) -%}
-            {{ sap_ha_pacemaker_cluster_sbd_options + [{'name': 'startmode', 'value': __sbd_startmode}]}}
+          {%- if sap_ha_pacemaker_cluster_sbd_options | d([]) | length > 0 -%}
+            {{ sap_ha_pacemaker_cluster_sbd_options }}
           {%- else -%}
             {{ [{'name': 'startmode', 'value': __sbd_startmode}] }}
           {%- endif -%}
@@ -225,35 +198,25 @@
         __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
           {{
             dict(
-              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices if sap_ha_pacemaker_cluster_sbd_devices is defined
-                and sap_ha_pacemaker_cluster_sbd_devices | length > 0 and not __sap_ha_pacemaker_cluster_ha_cluster_sbd_devices_exists
+              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices
+                if sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0 and not __ha_cluster_sbd_devices_exists
                 else omit),
-              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog if sap_ha_pacemaker_cluster_sbd_watchdog is defined
-                and sap_ha_pacemaker_cluster_sbd_watchdog | length > 0 and not __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_exists
+              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
+                if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
                 else omit),
               sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
-                if sap_ha_pacemaker_cluster_sbd_watchdog_modules is defined
-                and sap_ha_pacemaker_cluster_sbd_watchdog_modules | length > 0
-                and not __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_modules_exists
+                if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
                 else omit)
             )
           }}
       vars:
         # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
-        __sap_ha_pacemaker_cluster_ha_cluster_sbd_devices_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster is defined
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices is defined
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | length > 0
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices is iterable else false }}"
-        __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster is defined
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog is defined
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | length > 0 else false }}"
-        __sap_ha_pacemaker_cluster_ha_cluster_sbd_watchdog_modules_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster is defined
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules is defined
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | length > 0
-           and __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules is iterable else false }}"
+        __ha_cluster_sbd_devices_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | d([]) | length > 0 else false }}"
+        __ha_cluster_sbd_watchdog_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | d([]) | length > 0 else false }}"
+        __ha_cluster_sbd_watchdog_modules_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | d([]) | length > 0 else false }}"
 
 
     - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"
@@ -265,63 +228,18 @@
       ansible.builtin.set_fact:
         __sap_ha_pacemaker_cluster_sbd_enabled: true
 
-### End of SBD configuration block.
-
-
-# sap_ha_pacemaker_cluster_stonith_custom input was redesigned to use ha_cluster structure.
-# Following task will remain until next release to ensure compatibility with previous structure.
-
-# TODO: Remove Tech debt task in future release, once options and name are no longer supported.
-- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition - Legacy"
-  when:
-    - sap_ha_pacemaker_cluster_stonith_custom is defined
-      and sap_ha_pacemaker_cluster_stonith_custom | length > 0
-      and sap_ha_pacemaker_cluster_stonith_custom is iterable
-      and sap_ha_pacemaker_cluster_stonith_custom is not string
-    # Tech Debt: Execute only if name and options are provided, previously required parameters.
-    - stonith_item.name is defined and stonith_item.name | length > 0
-      and stonith_item.options is defined and stonith_item.options | length > 0
-    # Keep following conditional after removing Tech Debt
-    - __stonith_resource_element.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_stonith_resource: "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [__stonith_resource_element] }}"
-  vars:
-    __stonith_resource_element:
-      # Ensure that resource name conforms with naming convention rsc_
-      id: "{{ stonith_item.name if stonith_item.name.startswith('rsc_') else 'rsc_' ~ stonith_item.name }}"  # "rsc_{{ stonith_item.name }}"
-      agent: "{{ stonith_item.agent }}"
-      instance_attrs:
-        - attrs: |-
-            {% set attrs = [] -%}
-            {%- for option in (stonith_item.options | dict2items) -%}
-              {% set aopts = attrs.extend([
-                {
-                  'name': option.key,
-                  'value': option.value
-                }
-              ]) -%}
-            {%- endfor %}
-            {{ attrs }}
-  loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
-  loop_control:
-    label: "{{ stonith_item.name if stonith_item.name is defined else stonith_item.id }}"
-    loop_var: stonith_item
-
 
 - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
   when:
-    - sap_ha_pacemaker_cluster_stonith_custom is defined
-     and sap_ha_pacemaker_cluster_stonith_custom | length > 0
-     and sap_ha_pacemaker_cluster_stonith_custom is iterable
-     and sap_ha_pacemaker_cluster_stonith_custom is not string
-    - stonith_item.id is defined and stonith_item.id | length > 0
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
+    - stonith_item.id | d('') | length > 0
     - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_stonith_resource:
       "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [stonith_item] }}"
   loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
   loop_control:
-    label: "{{ stonith_item.name if stonith_item.name is defined else stonith_item.id }}"
+    label: "{{ stonith_item.id }}"
     loop_var: stonith_item
 
 
@@ -330,10 +248,7 @@
   when:
     - __sap_ha_pacemaker_cluster_stonith_resource is defined
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_resource_primitives: |-
-      {{
-        __sap_ha_pacemaker_cluster_resource_primitives
-        +
-        (__sap_ha_pacemaker_cluster_stonith_resource | from_yaml)
-      }}
+    __sap_ha_pacemaker_cluster_resource_primitives:
+      "{{ __sap_ha_pacemaker_cluster_resource_primitives
+        + (__sap_ha_pacemaker_cluster_stonith_resource | from_yaml) }}"
   no_log: true  # stonith resources can contain secrets

--- a/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith_custom.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/construct_vars_stonith_custom.yml
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# Custom STONITH can be used for customizing but also debugging.
+# This task file must ensure that empty list is allowed.
+
+# Show warning and disable fencing if user STONITH resources are not defined.
+- name: Block when STONITH list is defined but empty
+  when: sap_ha_pacemaker_cluster_stonith_custom | length == 0
+  block:
+
+    # Ensure that property 'stonith-enabled' is set to 'false' if no Stonith resources are defined.
+    # STONITH property will be disabled only if 'sap_ha_pacemaker_cluster_cluster_properties' is not defined.
+    - name: "SAP HA Prepare Pacemaker - (STONITH) Set to disabled when no fencing resource is defined"
+      when:
+        - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+        - sap_ha_pacemaker_cluster_cluster_properties is not defined
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_cluster_properties:
+          "{{ __sap_ha_pacemaker_cluster_cluster_properties | combine({'stonith-enabled': false}) }}"
+
+    - name: "SAP HA Prepare Pacemaker - Warning when no STONITH resources are defined"
+      ansible.builtin.pause:
+        seconds: 5
+        prompt: |
+          WARNING: The variable 'sap_ha_pacemaker_cluster_stonith_custom' is defined, but empty!
+          {% if ha_cluster_cluster_properties is not defined and sap_ha_pacemaker_cluster_cluster_properties is not defined %}
+          No STONITH resources are defined and STONITH will be disabled!
+          The cluster property "stonith-enabled: false" will be configured to disable fencing.
+          {% else %}
+          No STONITH resources are defined!
+          {% endif %}
+
+          Please configure appropriate fencing resources for your environment by following steps:
+          - Add a STONITH resource(s) using the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+          - Add a cluster property "stonith-enabled: true" to 'sap_ha_pacemaker_cluster_cluster_properties'.
+
+
+- name: "SAP HA Prepare Pacemaker - Warning when pcmk_delay_max is missing"
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom | length > 0
+    - sap_ha_pacemaker_cluster_stonith_custom | map(attribute='instance_attrs', default=[]) | flatten
+        | map(attribute='attrs', default=[]) | flatten | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0
+  ansible.builtin.debug:
+    msg: |
+      WARNING: The STONITH resource is missing 'pcmk_delay_max'!
+
+      Without a delay, both cluster nodes may attempt to fence each other simultaneously
+      during a split-brain event ("Double STONITH"), leading to a total cluster outage.
+      Add pcmk_delay_max=15 (or similar) to STONITH resource defined in the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+
+
+# Prepare structure compatible with the variable 'ha_cluster_cluster_properties'.
+- name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
+  when:
+    - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+    - sap_ha_pacemaker_cluster_cluster_properties is defined
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_cluster_properties:
+      - attrs: |-
+          {% set attrs = [] -%}
+          {%- for default_cluster_properties in (__sap_ha_pacemaker_cluster_cluster_properties | dict2items) -%}
+            {% set role_attrs = attrs.extend([
+              {
+                'name': default_cluster_properties.key,
+                'value': default_cluster_properties.value
+              }
+            ]) -%}
+          {%- endfor %}
+          {{ attrs }}
+
+
+# SBD Configuration is executed only when all conditions are met:
+# sap_ha_pacemaker_cluster_sbd_enabled is true
+# sap_ha_pacemaker_cluster_sbd_devices is defined, list and not empty
+# sap_ha_pacemaker_cluster_stonith_custom is defined, list and not empty
+# __sap_ha_pacemaker_cluster_sbd_enabled is not defined
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Prepare SBD configuration"
+  when:
+    - ha_cluster_sbd_enabled is not defined or ha_cluster_sbd_enabled | bool  # We cannot overwrite due to precedence.
+    - sap_ha_pacemaker_cluster_sbd_enabled | d(false)
+    - sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0
+    - sap_ha_pacemaker_cluster_stonith_custom | length > 0
+  block:
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create sbd_options"
+      when:
+        - ha_cluster_sbd_options is not defined
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_sbd_options: >-
+          {%- if sap_ha_pacemaker_cluster_sbd_options | d([]) | length > 0 -%}
+            {{ sap_ha_pacemaker_cluster_sbd_options }}
+          {%- else -%}
+            {{ [{'name': 'startmode', 'value': __sbd_startmode}] }}
+          {%- endif -%}
+      vars:
+        __sbd_startmode: "{{ 'clean' if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0 else 'always' }}"
+
+
+    # Create dictionary with SBD specific parameters for ha_cluster
+    # Omit parameters if they are already present in provided dictionary sap_ha_pacemaker_cluster_ha_cluster
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
+          {{
+            dict(
+              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices
+                if sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0 and not __ha_cluster_sbd_devices_exists
+                else omit),
+              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
+                if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
+                else omit),
+              sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
+                if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
+                else omit)
+            )
+          }}
+      vars:
+        # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
+        __ha_cluster_sbd_devices_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | d([]) | length > 0 else false }}"
+        __ha_cluster_sbd_watchdog_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | d([]) | length > 0 else false }}"
+        __ha_cluster_sbd_watchdog_modules_exists:
+          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | d([]) | length > 0 else false }}"
+
+
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_fence_agent_packages:
+          "{{ __sap_ha_pacemaker_cluster_fence_agent_packages + ['sbd'] }}"
+
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set __sap_ha_pacemaker_cluster_sbd_enabled"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_sbd_enabled: true
+
+
+- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom | length > 0
+    - stonith_item.id | d('') | length > 0
+    - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_stonith_resource:
+      "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [stonith_item] }}"
+  loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
+  loop_control:
+    label: "{{ stonith_item.id }}"
+    loop_var: stonith_item
+
+
+# The STONITH resource is an element in the cluster_resource_primitives list
+- name: "SAP HA Prepare Pacemaker - (STONITH) Construct resources definition"
+  when:
+    - __sap_ha_pacemaker_cluster_stonith_resource is defined
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_primitives:
+      "{{ __sap_ha_pacemaker_cluster_resource_primitives
+        + (__sap_ha_pacemaker_cluster_stonith_resource | from_yaml) }}"
+  no_log: true  # stonith resources can contain secrets

--- a/roles/sap_ha_pacemaker_cluster/tasks/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/main.yml
@@ -50,9 +50,16 @@
   ansible.builtin.import_tasks: construct_vars_common.yml
   tags: pre_ha_cluster
 
-- name: "SAP HA Prepare Pacemaker - Include variable construction for STONITH resources"
+# STONITH tasks are split to allow for full user override using 'sap_ha_pacemaker_cluster_stonith_custom'.
+- name: "SAP HA Prepare Pacemaker - Include variable construction for default STONITH resources"
   ansible.builtin.import_tasks: construct_vars_stonith.yml
   tags: pre_ha_cluster
+  when: sap_ha_pacemaker_cluster_stonith_custom is not defined
+
+- name: "SAP HA Prepare Pacemaker - Include variable construction for custom STONITH resources"
+  ansible.builtin.import_tasks: construct_vars_stonith_custom.yml
+  tags: pre_ha_cluster
+  when: sap_ha_pacemaker_cluster_stonith_custom is defined
 
 - name: "SAP HA Prepare Pacemaker - Include variable construction for VIP resources"
   ansible.builtin.import_tasks: include_construct_vip_resources.yml

--- a/roles/sap_ha_pacemaker_cluster/vars/SLES_16.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/SLES_16.yml
@@ -43,6 +43,26 @@ __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict:
 # - supportutils-plugin-ha-sap
 # - socat
 
+# Package 'fence-agents' is not present on SLES 16 and all agents have dedicated packages.
+# Alternatively package 'fence-agents-all' is available with all agents included.
+__sap_ha_pacemaker_cluster_fence_agent_packages_minimal: []
+
+# Dictionary with fence packages for each platform
+# fence-agents are defined in __sap_ha_pacemaker_cluster_fence_agent_packages_minimal already.
+__sap_ha_pacemaker_cluster_fence_agent_packages_dict:
+  cloud_aws_ec2_vs:
+    - fence-agents-aws
+  cloud_gcp_ce_vm:
+    - fence-agents-gce
+  cloud_ibmcloud_powervs:
+    - fence-agents-ibm-powervs
+  cloud_ibmcloud_vs:
+    - fence-agents-ibm-vpc
+  cloud_msazure_vm:
+    - fence-agents-azure-arm
+  hyp_ibmpower_vm:
+    - fence-agents-lpar
+
 # Default corosync transport options
 __sap_ha_pacemaker_cluster_corosync_transport_default:
   type: knet

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -24,160 +24,240 @@ __sap_ha_pacemaker_cluster_repos:
 # NWAS:
 #   SLES: https://docs.aws.amazon.com/sap/latest/sap-netweaver/sles-netweaver-ha-cluster-resources.html#create-stonith
 #   RHEL: https://docs.aws.amazon.com/sap/latest/sap-netweaver/rhel-netweaver-ha-cluster-resources.html#create-stonith
+# NOTE: Versions must be string for keys to work.
 
 __sap_ha_pacemaker_cluster_stonith_default_dict:
-  redhat_hana:
-    id: "rsc_fence_aws"
-    agent: "stonith:fence_aws"
-    instance_attrs:
-      - attrs:
-          # String of cluster hosts defined in include_vars_platform
-          - name: pcmk_host_map
-            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
-          - name: pcmk_delay_max
-            value: 45
-          - name: power_timeout
-            value: 600
-          # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
-          - name: pcmk_reboot_action
-            value: 'off'
-          - name: pcmk_reboot_timeout
-            value: 600
-          - name: pcmk_reboot_retries
-            value: 4
-          # AWS Credentials are not defined here, because they override attached
-          # IAM Role or IAM Instance Profile
-          # - name: access_key
-          #   value: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
-          # - name: secret_key
-          #   value: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
-          # - name: region
-          #   value: "{{ sap_ha_pacemaker_cluster_aws_region }}"
-    operations:
-      - action: start
-        attrs:
-          - name: timeout
-            value: 600
-      - action: monitor
-        attrs:
-          - name: interval
-            value: 300
-          - name: timeout
-            value: 60
+  redhat:
+    default:  # default for all versions
+      hana:
+        id: "rsc_fence_aws"
+        agent: "stonith:fence_aws"
+        instance_attrs:
+          - attrs:
+              # String of cluster hosts defined in include_vars_platform
+              - name: pcmk_host_map
+                value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+              - name: pcmk_delay_max
+                value: 45
+              - name: power_timeout
+                value: 600
+              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
+              - name: pcmk_reboot_action
+                value: 'off'
+              - name: pcmk_reboot_timeout
+                value: 600
+              - name: pcmk_reboot_retries
+                value: 4
+              # AWS Credentials are not defined here, because they override attached
+              # IAM Role or IAM Instance Profile
+              # - name: access_key
+              #   value: "{{ sap_ha_pacemaker_cluster_aws_access_key_id }}"
+              # - name: secret_key
+              #   value: "{{ sap_ha_pacemaker_cluster_aws_secret_access_key }}"
+              # - name: region
+              #   value: "{{ sap_ha_pacemaker_cluster_aws_region }}"
+        operations:
+          - action: start
+            attrs:
+              - name: timeout
+                value: 600
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 300
+              - name: timeout
+                value: 60
 
-  redhat_nwas:
-    id: "rsc_fence_aws"
-    agent: "stonith:fence_aws"
-    instance_attrs:
-      - attrs:
-          # String of cluster hosts defined in include_vars_platform
-          - name: pcmk_host_map
-            value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
-          - name: pcmk_delay_max
-            value: 30
-          - name: power_timeout
-            value: 240
-          # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
-          - name: pcmk_reboot_action
-            value: 'off'
-          - name: pcmk_reboot_timeout
-            value: 300
-          - name: pcmk_reboot_retries
-            value: 2
-    operations:
-      - action: start
-        attrs:
-          - name: timeout
-            value: 180
-      - action: stop
-        attrs:
-          - name: timeout
-            value: 180
-      - action: monitor
-        attrs:
-          - name: interval
-            value: 180
-          - name: timeout
-            value: 60
+      nwas:
+        id: "rsc_fence_aws"
+        agent: "stonith:fence_aws"
+        instance_attrs:
+          - attrs:
+              # String of cluster hosts defined in include_vars_platform
+              - name: pcmk_host_map
+                value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+              - name: pcmk_delay_max
+                value: 30
+              - name: power_timeout
+                value: 240
+              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
+              - name: pcmk_reboot_action
+                value: 'off'
+              - name: pcmk_reboot_timeout
+                value: 300
+              - name: pcmk_reboot_retries
+                value: 2
+        operations:
+          - action: start
+            attrs:
+              - name: timeout
+                value: 180
+          - action: stop
+            attrs:
+              - name: timeout
+                value: 180
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 180
+              - name: timeout
+                value: 60
 
-  # SUSE Recommends stonith:external/ec2 instead of fence_aws
-  suse_hana:
-    id: "rsc_fence_aws"
-    agent: "stonith:external/ec2"
-    instance_attrs:
-      - attrs:
-          - name: pcmk_delay_max
-            value: 45
-          - name: tag
-            value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
-          # Use AWS config profile if AWS credentials are used.
-          # - name: profile
-          #   value: cluster
-    meta_attrs:
-      - attrs:
-          - name: target-role
-            value: Started
-    operations:
-      - action: start
-        attrs:
-          - name: interval
-            value: 0
-          - name: timeout
-            value: 180
-      - action: stop
-        attrs:
-          - name: interval
-            value: 0
-          - name: timeout
-            value: 180
-      - action: monitor
-        attrs:
-          - name: interval
-            value: 120
-          - name: timeout
-            value: 60
+  suse:
+    # SLES 15 uses stonith:external/ec2 instead of fence_aws.
+    '15':  # SLES_SAP 15
+      hana:
+        id: "rsc_fence_aws"
+        agent: "stonith:external/ec2"
+        instance_attrs:
+          - attrs:
+              - name: pcmk_delay_max
+                value: 45
+              - name: tag
+                value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
+              # Use AWS config profile if AWS credentials are used.
+              # - name: profile
+              #   value: cluster
+        meta_attrs:
+          - attrs:
+              - name: target-role
+                value: Started
+        operations:
+          - action: start
+            attrs:
+              - name: interval
+                value: 0
+              - name: timeout
+                value: 180
+          - action: stop
+            attrs:
+              - name: interval
+                value: 0
+              - name: timeout
+                value: 180
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 120
+              - name: timeout
+                value: 60
 
-  suse_nwas:
-    id: "rsc_fence_aws"
-    agent: "stonith:external/ec2"
-    instance_attrs:
-      - attrs:
-          - name: pcmk_delay_max
-            value: 30
-          - name: tag
-            value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
-          # Use AWS config profile if AWS credentials are used.
-          # - name: profile
-          #   value: cluster
-    meta_attrs:
-      - attrs:
-          - name: target-role
-            value: Started
-    operations:
-      - action: start
-        attrs:
-          - name: interval
-            value: 0
-          - name: timeout
-            value: 180
-      - action: stop
-        attrs:
-          - name: interval
-            value: 0
-          - name: timeout
-            value: 180
-      - action: monitor
-        attrs:
-          - name: interval
-            value: 120
-          - name: timeout
-            value: 60
+      nwas:
+        id: "rsc_fence_aws"
+        agent: "stonith:external/ec2"
+        instance_attrs:
+          - attrs:
+              - name: pcmk_delay_max
+                value: 30
+              - name: tag
+                value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
+              # Use AWS config profile if AWS credentials are used.
+              # - name: profile
+              #   value: cluster
+        meta_attrs:
+          - attrs:
+              - name: target-role
+                value: Started
+        operations:
+          - action: start
+            attrs:
+              - name: interval
+                value: 0
+              - name: timeout
+                value: 180
+          - action: stop
+            attrs:
+              - name: interval
+                value: 0
+              - name: timeout
+                value: 180
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 120
+              - name: timeout
+                value: 60
+
+    # Agent 'stonith:external/ec2' was removed in SLES 16, use 'fence_aws' instead.
+    '16':  # SLES_SAP 16
+      hana:
+        id: "rsc_fence_aws"
+        agent: "stonith:fence_aws"
+        instance_attrs:
+          - attrs:
+              # String of cluster hosts defined in include_vars_platform
+              - name: pcmk_host_map
+                value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+              - name: pcmk_delay_max
+                value: 45
+              - name: power_timeout
+                value: 600
+              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
+              - name: pcmk_reboot_action
+                value: 'off'
+              - name: pcmk_reboot_timeout
+                value: 600
+              - name: pcmk_reboot_retries
+                value: 4
+        operations:
+          - action: start
+            attrs:
+              - name: timeout
+                value: 600
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 300
+              - name: timeout
+                value: 60
+
+      nwas:
+        id: "rsc_fence_aws"
+        agent: "stonith:fence_aws"
+        instance_attrs:
+          - attrs:
+              # String of cluster hosts defined in include_vars_platform
+              - name: pcmk_host_map
+                value: "{{ __sap_ha_pacemaker_cluster_pcmk_host_map }}"
+              - name: pcmk_delay_max
+                value: 30
+              - name: power_timeout
+                value: 240
+              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
+              - name: pcmk_reboot_action
+                value: 'off'
+              - name: pcmk_reboot_timeout
+                value: 300
+              - name: pcmk_reboot_retries
+                value: 2
+        operations:
+          - action: start
+            attrs:
+              - name: timeout
+                value: 180
+          - action: stop
+            attrs:
+              - name: timeout
+                value: 180
+          - action: monitor
+            attrs:
+              - name: interval
+                value: 180
+              - name: timeout
+                value: 60
+
+# Set helper variables to simplify default stonith selection.
+__sap_ha_pacemaker_cluster_stonith_version:
+  "{{ ansible_distribution_major_version if ansible_os_family == 'Suse' else 'default' }}"
+
+__sap_ha_pacemaker_cluster_stonith_type:
+  "{{ 'hana' if (sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | list | length > 0) else 'nwas' }}"
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
+# This structure can be adjusted in future if more combinations are needed.
+# Current levels are: OS Family -> Major Version -> Type
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower ~ '_hana']
-    if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
-   else __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower ~ '_nwas'] }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower][__sap_ha_pacemaker_cluster_stonith_version][__sap_ha_pacemaker_cluster_stonith_type] }}"
 
 
 # Default corosync options - Platform specific

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -41,9 +41,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
                 value: 45
               - name: power_timeout
                 value: 600
-              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
-              - name: pcmk_reboot_action
-                value: 'off'
+              # Parameter 'pcmk_reboot_action' is removed as documentations rely on default value. Default: 'reboot'.
               - name: pcmk_reboot_timeout
                 value: 600
               - name: pcmk_reboot_retries
@@ -80,9 +78,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
                 value: 30
               - name: power_timeout
                 value: 240
-              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
-              - name: pcmk_reboot_action
-                value: 'off'
+              # Parameter 'pcmk_reboot_action' is removed as documentations rely on default value. Default: 'reboot'.
               - name: pcmk_reboot_timeout
                 value: 300
               - name: pcmk_reboot_retries
@@ -192,9 +188,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
                 value: 45
               - name: power_timeout
                 value: 600
-              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
-              - name: pcmk_reboot_action
-                value: 'off'
+              # Parameter 'pcmk_reboot_action' is removed as documentations rely on default value. Default: 'reboot'.
               - name: pcmk_reboot_timeout
                 value: 600
               - name: pcmk_reboot_retries
@@ -223,9 +217,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
                 value: 30
               - name: power_timeout
                 value: 240
-              # It is recommended to disable default reboot action for Production environment or when manual investigation is required.
-              - name: pcmk_reboot_action
-                value: 'off'
+              # Parameter 'pcmk_reboot_action' is removed as documentations rely on default value. Default: 'reboot'.
               - name: pcmk_reboot_timeout
                 value: 300
               - name: pcmk_reboot_retries


### PR DESCRIPTION
## Changes
- Redesign AWS fence agent dictionary to allow for different definition for SLES 15 and 16
- Define `fence_aws` for SLES 16 on AWS
- **Fix incorrect variable loading that conflicted with precedence and remove appends.**
  - We will never append to user defined variables as there can be intent for testing or debugging. Example: No longer add fencing properties if `sap_ha_pacemaker_cluster_cluster_properties` is defined already.
- Remove Tech Debt for deprecated variables
- Update arg spec file to align with new readme update tool.
- Update README.md to align with https://github.com/sap-linuxlab/community.sap_install/pull/1148

## Tests
Tested on:
- SLES_SAP 15 SP7 on AWS, GCP and Azure.
- SLES_SAP 16.0 on GCP and Azure.

**NOTE: AWS cannot be currently tested because of issues with Resource Agents! **