### PR TITLE
sap_ha_install_hana_hsr: Add firewall steps

### DIFF
--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -205,11 +205,20 @@ The backup created will have a file prefix of `<SID>_PRE_HSR_<TIMESTAMP>`.</br>
 - _Type:_ `bool`
 - _Default:_ `False`
 
-Set this variable to `true` to configure the required firewall ports for SAP HANA HSR.</br>
+Set this variable to `true` to configure the required firewall ports for SAP HANA System Replication.</br>
 What this configuration includes:<br>
 
 - Installation of the `firewalld` package and starting the service.
-- If `sap_ha_install_hana_hsr_firewall_ports` is undefined: A Firewalld service definition is created with recommended ports.<br>
+- If `sap_ha_install_hana_hsr_firewall_ports` is undefined: A `firewalld` service definition is created with recommended ports.<br>
+  Note: `NN` refers to the SAP Instance Number defined in `sap_ha_install_hana_hsr_instance_number`.<br>
+
+| Ports | Protocol | Reason |
+| --- | --- | --- |
+| 30105 | TCP | Fixed port for SAP HANA System Replication (SR) and internal endpoint communication |
+| 30107 | TCP | Fixed port for SAP HANA System Replication (SR) and internal endpoint communication |
+| 30140 | TCP | Fixed port for SAP HANA System Replication (SR) and internal endpoint communication |
+| 4NN00-4NN99 | TCP | Range for SAP HANA System Replication (SR) and internal endpoint communication |
+
 - If `sap_ha_install_hana_hsr_firewall_ports` is defined: The specified ports are opened directly and no service definition is created.<br>
 
 **Important:** This does not include configuration of SAP HANA services or ports, because they are managed separately in the `sap_hana_install` role.<br>

--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -201,4 +201,17 @@ If not specified, the default HANA backup location is used.</br>
 Required sub-directories (`SYSTEMDB` and `DB_<SID>`) will be created automatically within this path</br>
 The backup created will have a file prefix of `<SID>_PRE_HSR_<TIMESTAMP>`.</br>
 
+### sap_ha_install_hana_hsr_configure_firewall
+
+- _Type:_ `bool`
+- _Default:_ `False`
+
+Set this variable to `true` to configure the required firewall ports for SAP HANA (default is `false`).</br>
+This configuration includes installing the `firewalld` package and starting the service.<br>
+Configuration can be customized by variable `sap_ha_install_hana_hsr_firewall_ports`:<br>
+- If not defined, a Firewalld service definition is created with the recommended ports.<br>
+- If defined, the specified ports are opened directly and no service definition is created.<br>
+Note: Setting this variable to `false` does not remove any existing firewall configuration.<br>
+For ongoing firewall management after installation, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.</br>
+
 <!-- END Role Variables -->

--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -202,16 +202,32 @@ Required sub-directories (`SYSTEMDB` and `DB_<SID>`) will be created automatical
 The backup created will have a file prefix of `<SID>_PRE_HSR_<TIMESTAMP>`.</br>
 
 ### sap_ha_install_hana_hsr_configure_firewall
-
 - _Type:_ `bool`
 - _Default:_ `False`
 
-Set this variable to `true` to configure the required firewall ports for SAP HANA (default is `false`).</br>
-This configuration includes installing the `firewalld` package and starting the service.<br>
-Configuration can be customized by variable `sap_ha_install_hana_hsr_firewall_ports`:<br>
-- If not defined, a Firewalld service definition is created with the recommended ports.<br>
-- If defined, the specified ports are opened directly and no service definition is created.<br>
-Note: Setting this variable to `false` does not remove any existing firewall configuration.<br>
-For ongoing firewall management after installation, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.</br>
+Set this variable to `true` to configure the required firewall ports for SAP HANA HSR.</br>
+What this configuration includes:<br>
+
+- Installation of the `firewalld` package and starting the service.
+- If `sap_ha_install_hana_hsr_firewall_ports` is undefined: A Firewalld service definition is created with recommended ports.<br>
+- If `sap_ha_install_hana_hsr_firewall_ports` is defined: The specified ports are opened directly and no service definition is created.<br>
+
+**Important:** This does not include configuration of SAP HANA services or ports, because they are managed separately in the `sap_hana_install` role.<br>
+Managing configured Firewall:<br>
+
+- Setting this variable to `false` does not remove any existing firewall configuration.<br>
+- For ongoing firewall management, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.</br>
+
+### sap_ha_install_hana_hsr_firewall_ports
+- _Type:_ `list`
+
+Optional list of firewall ports.<br>
+The specified ports are opened directly and no service definition is created.<br>
+
+### sap_ha_install_hana_hsr_firewall_zone
+- _Type:_ `string`
+
+Optional name of firewall zone where service or ports will be configured.<br>
+Default firewall zone, usually `public`, is used if this variable is undefined.
 
 <!-- END Role Variables -->

