### PR TITLE
sap_hana_install: Fix hana versions mismatch and replace injected vars

### DIFF
--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -175,7 +175,7 @@
       {% if __sap_hana_install_configure_selinux %}
       SELinux file contexts are configured for SAP folders ({{ sap_hana_install_directories | map('quote') | join(', ') }}).
       {% endif %}
-      {% if ansible_os_family == "RedHat" and __sap_hana_install_configure_fapolicyd %}
+      {% if ansible_facts['os_family'] == "RedHat" and __sap_hana_install_configure_fapolicyd %}
       Fapolicyd is configured for SAP folders ({{ sap_hana_install_directories | map('quote') | join(', ') }}).
       {% endif %}
   vars:

--- a/roles/sap_hana_install/tasks/post_addhosts.yml
+++ b/roles/sap_hana_install/tasks/post_addhosts.yml
@@ -25,5 +25,5 @@
     file: post_tasks/fapolicyd.yml
   when:
     # Ensure fapolicyd is checked only on supported systems.
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_configure_fapolicyd

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -73,5 +73,5 @@
     file: post_tasks/fapolicyd.yml
   when:
     # Ensure fapolicyd is checked only on supported systems.
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_configure_fapolicyd

--- a/roles/sap_hana_install/tasks/post_tasks/hdbuserstore.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/hdbuserstore.yml
@@ -6,7 +6,7 @@
   ansible.builtin.shell: |
       /usr/sap/{{ sap_hana_install_sid }}/SYS/exe/hdb/hdbuserstore \
       SET {{ sap_hana_install_hdbuserstore_key }} \
-      {{ ansible_hostname }}:3{{ sap_hana_install_number }}13 \
+      {{ ansible_facts['hostname'] }}:3{{ sap_hana_install_number }}13 \
       SYSTEM '{{ sap_hana_install_db_system_password | d(sap_hana_install_master_password) }}'
   args:
     executable: /bin/bash

--- a/roles/sap_hana_install/tasks/post_tasks/log_mode.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/log_mode.yml
@@ -5,14 +5,14 @@
   ansible.builtin.shell: |
       LD_LIBRARY_PATH=/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/exe \
       /usr/sap/{{ sap_hana_install_sid }}/SYS/exe/hdb/hdbsql \
-      -n '{{ ansible_hostname }}' \
+      -n '{{ ansible_facts['hostname'] }}' \
       -i '{{ sap_hana_install_number }}' \
       -d SYSTEMDB \
       -u SYSTEM \
       -p '{{ sap_hana_install_db_system_password | d(sap_hana_install_master_password) }}' \
       -m <<EOF
       ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
