### PR TITLE
sap_ha_pacemaker_cluster: Add firewall steps

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -284,6 +284,23 @@ sap_ha_pacemaker_cluster_cluster_properties:
   stonith-timeout: 150
 ```
 
+### sap_ha_pacemaker_cluster_configure_firewall
+- _Type:_ `bool`
+- _Default:_ `false`
+
+Set this variable to `true` to configure the required firewall ports for Pacemaker/Corosync.<br>
+What this configuration includes:<br>
+- Installation of the `firewalld` package and starting the service.<br>
+- A Firewalld service definition is created with recommended ports:<br>
+  5404-5405/udp for Corosync communication and 2224/tcp with 3121/tcp for Pacemaker remote communication.<br>
+Important: This does not include configuration of ports for SAP products, as they are not directly installed with this role.<br>
+For example:<br>
+- Firewall configuration for SAP HANA can be managed separately in the `sap_hana_install` role.<br>
+- Firewall configuration for SAP ASCS/ERS can be managed separately in the `sap_swpm` role.<br>
+Managing configured Firewall:<br>
+- Setting this variable to `false` does not remove any existing firewall configuration.<br>
+- For ongoing firewall management, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.<br>
+
 ### sap_ha_pacemaker_cluster_corosync_totem
 - _Type:_ `dict`
 - _Default:_ `Specified in Operating System and Platform variables.`
@@ -355,6 +372,12 @@ For SAP clusters configured by this role, the relevant standard packages for the
 
 Additional fence agent packages to be installed.<br>
 This is automatically combined with default OS and Platform specific packages.<br>
+
+### sap_ha_pacemaker_cluster_firewall_zone
+- _Type:_ `str`
+
+Optional name of firewall zone where service or ports will be configured.<br>
+Default firewall zone, usually `public`, is used if this variable is undefined.<br>
 
 ### sap_ha_pacemaker_cluster_gcp_project
 - _Type:_ `string`

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -80,6 +80,25 @@ sap_ha_pacemaker_cluster_constraint_colo_base_score: 2000
 sap_ha_pacemaker_cluster_corosync_totem: {}
 sap_ha_pacemaker_cluster_corosync_transport: {}
 
+### Firewall
+# Set this variable to `true` to configure the required firewall ports for Pacemaker/Corosync.
+# What this configuration includes:
+# - Installation of the `firewalld` package and starting the service.
+# - A Firewalld service definition is created with recommended ports:
+#   5404-5405/udp for Corosync communication and 2224/tcp with 3121/tcp for Pacemaker remote communication.
+# Important: This does not include configuration of ports for SAP products, as they are not directly installed with this role.
+# For example:
+# - Firewall configuration for SAP HANA can be managed separately in the `sap_hana_install` role.
+# - Firewall configuration for SAP ASCS/ERS can be managed separately in the `sap_swpm` role.
+# Managing configured Firewall:
+# - Setting this variable to `false` does not remove any existing firewall configuration.
+# - For ongoing firewall management, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role.
+sap_ha_pacemaker_cluster_configure_firewall: false
+
+# Optional name of firewall zone where service or ports will be configured.
+# Default firewall zone, usually `public`, is used if this variable is undefined.
+# sap_ha_pacemaker_cluster_firewall_zone: ''
+
 ################################################################################
 # Inherit from 'ha_cluster' Linux System Role parameters when defined
 ################################################################################

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -333,6 +333,29 @@ argument_specs:
               - name: crypto_cipher
                 value: aes256
 
+      sap_ha_pacemaker_cluster_configure_firewall:
+        type: bool
+        default: false
+        description:
+          - Set this variable to `true` to configure the required firewall ports for Pacemaker/Corosync.
+          - "What this configuration includes:"
+          - "- Installation of the `firewalld` package and starting the service."
+          - "- A Firewalld service definition is created with recommended ports:"
+          - "  5404-5405/udp for Corosync communication and 2224/tcp with 3121/tcp for Pacemaker remote communication."
+          - "Important: This does not include configuration of ports for SAP products, as they are not directly installed with this role."
+          - "For example:"
+          - "- Firewall configuration for SAP HANA can be managed separately in the `sap_hana_install` role."
+          - "- Firewall configuration for SAP ASCS/ERS can be managed separately in the `sap_swpm` role."
+          - "Managing configured Firewall:"
+          - "- Setting this variable to `false` does not remove any existing firewall configuration."
+          - "- For ongoing firewall management, consider using the `community.sap_operations.sap_firewall` role or the `firewall` Linux System Role."
+
+      sap_ha_pacemaker_cluster_firewall_zone:
+        type: str
+        description:
+          - Optional name of firewall zone where service or ports will be configured.
+          - "Default firewall zone, usually `public`, is used if this variable is undefined."
+
 
       ##########################################################################
       # Parameters that are optionally imported from 'ha_cluster' LSR parameters

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_firewall.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_firewall.yml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: SAP HA Install Pacemaker - Firewall - Install packages
+  ansible.builtin.package:
+    name: "{{ __sap_ha_pacemaker_cluster_firewall_packages + __sap_ha_pacemaker_cluster_firewall_extra_packages }}"
+    state: present
+
+- name: SAP HA Install Pacemaker - Firewall - Start and enable firewalld service
+  ansible.builtin.systemd_service:
+    name: firewalld
+    state: started
+    enabled: true
+    masked: false
+
+
+# Validate firewall zone if defined
+- name: Block for validation of firewall zone
+  when: sap_ha_pacemaker_cluster_firewall_zone is defined
+  block:
+    - name: SAP HA Install Pacemaker - Firewall - Get list of configured zones from firewalld
+      ansible.builtin.command:
+        cmd: firewall-cmd --get-zones
+      register: __sap_ha_pacemaker_cluster_register_firewall_zones
+      changed_when: false
+
+    - name: SAP HA Install Pacemaker - Firewall - Assert that the firewall zone is available
+      ansible.builtin.assert:
+        that:
+          - sap_ha_pacemaker_cluster_firewall_zone in __sap_ha_pacemaker_cluster_register_firewall_zones.stdout.split()
+        success_msg: |
+          PASS: The zone '{{ sap_ha_pacemaker_cluster_firewall_zone }}' is present in firewalld.
+        fail_msg: |
+          FAIL: The zone '{{ sap_ha_pacemaker_cluster_firewall_zone }}' is not preset in firewalld.
+          Available zones: {{ __sap_ha_pacemaker_cluster_register_firewall_zones.stdout }}
+        quiet: true
+
+
+# Proceed straight to firewall service configuration as custom ports are not an option.
+- name: SAP HA Install Pacemaker - Firewall - Generate service file from template
+  ansible.builtin.template:
+    src: firewall-ha-cluster.j2
+    dest: "/etc/firewalld/services/{{ __sap_ha_pacemaker_cluster_firewall_service_name }}.xml"
+    owner: 'root'
+    group: 'root'
+    mode: '0640'
+
+- name: SAP HA Install Pacemaker - Firewall - Reload firewalld after creating service file
+  ansible.builtin.command:
+    cmd: firewall-cmd --reload
+  changed_when: true
+
+- name: SAP HA Install Pacemaker - Firewall - Configure service in firewall
+  ansible.builtin.command:
+    cmd: >-
+      firewall-cmd
+      {% if sap_ha_pacemaker_cluster_firewall_zone is defined %}
+      --zone={{ sap_ha_pacemaker_cluster_firewall_zone }}
+      {% endif %}
+      --permanent
+      --add-service={{ __sap_ha_pacemaker_cluster_firewall_service_name }}
+  register: __sap_ha_pacemaker_cluster_register_firewall_add_service
+  changed_when: true
+
+
+- name: SAP HA Install Pacemaker - Firewall - Reload firewalld after applying changes
+  ansible.builtin.command:
+    cmd: firewall-cmd --reload
+  changed_when: true
+
+- name: SAP HA Install Pacemaker - Firewall - Get current firewall configuration of the default zone
+  ansible.builtin.command:
+    cmd: firewall-cmd --list-all
+  changed_when: false
+  register: __sap_ha_pacemaker_cluster_register_current_firewall_configuration
+
+
+- name: SAP HA Install Pacemaker - Firewall - Show details of configured firewall
+  ansible.builtin.debug:
+    msg: |
+      Firewall was configured for SAP High Availability Cluster and reloaded.
+      Output of command 'firewall-cmd --list-all':
+      {{ __sap_ha_pacemaker_cluster_register_current_firewall_configuration.stdout }}
+  when: __sap_ha_pacemaker_cluster_register_current_firewall_configuration.stdout is defined

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_main.yml
@@ -13,6 +13,12 @@
   when: __task_file_path is file
   tags: pre_ha_cluster
 
+# Firewall
+- name: SAP HA Install Pacemaker - Configure Firewall
+  ansible.builtin.include_tasks:
+    file: pre_firewall.yml
+  when: sap_ha_pacemaker_cluster_configure_firewall | d(false)
+
 
 # ASCS/ERS
 - name: "SAP HA Install Pacemaker - Include NetWeaver (A)SCS/ERS pre-tasks"

--- a/roles/sap_ha_pacemaker_cluster/templates/firewall-ha-cluster.j2
+++ b/roles/sap_ha_pacemaker_cluster/templates/firewall-ha-cluster.j2
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>SAP HA Cluster (Pacemaker/Corosync)</short>
+  <description>Core ports required for SAP High Availability (HA) Cluster. Maintained by Ansible Role sap_install.sap_ha_pacemaker_cluster.</description>
+  
+  {# Default UDP ports used by Corosync for inter-node communication and cluster heartbeats. -#}
+  <port protocol="udp" port="5404-5405"/>
+  
+  {# TCP ports used by the Pacemaker Remote service to manage remote nodes or containerized resources. -#}
+  <port protocol="tcp" port="2224"/>
+  <port protocol="tcp" port="3121"/>
+
+</service>

--- a/roles/sap_ha_pacemaker_cluster/vars/SLES_15.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/SLES_15.yml
@@ -24,3 +24,18 @@ __sap_ha_pacemaker_cluster_sap_zypper_patterns_dict:
   hana_scaleout: []
   hana_scaleup: []
   nwas: []
+
+# Firewall
+# NOTE: SLES 16 contains dependency between firewalld and python313-firewall package.
+
+__sap_ha_pacemaker_cluster_firewall_extra_packages:
+  "{{ __sap_ha_pacemaker_cluster_firewall_extra_packages_3
+    if ansible_facts['distribution_version'].split('.')[1] | int < 6
+    else __sap_ha_pacemaker_cluster_firewall_extra_packages_311 }}"
+
+# The lists of bindings for specific python version
+__sap_ha_pacemaker_cluster_firewall_extra_packages_3:
+  - "python3-firewall"
+
+__sap_ha_pacemaker_cluster_firewall_extra_packages_311:
+  - "python311-firewall"

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -110,3 +110,11 @@ __sap_ha_pacemaker_cluster_resource_primitives: []
 # Pre-define this parameter in its dictionary format:
 __sap_ha_pacemaker_cluster_corosync_totem:
   options: []
+
+# List of firewall packages
+__sap_ha_pacemaker_cluster_firewall_packages:
+  - firewalld
+__sap_ha_pacemaker_cluster_firewall_extra_packages: []
+
+# Predefined firewall service name.
+__sap_ha_pacemaker_cluster_firewall_service_name: "sap-ha-cluster"


### PR DESCRIPTION
## Changes
- Add new firewall steps to handle firewall related failures. Based on my PR https://github.com/sap-linuxlab/community.sap_install/pull/1156 and https://github.com/sap-linuxlab/community.sap_operations/pull/46
- Compared to HANA, HSR, SWPM roles, there are no custom ports offered here as pacemaker/corosync are pretty much locked in.
  - This also means they are not dependent on instance numbers so we can generalize service file name.

Resulting configuration:
```console
cat /etc/firewalld/services/sap-ha-cluster.xml
<?xml version="1.0" encoding="utf-8"?>
<service>
  <short>SAP HA Cluster (Pacemaker/Corosync)</short>
  <description>Core ports required for SAP High Availability (HA) Cluster. Maintained by Ansible Role sap_install.sap_ha_pacemaker_cluster.</description>

  <port protocol="udp" port="5404-5405"/>

  <port protocol="tcp" port="2224"/>
  <port protocol="tcp" port="3121"/>

</service>
```

## Tests
Tested on SLES_SAP 16.0 on AWS with AP4S `sap_nwas_abap_ascs_ers_cluster` scenario.