--- a/roles/sap_ha_install_hana_hsr/defaults/main.yml
+++ b/roles/sap_ha_install_hana_hsr/defaults/main.yml
@@ -73,7 +73,7 @@ sap_ha_install_hana_hsr_update_etchosts: true
 # Set to true to create a safety backup of the HANA database before configuring HSR (Boolean).
 sap_ha_install_hana_hsr_create_backup: true
 
-# Set this variable to `true` to configure the required firewall ports for SAP HANA HSR (default is `false`).
+# Set this variable to `true` to configure the required firewall ports for SAP HANA HSR.
 # This configuration includes installing the `firewalld` package and starting the service.
 # Configuration can be customized by variable `sap_ha_install_hana_hsr_firewall_ports`:
 # - If not defined, a Firewalld service definition is created with the recommended ports.
@@ -83,8 +83,9 @@ sap_ha_install_hana_hsr_create_backup: true
 # consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.
 sap_ha_install_hana_hsr_configure_firewall: false
 
-# List of firewall ports for SAP HANA.
-# Commented out example shows same ports that are defined in service file.
+# Optional list of firewall ports.
+# The specified ports are opened directly and no service definition is created.
+# Commented out example: Ports that are defined in service file.
 # sap_ha_install_hana_hsr_firewall_ports:
 #   # Fixed ports for SAP HANA System Replication (SR) and internal endpoint communication.
 #   - "30105/tcp"
@@ -92,6 +93,6 @@ sap_ha_install_hana_hsr_configure_firewall: false
 #   - "30140/tcp"
 #   - "4{{ sap_ha_install_hana_hsr_instance_number }}00-4{{ sap_ha_install_hana_hsr_instance_number }}99/tcp"
 
-# Name of firewall zone, where service or ports will be configured.
-# Default zone is used if not set.
+# Name of firewall zone where service or ports will be configured.
+# Default firewall zone, usually `public`, is used if this variable is undefined.
 # sap_ha_install_hana_hsr_firewall_zone: ''

--- a/roles/sap_ha_install_hana_hsr/defaults/main.yml
+++ b/roles/sap_ha_install_hana_hsr/defaults/main.yml
@@ -73,14 +73,22 @@ sap_ha_install_hana_hsr_update_etchosts: true
 # Set to true to create a safety backup of the HANA database before configuring HSR (Boolean).
 sap_ha_install_hana_hsr_create_backup: true
 
-# Set this variable to `true` to configure the required firewall ports for SAP HANA HSR.
-# This configuration includes installing the `firewalld` package and starting the service.
-# Configuration can be customized by variable `sap_ha_install_hana_hsr_firewall_ports`:
-# - If not defined, a Firewalld service definition is created with the recommended ports.
-# - If defined, the specified ports are opened directly and no service definition is created.
-# Note: Setting this variable to `false` does not remove any existing firewall configuration.
-# For ongoing firewall management after installation,
-# consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.
+# Set this variable to `true` to configure the required firewall ports for SAP HANA System Replication.
+# What this configuration includes:
+# - Installation of the `firewalld` package and starting the service.
+# - If `sap_ha_install_hana_hsr_firewall_ports` is undefined: A `firewalld` service definition is created with recommended ports.
+#   Note: `NN` refers to the SAP Instance Number defined in `sap_ha_install_hana_hsr_instance_number`.
+#  | Ports | Protocol | Reason |
+#  | --- | --- | --- |
+#  | 30105 | TCP | Fixed port for SAP HANA System Replication (SR) and internal endpoint communication |
+#  | 30107 | TCP | Fixed port for SAP HANA System Replication (SR) and internal endpoint communication |
+#  | 30140 | TCP | Fixed port for SAP HANA System Replication (SR) and internal endpoint communication |
+#  | 4NN00-4NN99 | TCP | Range for SAP HANA System Replication (SR) and internal endpoint communication |
+# - If `sap_ha_install_hana_hsr_firewall_ports` is defined: The specified ports are opened directly and no service definition is created.
+# Important: This does not include configuration of SAP HANA services or ports, because they are managed separately in the `sap_hana_install` role.
+# Managing configured Firewall:
+# - Setting this variable to `false` does not remove any existing firewall configuration.
+# - For ongoing firewall management, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.
 sap_ha_install_hana_hsr_configure_firewall: false
 
 # Optional list of firewall ports.