-      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'HOST', '{{ ansible_hostname }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'HOST', '{{ ansible_facts['hostname'] }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
       EOF
   args:
     executable: /bin/bash
@@ -38,14 +38,14 @@
   ansible.builtin.shell: |
       LD_LIBRARY_PATH=/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/exe \
       /usr/sap/{{ sap_hana_install_sid }}/SYS/exe/hdb/hdbsql \
-      -n '{{ ansible_hostname }}' \
+      -n '{{ ansible_facts['hostname'] }}' \
       -i '{{ sap_hana_install_number }}' \
       -d SYSTEMDB \
       -u SYSTEM \
       -p '{{ sap_hana_install_db_system_password | d(sap_hana_install_master_password) }}' \
       -m <<EOF
       ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
-      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'HOST', '{{ ansible_hostname }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'HOST', '{{ ansible_facts['hostname'] }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
       ALTER SYSTEM ALTER CONFIGURATION('global.ini', 'DATABASE', '{{ sap_hana_install_sid }}') SET ('persistence', 'log_mode') = 'overwrite' WITH RECONFIGURE;
       EOF
   args:

--- a/roles/sap_hana_install/tasks/post_tasks/recreate_tenant_database.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/recreate_tenant_database.yml
@@ -5,7 +5,7 @@
   ansible.builtin.shell: |
       LD_LIBRARY_PATH=/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/exe \
       /usr/sap/{{ sap_hana_install_sid }}/SYS/exe/hdb/hdbsql \
-      -n '{{ ansible_hostname }}' \
+      -n '{{ ansible_facts['hostname'] }}' \
       -i '{{ sap_hana_install_number }}' \
       -d SYSTEMDB \
       -u SYSTEM \

--- a/roles/sap_hana_install/tasks/pre_addhosts.yml
+++ b/roles/sap_hana_install/tasks/pre_addhosts.yml
@@ -49,7 +49,7 @@
     file: pre_tasks/fapolicyd.yml
   when:
     # Ensure fapolicyd is checked only on supported systems.
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_fact_is_new_addhost_host
 
 

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -6,7 +6,7 @@
     file: pre_tasks/fapolicyd.yml
   when:
     # Ensure fapolicyd is checked only on supported systems.
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
     - not __sap_hana_install_fact_is_installed
 
 

--- a/roles/sap_hana_install/tasks/pre_tasks/check_version.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/check_version.yml
@@ -38,11 +38,11 @@
           - (__sap_hana_install_fact_manifest_version.split('.') | map('int') | list) ==
             (__existing_version.split('.') | map('int') | list)
         success_msg: |
-          PASS: Existing installation has expected version.
-          Expected: {{ __sap_hana_install_fact_manifest_version }}
+          PASS: The existing installation has the expected version.
           Existing: {{ __existing_version }}
+          Expected: {{ __sap_hana_install_fact_manifest_version }}
         fail_msg: |
-          FAIL: Existing installation version mismatch!
+          FAIL: The existing installation version does not match the expected version.
           Existing: {{ __existing_version }}
           Expected: {{ __sap_hana_install_fact_manifest_version }}
       vars:

--- a/roles/sap_hana_install/tasks/pre_tasks/check_version.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/check_version.yml
@@ -26,19 +26,29 @@
         __revision: "{{ __manifest_lines | select('match', '^rev-number:') | first | default('') }}"
         __version: "{{ __manifest_lines | select('match', '^fullversion:') | first | default('') }}"
 
+
+    # This implementation solves issue where SAP mentions '0' in 'hdblcm --list systems',
+    # while having '00' in manifest file for patch level 0, which would lead to version mismatch. Example:
+    # Existing version: 2.00.077.0
+    # Expected version: 2.00.077.00
     - name: SAP HANA - Pre-Tasks - Assert that existing installation has correct version
       ansible.builtin.assert:
         that:
-          - __sap_hana_install_fact_manifest_version == __existing_version
+          # Compare as lists of integers: [2, 0, 77, 0] == [2, 0, 77, 0]
+          - (__sap_hana_install_fact_manifest_version.split('.') | map('int') | list) ==
+            (__existing_version.split('.') | map('int') | list)
         success_msg: |
           PASS: Existing installation has expected version.
-          Expected version: {{ __sap_hana_install_fact_manifest_version }}.
+          Expected: {{ __sap_hana_install_fact_manifest_version }}
+          Existing: {{ __existing_version }}
         fail_msg: |
-          FAIL: Existing installation does not have expected version!
-          Existing version: {{ __existing_version }}
-          Expected version: {{ __sap_hana_install_fact_manifest_version }}
+          FAIL: Existing installation version mismatch!
+          Existing: {{ __existing_version }}
+          Expected: {{ __sap_hana_install_fact_manifest_version }}
       vars:
-        __existing_version: "{{ __sap_hana_install_fact_existing_hana_version.split('.')[:4] | join('.') }}"
+        # Ensure we are only looking at the first 4 parts (Major.Minor.SPS.Patch)
+        __existing_version:
+          "{{ __sap_hana_install_register_existing_systems.stdout.split(';')[0].split('.')[:4] | join('.') }}"
       when: __sap_hana_install_fact_is_installed
 
     # Revision number follows SPS, where first digit designates SPS.

--- a/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
@@ -9,7 +9,7 @@
     - sap_hana_install_addhosts is defined
     - sap_hana_install_addhosts is string
     - sap_hana_install_addhosts | trim | length > 0
-    - ansible_play_hosts_all[0] in [ansible_hostname, inventory_hostname, inventory_hostname_short]
+    - ansible_play_hosts_all[0] in [ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
   block:
 
     # Difference ensures that our addhosts list does not contain Managed node.
@@ -17,7 +17,7 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_addhosts_hosts:
           "{{ sap_hana_install_addhosts.split(',') | map('trim') | reject('equalto', '')
-            | map('regex_replace', ':.*$', '') | list | difference([ansible_hostname, inventory_hostname, inventory_hostname_short]) }}"
+            | map('regex_replace', ':.*$', '') | list | difference([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]) }}"
 
     - name: SAP HANA - Addhosts - Pre-Tasks - Assert that the variable 'sap_hana_install_addhosts' is valid addhosts string
       ansible.builtin.assert:
@@ -29,7 +29,7 @@
         fail_msg: |
           FAIL: The 'sap_hana_install_addhosts' variable did not result in any valid hosts to be added.
           Value provided: '{{ sap_hana_install_addhosts }}'
-          This can happen if the variable is empty, or if it only contains the main host ('{{ ansible_hostname }}'), which is automatically filtered out.
+          This can happen if the variable is empty, or if it only contains the main host ('{{ ansible_facts['hostname'] }}'), which is automatically filtered out.
           Please provide a comma-separated list of worker hostnames.
           Examples:
           sap_hana_install_addhosts: "hanaworker1,hanaworker2"
@@ -45,7 +45,7 @@
           PASS: The variable 'sap_hana_install_addhosts' and inventory are aligned.
         fail_msg: |
           FAIL: The variable 'sap_hana_install_addhosts' and inventory are not aligned.
-          The variable 'sap_hana_install_addhosts' should not contain Master host {{ ansible_hostname }} and validation is done without it.
+          The variable 'sap_hana_install_addhosts' should not contain Master host {{ ansible_facts['hostname'] }} and validation is done without it.
 
           Inventory hosts: {{ ansible_play_hosts_all | join(', ') }}
           Addhosts hosts: {{ __sap_hana_install_fact_addhosts_hosts | join(', ') }}
@@ -60,8 +60,10 @@
           Hosts missing in the inventory: {{ __addhosts_diff_inventory | join(', ') }}
           {% endif %}
       vars:
