### PR TITLE
sap_ha_pacemaker_cluster: Split off HANA pre_tasks from include_vars and add new force mode

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -969,11 +969,24 @@ sap_ha_pacemaker_cluster_resource_defaults:
 ```
 
 ### sap_ha_pacemaker_cluster_saphanasr_angi_detection
-- _Type:_ `string`
+- _Type:_ `bool`
 - _Default:_ `true`
 
-Disabling this variable enables to use Classic SAPHanaSR agents even on server, where SAPHanaSR-angi is available.<br>
-Value `false` (Classic) is ignored when only SAPHanaSR-angi packages are available.<br>
+Set to 'false' to disable auto-detection of SAP HANA Angi resource agent and use Classic agents.<br>
+This role does not substitute Migration procedure from Classic to Angi on existing cluster,<br>
+but rather new cluster setup with Angi resource agent when detected.<br>
+
+### sap_ha_pacemaker_cluster_saphanasr_angi_force
+- _Type:_ `bool`
+- _Default:_ `false`
+
+Set to 'true' to uninstall conflicting packages before using SAP HANA Angi.<br>
+This is destructive step if executed on running cluster without proper migration to SAP HANA Angi resource agent!<br>
+This is one-way process and it cannot be reverted by this role.<br>
+Reinstallation of removed packages is required to get back to the previous state.<br>
+Example for SAP HANA Scale-Up:<br>
+- RedHat: 'resource-agents-sap-hana' conflicts with SAP HANA Angi package 'sap-hana-ha'.<br>
+- Suse: 'SAPHanaSR' conflicts with SAP HANA Angi package 'SAPHanaSR-angi'.<br>
 
 ### sap_ha_pacemaker_cluster_sbd_devices
 - _Type:_ `list`

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -180,8 +180,19 @@ sap_ha_pacemaker_cluster_hana_hook_chksrv: false
 # SAP Hana global.ini path calculated from SID
 sap_ha_pacemaker_cluster_hana_global_ini_path: ''  # Default: /usr/sap/<SID>/SYS/global/hdb/custom/config/global.ini
 
-# Disable auto-detection of SAPHanaSR-angi package and use Classic
+# Set to 'false' to disable auto-detection of SAP HANA Angi resource agent and use Classic agents.
+# This role does not substitute Migration procedure from Classic to Angi on existing cluster,
+# but rather new cluster setup with Angi resource agent when detected.
 sap_ha_pacemaker_cluster_saphanasr_angi_detection: true
+
+# Set to 'true' to uninstall conflicting packages before using SAP HANA Angi.
+# This is destructive step if executed on running cluster without proper migration to SAP HANA Angi resource agent!
+# This is one-way process and it cannot be reverted by this role.
+# Reinstallation of removed packages is required to get back to the previous state.
+# Example for SAP HANA Scale-Up:
+# RedHat: 'resource-agents-sap-hana' conflicts with SAP HANA Angi package 'sap-hana-ha'.
+# Suse: 'SAPHanaSR' conflicts with SAP HANA Angi package 'SAPHanaSR-angi'.
+sap_ha_pacemaker_cluster_saphanasr_angi_force: false
 
 ################################################################################
 # NetWeaver generic definitions

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -604,11 +604,24 @@ argument_specs:
           - Path with location of global.ini for srHook update
 
       sap_ha_pacemaker_cluster_saphanasr_angi_detection:
+        type: bool
         default: true
         description:
-          - Disabling this variable enables to use Classic SAPHanaSR agents even on server,
-            where SAPHanaSR-angi is available.
-          - Value `false` (Classic) is ignored when only SAPHanaSR-angi packages are available.
+          - Set to 'false' to disable auto-detection of SAP HANA Angi resource agent and use Classic agents.
+          - This role does not substitute Migration procedure from Classic to Angi on existing cluster,
+          - but rather new cluster setup with Angi resource agent when detected.
+
+      sap_ha_pacemaker_cluster_saphanasr_angi_force:
+        type: bool
+        default: false
+        description:
+          - Set to 'true' to uninstall conflicting packages before using SAP HANA Angi.
+          - This is destructive step if executed on running cluster without proper migration to SAP HANA Angi resource agent!
+          - This is one-way process and it cannot be reverted by this role.
+          - Reinstallation of removed packages is required to get back to the previous state.
+          - "Example for SAP HANA Scale-Up:"
+          - "- RedHat: 'resource-agents-sap-hana' conflicts with SAP HANA Angi package 'sap-hana-ha'."
+          - "- Suse: 'SAPHanaSR' conflicts with SAP HANA Angi package 'SAPHanaSR-angi'."
 
       ##########################################################################
       # NetWeaver specific parameters

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/RedHat/detect_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/RedHat/detect_hana.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# NOTE: If list of packages is needed in future, these tasks need to be updated to assert loop results.
+
+- name: Block for SAP HANA Angi detection
+  when:
+    - sap_ha_pacemaker_cluster_saphanasr_angi_detection
+    - __sap_ha_pacemaker_cluster_saphanasr_angi_package_name | trim | length > 0
+  block:
+
+    - name: SAP HA Prepare Pacemaker - Check if SAP HANA Angi package is available for installation
+      ansible.builtin.command:
+        cmd: dnf list --available {{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_name }}
+      changed_when: false
+      check_mode: false
+      register: __sap_ha_pacemaker_cluster_register_saphanasr_angi_exists
+      failed_when: false
+
+    - name: SAP HA Prepare Pacemaker - Assert that the SAP HANA Angi package is available
+      ansible.builtin.assert:
+        that:
+          - __sap_ha_pacemaker_cluster_register_saphanasr_angi_exists.rc == 0
+          - __sap_ha_pacemaker_cluster_saphanasr_angi_package_name in __sap_ha_pacemaker_cluster_register_saphanasr_angi_exists.stdout
+        fail_msg: |
+          FAIL: Required package '{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_name }}' was not found in repositories.
+          Please make sure that the package is available for installation before executing the role again.
+
+
+    - name: Block for defined conflicting packages
+      when: __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | length > 0
+      block:
+        - name: SAP HA Prepare Pacemaker - Gather installed packages facts
+          ansible.builtin.package_facts:
+            manager: auto
+
+        # Force var is part of assert because it passes only if force is enabled or conflicting package is not installed.
+        - name: SAP HA Prepare Pacemaker - Assert that conflicting package was not found when force is not enabled
+          ansible.builtin.assert:
+            that:
+              - sap_ha_pacemaker_cluster_saphanasr_angi_force
+                or (__sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | d([]) | intersect(ansible_facts.packages | list) | length == 0)
+            fail_msg: |
+              FAIL: Conflicting packages '{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | join(", ") }}' are installed.
+              Uninstall these packages or set 'sap_ha_pacemaker_cluster_saphanasr_angi_force' to 'true' before executing the role again.
+
+
+        - name: SAP HA Prepare Pacemaker - Show information about upcoming removal of conflicting packages when force is enabled
+          ansible.builtin.debug:
+            msg: |
+              INFO: Conflicting packages '{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | d([])| intersect(ansible_facts.packages | list)
+                | join(", ") }}' are installed, but 'sap_ha_pacemaker_cluster_saphanasr_angi_force' is set to 'true'.
+              The role will attempt to remove these packages during execution.
+          when:
+            - sap_ha_pacemaker_cluster_saphanasr_angi_force
+            - __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | d([]) | intersect(ansible_facts.packages | list) | length > 0
+
+    - name: SAP HA Prepare Pacemaker - Set fact that SAP HANA Angi is available if asserts passed
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_saphanasr_angi_available: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/Suse/detect_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/Suse/detect_hana.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# NOTE: If list of packages is needed in future, these tasks need to be updated to assert loop results.
+
+- name: Block for SAP HANA Angi detection
+  when:
+    - sap_ha_pacemaker_cluster_saphanasr_angi_detection
+    - __sap_ha_pacemaker_cluster_saphanasr_angi_package_name | trim | length > 0
+  block:
+
+    - name: SAP HA Prepare Pacemaker - Check if SAP HANA Angi package is available for installation
+      ansible.builtin.command:
+        cmd: zypper search --provides --match-exact {{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_name }}
+      changed_when: false
+      check_mode: false
+      register: __sap_ha_pacemaker_cluster_register_saphanasr_angi_exists
+      failed_when: false
+
+    - name: SAP HA Prepare Pacemaker - Assert that the SAP HANA Angi package is available
+      ansible.builtin.assert:
+        that:
+          - __sap_ha_pacemaker_cluster_register_saphanasr_angi_exists.rc == 0
+          - __sap_ha_pacemaker_cluster_saphanasr_angi_package_name in __sap_ha_pacemaker_cluster_register_saphanasr_angi_exists.stdout
+        fail_msg: |
+          FAIL: Required package '{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_name }}' was not found in repositories.
+          Please make sure that the package is available for installation before executing the role again.
+
+
+    - name: Block for defined conflicting packages
+      when: __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | length > 0
+      block:
+        # Reason for noqa: rpm is used directly instead of ansible package facts to remove 'rpm' library dependency.
+        - name: SAP HA Prepare Pacemaker - Check the availability of conflicting package 'SAPHanaSR'  # noqa: command-instead-of-module
+          ansible.builtin.command:
+            cmd: rpm -q {{ conflict_item }}
+          loop: "{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts }}"
+          loop_control:
+            loop_var: conflict_item
+          register: __sap_ha_pacemaker_cluster_register_saphanasr_conflict
+          changed_when: false
+          check_mode: false
+          failed_when: false  # avoid failure in logs if package is not installed
+
+        # Force var is part of assert because it passes only if force is enabled or conflicting package is not installed.
+        - name: SAP HA Prepare Pacemaker - Assert that conflicting package was not found when force is not enabled
+          ansible.builtin.assert:
+            that:
+              - sap_ha_pacemaker_cluster_saphanasr_angi_force
+                or (__sap_ha_pacemaker_cluster_register_saphanasr_conflict.results | selectattr('rc', 'equalto', 0) | list | length == 0)
+            fail_msg: |
+              FAIL: Conflicting packages '{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | join(", ") }}' are installed.
+              Uninstall these packages or set 'sap_ha_pacemaker_cluster_saphanasr_angi_force' to 'true' before executing the role again.
+
+
+        - name: SAP HA Prepare Pacemaker - Show information about upcoming removal of conflicting packages when force is enabled
+          ansible.builtin.debug:
+            msg: |
+              INFO: Conflicting packages '{{ __sap_ha_pacemaker_cluster_register_saphanasr_conflict.results | selectattr('rc', 'equalto', 0)
+                | map(attribute='conflict_item') | list | join(", ") }}' are installed, but 'sap_ha_pacemaker_cluster_saphanasr_angi_force' is set to 'true'.
+              The role will attempt to remove these packages during execution.
+          when:
+            - sap_ha_pacemaker_cluster_saphanasr_angi_force
+            - __sap_ha_pacemaker_cluster_register_saphanasr_conflict.results | selectattr('rc', 'equalto', 0) | list | length > 0
+
+    - name: SAP HA Prepare Pacemaker - Set fact that SAP HANA Angi is available if asserts passed
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_saphanasr_angi_available: true

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/detect_sap_landscape.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/detect_sap_landscape.yml
@@ -46,6 +46,7 @@
       Conflicting host types found!
       There can only be max. 1 HANA and/or 1 NWAS (A)SCS/ERS type in the same definition.
 
+
 - name: "SAP HA Prepare Pacemaker - Include HANA specific variables"
   ansible.builtin.include_tasks:
     file: include_vars/include_hana.yml

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_hana.yml
@@ -1,20 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Detect presence of SAPHanaSR-angi package before loading HANA variables
-# Detection of package availability was chosen instead of OS version check.
-# SAPHanaSR-angi will be retrofitted to older SP repositories in future.
-# NOTE: This task is doing changes and should not be run in variable section!
-# TODO: Split and move to pre-tasks.
-- name: "SAP HA Install Pacemaker - Include HANA pre-tasks"
+
+# Detect presence of SAP HANA packages before loading HANA variables.
+# This is used to populate accurate value of '__sap_ha_pacemaker_cluster_saphanasr_angi_available' used in set_facts.
+- name: "SAP HA Install Pacemaker - Detect SAP HANA packages"
   ansible.builtin.include_tasks:
-    # We cannot use full path as long as this task is in wrong place.
-    file: "../{{ __task_file }}"
+    file: "{{ __task_file }}"
+    apply:
+      tags: pre_ha_cluster
   vars:
-    __task_file: "pre_tasks/{{ ansible_facts['os_family'] }}/pre_hana.yml"
-    __task_file_path: "{{ role_path }}/tasks/{{ __task_file }}"
+    __task_file: "{{ ansible_facts['os_family'] }}/detect_hana.yml"
+    __task_file_path: "{{ role_path }}/tasks/include_vars/{{ __task_file }}"
   when:
     - __task_file_path is file
-    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
 
 
 - name: "SAP HA Prepare Pacemaker - Include HANA landscape specific variables"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/RedHat/pre_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/RedHat/pre_hana.yml
@@ -1,57 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Identify if 'sap-hana-ha' package is available for installation.
-# sap-hana-ha replaces resource-agents-sap-hana and resource-agents-sap-hana-scaleout.
 
-- name: "SAP HA Prepare Pacemaker - Block for detection of 'SAPHanaSR-angi'"
-  when: (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
-  block:
+- name: SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi
+  ansible.builtin.package:
+    name: "{{ package_item }}"
+    state: absent
+  loop: "{{ __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | intersect(ansible_facts.packages | list) }}"
+  loop_control:
+    loop_var: package_item
+  when:
+    - sap_ha_pacemaker_cluster_saphanasr_angi_detection
+    - __sap_ha_pacemaker_cluster_saphanasr_angi_available
+    - __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | length > 0
 
-    - name: "SAP HA Prepare Pacemaker - Gather installed packages facts"
-      ansible.builtin.package_facts:
-        manager: auto
-
-    - name: "SAP HA Prepare Pacemaker - Check the availability of 'sap-hana-ha'"
-      ansible.builtin.command:
-        cmd: dnf provides sap-hana-ha
-      changed_when: false
-      check_mode: false
-      register: __sap_ha_pacemaker_cluster_saphanasr_angi_check
-      failed_when:
-        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc != 0
-        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc != 1
-
-      # The provision role should not fix packages if run against systems that
-      # were previously installed with the conflicting packages. System state is
-      # unclear at this moment and the role should rather fail early.
-    - name: "SAP HA Prepare Pacemaker - Fail if there are package conflicts"
-      ansible.builtin.assert:
-        that:
-          - "'resource-agents-sap-hana' not in packages or
-            __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc == 0"
-        fail_msg: |
-
-          ERROR: Conflicting packages.
-
-          Package available and to be installed: sap-hana-ha
-
-          Conflicting packages are installed:
-          {% for finding in (packages | select('match', 'resource-agents-sap.*')) %}
-          - {{ finding }}
-          {% endfor %}
-
-          Remove the conflicting packages to continue the setup with the
-          detected resource agent package.
-          Alternatively: Disable the package detection
-          (sap_ha_pacemaker_cluster_saphanasr_angi_detection = false)
-          to continue the setup using the installed resource agents.
-      when:
-        - __sap_ha_pacemaker_cluster_saphanasr_angi_check is defined
-        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc == 0
-
-    - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
-      when:
-        - __sap_ha_pacemaker_cluster_saphanasr_angi_check is defined
-        - __sap_ha_pacemaker_cluster_saphanasr_angi_check.rc == 0
+# NOTE: Removal of SAP HANA Angi was removed from pre tasks.
+# Migration from Classic to Angi should be considered one-way process and it cannot be reverted by this role.
+# Reinstallation of removed packages is required to get back to the previous state.

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/RedHat/pre_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/RedHat/pre_hana.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+# This task does not use the variable 'sap_ha_pacemaker_cluster_saphanasr_angi_force' directly,
+# because it will always fail in include_vars assert section if it is in wrong state 'false'.
 - name: SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi
   ansible.builtin.package:
     name: "{{ package_item }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/Suse/pre_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/Suse/pre_hana.yml
@@ -1,86 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-# Identify if SAPHanaSR-angi package is available for installation.
-# SAPHanaSR-angi replaces SAPHanaSR and SAPHanaSR-ScaleOut.
 
-# This is destructive step if executed on running cluster
-# without proper migration from SAPHanaSR to SAPHanaSR-angi!
-
-# SLES_SAP 16 includes only SAPHanaSR-angi and SAPHanaSR tasks are skipped.
-
-
-- name: "SAP HA Prepare Pacemaker - Block for preparation of SAPHanaSR-angi HANA cluster"
+- name: SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi
+  ansible.builtin.package:
+    name: "{{ package_item.conflict_item }}"
+    state: absent
+  loop: "{{ __sap_ha_pacemaker_cluster_register_saphanasr_conflict.results | d([]) }}"
+  loop_control:
+    loop_var: package_item
+    label: "{{ package_item.conflict_item | d('') }}"
   when:
-    - sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool
-    - ansible_distribution_major_version | int < 16
-  block:
-    - name: Query package SAPHanaSR  # noqa command-instead-of-module
-      ansible.builtin.command:
-        cmd: rpm -q SAPHanaSR
-      register: __sap_ha_pacemaker_cluster_rpm_query_saphanasr
-      changed_when: false
-      ignore_errors: true
+    - sap_ha_pacemaker_cluster_saphanasr_angi_detection
+    - __sap_ha_pacemaker_cluster_saphanasr_angi_available
+    - __sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts | length > 0
+    - package_item.rc == 0
 
-    - name: "SAP HA Prepare Pacemaker - Search for SAPHanaSR-angi"
-      ansible.builtin.command:
-        cmd: zypper se SAPHanaSR-angi
-      changed_when: false
-      register: __sap_ha_pacemaker_cluster_zypper_angi_check
-      failed_when: false
-
-
-    # Uninstall SAPHanaSR package on SLES 15
-    # package can be replaced with "rpm -e --nodeps {{ item }}"
-    - name: "SAP HA Prepare Pacemaker - Remove SAPHanaSR and SAPHanaSR-doc"
-      ansible.builtin.package:
-        name: "{{ item }}"
-        state: absent
-      loop:
-        - SAPHanaSR
-        - SAPHanaSR-doc
-      when:
-        - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
-        - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
-        - __sap_ha_pacemaker_cluster_rpm_query_saphanasr.rc == 0
-
-    - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
-      when:
-        - __sap_ha_pacemaker_cluster_zypper_angi_check is defined
-        - __sap_ha_pacemaker_cluster_zypper_angi_check.rc == 0
-
-
-- name: "SAP HA Prepare Pacemaker - Block for preparation of Classic HANA cluster"
-  when:
-    - not (sap_ha_pacemaker_cluster_saphanasr_angi_detection | bool)
-    - ansible_distribution_major_version | int < 16
-  block:
-    - name: Query package SAPHanaSR-angi  # noqa command-instead-of-module
-      ansible.builtin.command:
-        cmd: rpm -q SAPHanaSR-angi
-      register: __sap_ha_pacemaker_cluster_rpm_query_saphanasr_angi
-      changed_when: false
-      ignore_errors: true
-
-    # package can be replaced with "rpm -e --nodeps {{ item }}"
-    - name: "SAP HA Prepare Pacemaker - Remove SAPHanaSR-angi"
-      ansible.builtin.package:
-        name: "{{ item }}"
-        state: absent
-      loop:
-        - SAPHanaSR-angi
-      when:
-        - __sap_ha_pacemaker_cluster_rpm_query_saphanasr_angi.rc == 0
-
-    - name: "SAP HA Prepare Pacemaker - Set fact angi_available"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_saphanasr_angi_available: false
-
-
-# Ensure that angi flag is always set for SLES 16
-- name: "SAP HA Prepare Pacemaker - Ensure angi_available is set for SLES 16"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_saphanasr_angi_available: true
-  when:
-    - ansible_distribution_major_version | int > 15
+# NOTE: Removal of SAP HANA Angi was removed from pre tasks.
+# Migration from Classic to Angi should be considered one-way process and it cannot be reverted by this role.
+# Reinstallation of removed packages is required to get back to the previous state.

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/Suse/pre_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/Suse/pre_hana.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+# This task does not use the variable 'sap_ha_pacemaker_cluster_saphanasr_angi_force' directly,
+# because it will always fail in include_vars assert section if it is in wrong state 'false'.
 - name: SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi
   ansible.builtin.package:
     name: "{{ package_item.conflict_item }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_main.yml
@@ -18,7 +18,21 @@
   ansible.builtin.include_tasks:
     file: pre_firewall.yml
   when: sap_ha_pacemaker_cluster_configure_firewall | d(false)
+  tags: pre_ha_cluster
 
+# HANA
+- name: "SAP HA Install Pacemaker - Include HANA pre-tasks"
+  ansible.builtin.include_tasks:
+    file: "{{ __task_file }}"
+    apply:
+      tags: pre_ha_cluster
+  vars:
+    __task_file: "{{ ansible_facts['os_family'] }}/pre_hana.yml"
+    __task_file_path: "{{ role_path }}/tasks/pre_tasks/{{ __task_file }}"
+  when:
+    - __task_file_path is file
+    - sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
+  tags: pre_ha_cluster
 
 # ASCS/ERS
 - name: "SAP HA Install Pacemaker - Include NetWeaver (A)SCS/ERS pre-tasks"
@@ -34,7 +48,6 @@
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas_.*_ers') | length > 0
   tags: pre_ha_cluster
 
-# TODO: separate pre-steps from variable includes for NW and HANA
 - name: "SAP HA Install Pacemaker - Include NetWeaver ASCS/ERS pre-tasks OS specific"
   ansible.builtin.include_tasks:
     file: "{{ __task_file }}"
@@ -46,6 +59,7 @@
   when:
     - __task_file_path is file
     - sap_ha_pacemaker_cluster_host_type | select('search', 'nwas') | length > 0
+  tags: pre_ha_cluster
 
 
 # Stop and disable services that conflict with cluster setups,

--- a/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
@@ -118,7 +118,14 @@ __sap_ha_pacemaker_cluster_resource_agents:
   saphanafilesystem: "ocf:heartbeat:SAPHanaFilesystem"
   sapstartsrv: "ocf:heartbeat:SAPStartSrv"
 
-__sap_ha_pacemaker_cluster_saphanasr_angi_available: false
+# Name of SAP HANA Angi package, used in detection and installation.
+# This is string variable, because there is only one package that provides all SAP HANA Resource agents.
+__sap_ha_pacemaker_cluster_saphanasr_angi_package_name: sap-hana-ha
+
+# List of conflicting packages that cannot be installed together with SAP HANA Angi, used in detection and assert tasks.
+__sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts:
+  - resource-agents-sap-hana
+  - resource-agents-sap-hana-scaleout
 
 # Default SAP HANA hook parameters combined based on user decision
 __sap_ha_pacemaker_cluster_hook_hana_scaleup_perf:

--- a/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/Suse.yml
@@ -79,8 +79,15 @@ __sap_ha_pacemaker_cluster_resource_agents:
   saphanafilesystem: "ocf:suse:SAPHanaFilesystem"
   sapstartsrv: "ocf:suse:SAPStartSrv"
 
-# Boolean variable reflecting availability of SAPHanaSR-angi availability.
-__sap_ha_pacemaker_cluster_saphanasr_angi_available: false
+# Name of SAP HANA Angi package, used in detection and installation.
+# This is string variable, because there is only one package that provides all SAP HANA Resource agents.
+__sap_ha_pacemaker_cluster_saphanasr_angi_package_name: SAPHanaSR-angi
+
+# List of conflicting packages that cannot be installed together with SAP HANA Angi, used in detection and assert tasks.
+__sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts:
+  - SAPHanaSR
+  - SAPHanaSR-doc
+  - SAPHanaSR-ScaleOut
 
 # Default SAP HANA hook parameters combined based on user decision
 __sap_ha_pacemaker_cluster_hook_hana_scaleup_perf:

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -77,6 +77,11 @@ __sap_ha_pacemaker_cluster_no_log: true
 # Predefine host_map for variable construction
 __sap_ha_pacemaker_cluster_pcmk_host_map: ''
 
+# Non-OS specific default values for SAP HANA Angi tasks.
+__sap_ha_pacemaker_cluster_saphanasr_angi_available: false
+__sap_ha_pacemaker_cluster_saphanasr_angi_package_name: ''
+__sap_ha_pacemaker_cluster_saphanasr_angi_package_conflicts: []
+
 ###############################################################################
 # 'ha_cluster' Linux System Role transparent integration
 #


### PR DESCRIPTION
## Changes
- Remove existing incorrect handling of HANA include_vars, where real action was taken when it should not have.
- Current split:
  - Detect SAP HANA Angi packages if angi detection is set to true (default). Assert that it is available.
  - Detect conflicting packages if they are defined. Assert that they are not installed or force mode is enabled.
  - Remove conflicting packages during pre_tasks, if force mode is used.

## Tests
Tested on SLES_SAP 15 SP7 on AWS with conflicting packages installed and uninstalled.

Force mode disabled, but conflicting packages found:
```bash
    msg: |-
        FAIL: Conflicting packages 'SAPHanaSR, SAPHanaSR-doc, SAPHanaSR-ScaleOut' are installed.
        Uninstall these packages or set 'sap_ha_pacemaker_cluster_saphanasr_angi_force' to 'true' before executing the role again.
```

Notification
```bash
    msg: |-
        INFO: Conflicting packages 'SAPHanaSR, SAPHanaSR-doc' are installed, but 'sap_ha_pacemaker_cluster_saphanasr_angi_force' is set to 'true'.
        The role will attempt to remove these packages during execution.
```

Uninstall
```bash
TASK [community.sap_install.sap_ha_pacemaker_cluster : SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi] **************************
 [started TASK: community.sap_install.sap_ha_pacemaker_cluster : SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi on h02hana0]
 [started TASK: community.sap_install.sap_ha_pacemaker_cluster : SAP HA Prepare Pacemaker - Remove packages conflicting with SAP HANA Angi on h02hana1]
changed: [h02hana1] => (item=SAPHanaSR)
changed: [h02hana0] => (item=SAPHanaSR)
changed: [h02hana1] => (item=SAPHanaSR-doc)
skipping: [h02hana1] => (item=SAPHanaSR-ScaleOut)
changed: [h02hana0] => (item=SAPHanaSR-doc)
skipping: [h02hana0] => (item=SAPHanaSR-ScaleOut)
```