@@ -93,6 +101,6 @@ sap_ha_install_hana_hsr_configure_firewall: false
 #   - "30140/tcp"
 #   - "4{{ sap_ha_install_hana_hsr_instance_number }}00-4{{ sap_ha_install_hana_hsr_instance_number }}99/tcp"
 
-# Name of firewall zone where service or ports will be configured.
+# Optional name of firewall zone where service or ports will be configured.
 # Default firewall zone, usually `public`, is used if this variable is undefined.
 # sap_ha_install_hana_hsr_firewall_zone: ''

--- a/roles/sap_ha_install_hana_hsr/defaults/main.yml
+++ b/roles/sap_ha_install_hana_hsr/defaults/main.yml
@@ -72,3 +72,26 @@ sap_ha_install_hana_hsr_update_etchosts: true
 
 # Set to true to create a safety backup of the HANA database before configuring HSR (Boolean).
 sap_ha_install_hana_hsr_create_backup: true
+
+# Set this variable to `true` to configure the required firewall ports for SAP HANA HSR (default is `false`).
+# This configuration includes installing the `firewalld` package and starting the service.
+# Configuration can be customized by variable `sap_ha_install_hana_hsr_firewall_ports`:
+# - If not defined, a Firewalld service definition is created with the recommended ports.
+# - If defined, the specified ports are opened directly and no service definition is created.
+# Note: Setting this variable to `false` does not remove any existing firewall configuration.
+# For ongoing firewall management after installation,
+# consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.
+sap_ha_install_hana_hsr_configure_firewall: false
+
+# List of firewall ports for SAP HANA.
+# Commented out example shows same ports that are defined in service file.
+# sap_ha_install_hana_hsr_firewall_ports:
+#   # Fixed ports for SAP HANA System Replication (SR) and internal endpoint communication.
+#   - "30105/tcp"
+#   - "30107/tcp"
+#   - "30140/tcp"
+#   - "4{{ sap_ha_install_hana_hsr_instance_number }}00-4{{ sap_ha_install_hana_hsr_instance_number }}99/tcp"
+
+# Name of firewall zone, where service or ports will be configured.
+# Default zone is used if not set.
+# sap_ha_install_hana_hsr_firewall_zone: ''

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -7,7 +7,7 @@
 # 3. SLES_15.6.yml / RedHat_9.2 - Specific to distribution (SLES, SLES_SAP or RedHat) and minor release.
 # 4. SLES_SAP_15.yml - Specific to distribution SLES_SAP and major release.
 # 5. SLES_SAP_15.6.yml - Specific to distribution SLES_SAP and minor release.