+        # NOTE: Defaults is used here only to remove linting warning, not because we expect addhosts_hosts to be undefined at this point.
+        # [WARNING]: Falling back to Ansible unique filter as Jinja2 one failed: 'ansible_facts' is undefined
         __addhosts_hosts_with_main:
-          "{{ __sap_hana_install_fact_addhosts_hosts + [ansible_hostname, inventory_hostname, inventory_hostname_short] | unique }}"
+          "{{ __sap_hana_install_fact_addhosts_hosts + [ansible_facts['hostname'] | d(''), inventory_hostname | d(''), inventory_hostname_short | d('')] | unique }}"
         __inventory_diff_addhosts:
           "{{ ansible_play_hosts_all | difference(__addhosts_hosts_with_main) }}"
         __addhosts_diff_inventory:
@@ -150,10 +152,10 @@
   ansible.builtin.set_fact:
     __sap_hana_install_fact_is_main_host:
       "{{ __sap_hana_install_fact_main_host
-        in [ansible_hostname, inventory_hostname, inventory_hostname_short] }}"
+        in [ansible_facts['hostname'], inventory_hostname, inventory_hostname_short] }}"
 
     __sap_hana_install_fact_is_addhost_host:
-      "{{ ([ansible_hostname, inventory_hostname, inventory_hostname_short]
+      "{{ ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
         | intersect(__sap_hana_install_fact_addhosts_hosts | d([]))) | length > 0 }}"
 
 
@@ -229,7 +231,7 @@
 - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with boolean flag for new hosts
   ansible.builtin.set_fact:
     __sap_hana_install_fact_is_new_addhost_host:
-      "{{ ([ansible_hostname, inventory_hostname, inventory_hostname_short]
+      "{{ ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
         | intersect(__sap_hana_install_fact_addhosts_hosts_new | d([]))) | length > 0 }}"
 
 

--- a/roles/sap_hana_install/tasks/pre_tasks/prepare_sapcar.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/prepare_sapcar.yml
@@ -90,14 +90,14 @@
       register: __sap_hana_install_register_sapcar_file_contents
       changed_when: false
 
-    # Loop through found files and compare them against search keywords for ansible_architecture.
+    # Loop through found files and compare them against search keywords for ansible_facts['architecture'].
     # Supported combinations are defined in the variable '__sap_hana_install_architecture_matrix' in vars/main.yml file.
     # Each platform can contain multiple search words. AND operator is achieved by counting all found keywords.
-    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Compare found files against the variable ansible_architecture
+    - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Compare found files against the variable ansible_facts['architecture']
       ansible.builtin.set_fact:
         __sap_hana_install_fact_sapcar_matching_arch: |
           {%- set matching_files = [] -%}
-          {%- set rule_sets = __sap_hana_install_architecture_matrix.get(ansible_architecture, []) -%}
+          {%- set rule_sets = __sap_hana_install_architecture_matrix.get(ansible_facts['architecture'], []) -%}
           {%- if rule_sets -%}
             {%- for line in __sap_hana_install_register_sapcar_file_contents.stdout_lines -%}
               {%- set parts = line.split(': ', 1) -%}
@@ -122,7 +122,7 @@
 
     - name: SAP HANA hdblcm prepare - SAPCAR auto-detection - Fail if no matching SAPCAR executable could be found
       ansible.builtin.fail:
-        msg: "FAIL: No SAPCAR EXE file for architecture '{{ ansible_architecture }}' was found in
+        msg: "FAIL: No SAPCAR EXE file for architecture '{{ ansible_facts['architecture'] }}' was found in
               {{ __sap_hana_install_fact_software_directory }}!"
       when: __sap_hana_install_fact_sapcar_matching_arch | length == 0
 

--- a/roles/sap_hana_install/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/prepare_variables.yml
@@ -232,4 +232,4 @@
 - name: SAP HANA Pre Install - Ensure SELinux does not execute for SLES
   ansible.builtin.set_fact:
     __sap_hana_install_configure_selinux: false
-  when: ansible_os_family == "Suse"
+  when: ansible_facts['os_family'] == "Suse"


### PR DESCRIPTION
## Issue
SAP mentions '0' in 'hdblcm --list systems', while having '00' in manifest file for patch level 0, which would lead to version mismatch.

Example:
```
FAIL: Existing installation version mismatch!
Existing version: 2.00.077.0
Expected version: 2.00.077.00
```

## Changes
- Replace literal string check with integer segmented comparison, that will solve issue with zeroes.
- Replace injected ansible vars like `ansible_hostname` with ansible facts like `ansible_facts['hostname'] which is new warning in 2.20.

## Linting Note
Linting warning is very useful for catching injected vars, but there is new warning when even ansible_facts are before filter.
`[WARNING]: Falling back to Ansible unique filter as Jinja2 one failed: 'ansible_facts' is undefined`

This was triggered for `pre_tasks/identify_hosts.yml` and resolution is defaulting before filter: `[ansible_facts['hostname'] | d(''), inventory_hostname | d(''), inventory_hostname_short | d('')] | unique`