-- name: SAP Firewall - Include OS specific vars
+- name: SAP HSR - Include OS specific vars
   ansible.builtin.include_vars: "{{ __vars_file }}"
   loop: "{{ __var_files }}"
   vars:

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -1,6 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+# Example of files loading order:
+# 1. Suse.yml / RedHat.yml - Specific to OS family.
+# 2. SLES_15.yml / RedHat_9.yml - Specific to distribution (SLES, SLES_SAP or RedHat) and major release.
+# 3. SLES_15.6.yml / RedHat_9.2 - Specific to distribution (SLES, SLES_SAP or RedHat) and minor release.
+# 4. SLES_SAP_15.yml - Specific to distribution SLES_SAP and major release.
+# 5. SLES_SAP_15.6.yml - Specific to distribution SLES_SAP and minor release.
+- name: SAP Firewall - Include OS specific vars
+  ansible.builtin.include_vars: "{{ __vars_file }}"
+  loop: "{{ __var_files }}"
+  vars:
+    __vars_file: "{{ role_path }}/vars/{{ item }}"
+    __distribution_major: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_version'] }}"
+    # Enables loading of shared vars between SLES and SLES_SAP
+    __distribution_major_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_version'] }}"
+    __var_files: >-
+      {{
+        [
+          ansible_facts['os_family'] ~ '.yml',
+          (ansible_facts['distribution'] ~ '.yml') if ansible_facts['distribution'] != ansible_facts['os_family'] else None,
+          (__distribution_major_split ~ '.yml') if __distribution_major_split != __distribution_major else None,
+          (__distribution_minor_split ~ '.yml') if __distribution_minor_split != __distribution_minor else None,
+          __distribution_major ~ '.yml',
+          __distribution_minor ~ '.yml'
+        ] | select('defined') | select('string') | list
+      }}
+  when: __vars_file is file
+  tags: always
+
 - name: SAP HSR - Prepare and validate variables
   ansible.builtin.include_tasks:
     file: pre_tasks/prepare_variables.yml
@@ -92,6 +122,11 @@
         - __sap_ha_install_hana_hsr_fact_is_primary
         - sap_ha_install_hana_hsr_create_backup | d(true)| bool
       tags: hsr_backup
+
+    - name: SAP HSR - Configure Firewall
+      ansible.builtin.include_tasks:
+        file: pre_tasks/firewall.yml
+      when: sap_ha_install_hana_hsr_configure_firewall
 
 
 - name: SAP HSR - Ensure HSR is configured

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/firewall.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/firewall.yml
@@ -39,28 +39,13 @@
 - name: Block for service
   when: sap_ha_install_hana_hsr_firewall_ports | d([]) | length == 0
   block:
-    - name: SAP HSR - Firewall - Create temporary file for generation
-      ansible.builtin.tempfile:
-        state: file
-        suffix: _sap_ha_install_hana_hsr_firewall_service
-      register: __sap_ha_install_hana_hsr_register_service_tempfile
-
     - name: SAP HSR - Firewall - Generate service file from template
       ansible.builtin.template:
         src: firewall-hana-replication.j2
-        dest: "{{ __sap_ha_install_hana_hsr_register_service_tempfile.path }}"
-        mode: '0640'
-
-    - name: SAP HSR - Firewall - Copy new service file to destination
-      ansible.builtin.copy:
-        src: "{{ __sap_ha_install_hana_hsr_register_service_tempfile.path }}"
         dest: "/etc/firewalld/services/{{ __sap_ha_install_hana_hsr_firewall_service_name }}.xml"
         owner: 'root'
         group: 'root'
         mode: '0640'
-        remote_src: true
-      register: __sap_ha_install_hana_hsr_register_firewall_copy_service
-      changed_when: __sap_ha_install_hana_hsr_register_firewall_copy_service.changed
 
     - name: SAP HSR - Firewall - Reload firewalld after creating service file
       ansible.builtin.command:
@@ -78,11 +63,6 @@
           --add-service={{ __sap_ha_install_hana_hsr_firewall_service_name }}
       register: __sap_ha_install_hana_hsr_register_firewall_add_service
       changed_when: true
-
-    - name: SAP HSR - Firewall - Remove temporary service file
-      ansible.builtin.file:
-        path: "{{ __sap_ha_install_hana_hsr_register_service_tempfile.path }}"
-        state: absent
 
 
 - name: Block for ports

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/firewall.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/firewall.yml
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: SAP HSR - Firewall - Install packages
+  ansible.builtin.package:
+    name: "{{ __sap_ha_install_hana_hsr_firewall_packages + __sap_ha_install_hana_hsr_firewall_extra_packages }}"
+    state: present
+
+- name: SAP HSR - Firewall - Start and enable firewalld service
+  ansible.builtin.systemd_service:
+    name: firewalld
+    state: started
+    enabled: true
+    masked: false
+
+
+# Validate firewall zone if defined
+- name: Block for validation of firewall zone
+  when: sap_ha_install_hana_hsr_firewall_zone is defined
+  block:
+    - name: SAP HSR - Firewall - Get list of configured zones from firewalld
+      ansible.builtin.command:
+        cmd: firewall-cmd --get-zones
+      register: __sap_ha_install_hana_hsr_register_firewall_zones
+      changed_when: false
+
+    - name: SAP HSR - Firewall - Assert that the firewall zone is available
+      ansible.builtin.assert:
+        that:
+          - sap_ha_install_hana_hsr_firewall_zone in __sap_ha_install_hana_hsr_register_firewall_zones.stdout.split()
+        success_msg: |
+          PASS: The zone '{{ sap_ha_install_hana_hsr_firewall_zone }}' is present in firewalld.
+        fail_msg: |
+          FAIL: The zone '{{ sap_ha_install_hana_hsr_firewall_zone }}' is not preset in firewalld.
+          Available zones: {{ __sap_ha_install_hana_hsr_register_firewall_zones.stdout }}
+        quiet: true
+
+
+- name: Block for service
+  when: sap_ha_install_hana_hsr_firewall_ports | d([]) | length == 0
+  block:
+    - name: SAP HSR - Firewall - Create temporary file for generation
+      ansible.builtin.tempfile:
+        state: file
+        suffix: _sap_ha_install_hana_hsr_firewall_service
+      register: __sap_ha_install_hana_hsr_register_service_tempfile
+
+    - name: SAP HSR - Firewall - Generate service file from template
+      ansible.builtin.template:
+        src: firewall-hana-replication.j2
+        dest: "{{ __sap_ha_install_hana_hsr_register_service_tempfile.path }}"
+        mode: '0640'
+
+    - name: SAP HSR - Firewall - Copy new service file to destination
+      ansible.builtin.copy:
+        src: "{{ __sap_ha_install_hana_hsr_register_service_tempfile.path }}"
+        dest: "/etc/firewalld/services/{{ __sap_ha_install_hana_hsr_firewall_service_name }}.xml"
+        owner: 'root'
+        group: 'root'
+        mode: '0640'
+        remote_src: true
+      register: __sap_ha_install_hana_hsr_register_firewall_copy_service
+      changed_when: __sap_ha_install_hana_hsr_register_firewall_copy_service.changed
+
+    - name: SAP HSR - Firewall - Reload firewalld after creating service file
+      ansible.builtin.command:
+        cmd: firewall-cmd --reload
+      changed_when: true
+
+    - name: SAP HSR - Firewall - Configure service in firewall
+      ansible.builtin.command:
+        cmd: >-
+          firewall-cmd
+          {% if sap_ha_install_hana_hsr_firewall_zone is defined %}
+          --zone={{ sap_ha_install_hana_hsr_firewall_zone }}
+          {% endif %}
+          --permanent
+          --add-service={{ __sap_ha_install_hana_hsr_firewall_service_name }}
+      register: __sap_ha_install_hana_hsr_register_firewall_add_service
+      changed_when: true
+
+    - name: SAP HSR - Firewall - Remove temporary service file
+      ansible.builtin.file:
+        path: "{{ __sap_ha_install_hana_hsr_register_service_tempfile.path }}"
+        state: absent
+
+
+- name: Block for ports
+  when: sap_ha_install_hana_hsr_firewall_ports | d([]) | length > 0
+  block:
+    - name: SAP HSR - Firewall - Open Ports without service file
+      ansible.builtin.command:
+        cmd: >-
+          firewall-cmd
+          {% if sap_ha_install_hana_hsr_firewall_zone is defined %}
+          --zone={{ sap_ha_install_hana_hsr_firewall_zone }}
+          {% endif %}
+          --permanent
+          {% for port_item in sap_ha_install_hana_hsr_firewall_ports %}
+          --add-port={{ port_item }}
+          {% endfor %}
+      register: __sap_ha_install_hana_hsr_register_firewall_add_port
+      changed_when: true
+
+
+- name: SAP HSR - Firewall - Reload firewalld after applying changes
+  ansible.builtin.command:
+    cmd: firewall-cmd --reload
+  changed_when: true
+
+- name: SAP HSR - Firewall - Get current firewall configuration of the default zone
+  ansible.builtin.command:
+    cmd: firewall-cmd --list-all
+  changed_when: false
+  register: __sap_ha_install_hana_hsr_register_current_firewall_configuration
+
+
+- name: SAP HSR - Firewall - Show details of configured firewall
+  ansible.builtin.debug:
+    msg: |
+      Firewall was configured for SAP HANA System Replication and reloaded.
+      Output of command 'firewall-cmd --list-all':
+      {{ __sap_ha_install_hana_hsr_register_current_firewall_configuration.stdout }}
+  when: __sap_ha_install_hana_hsr_register_current_firewall_configuration.stdout is defined

--- a/roles/sap_ha_install_hana_hsr/templates/firewall-hana-replication.j2
+++ b/roles/sap_ha_install_hana_hsr/templates/firewall-hana-replication.j2
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>SAP HANA System Replication</short>
+  <description>Ports required for the SAP HANA System Replication. Maintained by Ansible Role sap_install.sap_ha_install_hana_hsr.</description>
+
+  {# Fixed ports for SAP HANA System Replication (SR) and internal endpoint communication. -#}
+  <port protocol="tcp" port="30105"/>
+  <port protocol="tcp" port="30107"/>
+  <port protocol="tcp" port="30140"/>
+  <port protocol="tcp" port="4{{ sap_ha_install_hana_hsr_instance_number }}00-4{{ sap_ha_install_hana_hsr_instance_number }}99"/>
+
+</service>

--- a/roles/sap_ha_install_hana_hsr/vars/SLES_15.yml
+++ b/roles/sap_ha_install_hana_hsr/vars/SLES_15.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Variables specific to following versions:
+# - SUSE Linux Enterprise Server 15
+
+# NOTE: SLES 16 contains dependency between firewalld and python313-firewall package.
+
+__sap_ha_install_hana_hsr_firewall_extra_packages:
+  "{{ __sap_ha_install_hana_hsr_firewall_extra_packages_3
+    if ansible_facts['distribution_version'].split('.')[1] | int < 6
+    else __sap_ha_install_hana_hsr_firewall_extra_packages_311 }}"
+
+# The lists of bindings for specific python version
+__sap_ha_install_hana_hsr_firewall_extra_packages_3:
+  - "python3-firewall"
+
+__sap_ha_install_hana_hsr_firewall_extra_packages_311:
+  - "python311-firewall"

--- a/roles/sap_ha_install_hana_hsr/vars/main.yml
+++ b/roles/sap_ha_install_hana_hsr/vars/main.yml
@@ -18,3 +18,11 @@ __sap_ha_install_hana_hsr_backup_data_path:
 # The flags used for separation of tasks between hosts
 __sap_ha_install_hana_hsr_fact_is_primary: false
 __sap_ha_install_hana_hsr_fact_is_secondary: false
+
+# List of firewall packages
+__sap_ha_install_hana_hsr_firewall_packages:
+  - firewalld
+__sap_ha_install_hana_hsr_firewall_extra_packages: []
+
+# Predefined firewall service name.
+__sap_ha_install_hana_hsr_firewall_service_name: "sap-hana-replication"


### PR DESCRIPTION
## Changes
- Add new firewall steps to handle firewall related failures. Based on my PR https://github.com/sap-linuxlab/community.sap_install/pull/1156 and https://github.com/sap-linuxlab/community.sap_operations/pull/46
- These ports were obtained from SAP documentation and from testing, because last port range is no documented by SAP, yet it is mandatory for replication.
```yml
  <port protocol="tcp" port="30105"/>
  <port protocol="tcp" port="30107"/>
  <port protocol="tcp" port="30140"/>
  <port protocol="tcp" port="4{{ sap_ha_install_hana_hsr_instance_number }}00-4{{ sap_ha_install_hana_hsr_instance_number }}99"/>
```

## Tests
Tested on SLES_SAP 16.0 on AWS with AP4S `sap_hana_ha` scenario. 