### PR TITLE
Revert "sap_maintain_etc_hosts, sap_hana_install, sap_install_media_detect: Ansible 2.24 compatibility"

### DIFF
--- a/roles/sap_hana_install/tasks/pre_tasks/check_filesystems.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/check_filesystems.yml
@@ -14,8 +14,8 @@
 - name: SAP HANA - Install - Pre-Tasks - Set fact with mount details of {{ sap_hana_install_shared_path }}
   ansible.builtin.set_fact:
     __sap_hana_install_fact_mount_hana_shared:
-      "{{ ansible_facts['mounts'] | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | first }}"
-  when: ansible_facts['mounts'] | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | length > 0
+      "{{ ansible_mounts | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | first }}"
+  when: ansible_mounts | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | length > 0
 
 - name: SAP HANA - Install - Pre-Tasks - Assert that filesystem is shared - {{ sap_hana_install_shared_path }}
   ansible.builtin.assert:
@@ -56,8 +56,8 @@
     - name: SAP HANA - Install - Pre-Tasks - Set fact with mount details of {{ __sap_hana_install_lss_inst_path }}
       ansible.builtin.set_fact:
         __sap_hana_install_fact_mount_lss_shared:
-          "{{ ansible_facts['mounts'] | selectattr('mount', 'equalto', __sap_hana_install_lss_inst_path) | list | first }}"
-      when: ansible_facts['mounts'] | selectattr('mount', 'equalto', __sap_hana_install_lss_inst_path) | list | length > 0
+          "{{ ansible_mounts | selectattr('mount', 'equalto', __sap_hana_install_lss_inst_path) | list | first }}"
+      when: ansible_mounts | selectattr('mount', 'equalto', __sap_hana_install_lss_inst_path) | list | length > 0
 
     - name: SAP HANA - Install - Pre-Tasks - Assert that filesystem is shared - {{ __sap_hana_install_lss_inst_path }}
       ansible.builtin.assert:

--- a/roles/sap_hana_install/templates/sap-nw-input.j2
+++ b/roles/sap_hana_install/templates/sap-nw-input.j2
@@ -4,11 +4,11 @@
 #
 
 # SAP HANA Instance Parameters
-sap_swpm_db_ip: "{{ ansible_facts['default_ipv4'].address|default(ansible_facts['all_ipv4_addresses'][0]) }}"
-sap_swpm_db_fqdn: "{{ ansible_facts['fqdn'] }}"
-sap_swpm_db_host: "{{ ansible_facts['hostname'] }}"
-sap_swpm_db_sid: "{{ sap_hana_install_sid }}"
-sap_swpm_db_instance_nr: "{{ sap_hana_install_number }}"
+sap_swpm_db_ip: '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}'
+sap_swpm_db_fqdn: '{{ ansible_fqdn }}'
+sap_swpm_db_host: '{{ ansible_hostname }}'
+sap_swpm_db_sid: '{{ sap_hana_install_sid }}'
+sap_swpm_db_instance_nr: '{{ sap_hana_install_number }}'
 
 # SAP HANA Passwords
 sap_swpm_db_system_password: '{{ sap_hana_install_db_system_password|d(sap_hana_install_master_password) }}'

--- a/roles/sap_hana_install/vars/main.yml
+++ b/roles/sap_hana_install/vars/main.yml
@@ -8,7 +8,7 @@ __sap_hana_install_sid_prohibited: ['ADD', 'ADM', 'ALL', 'AMD', 'AND', 'ANY', 'A
 __sap_hana_install_fact_tmp_dirname: ''
 
 # This dictionary defines keyword rules to identify SAP binaries compatible with modern Linux distributions supported by SAP HANA.
-# Each key is a valid "ansible_facts['architecture']" value.
+# Each key is a valid `ansible_architecture` value.
 # The value is a list of rule sets, where each rule set is a list of keywords.
 # A file is considered a match if all keywords from any single rule set are found in the `file` command's output.
 __sap_hana_install_architecture_matrix:
@@ -40,7 +40,7 @@ __sap_hana_install_architecture_matrix:
     - ['aarch64']
 
 # Sets the default host which will run all non-addhosts tasks.
-__sap_hana_install_fact_main_host: "{{ ansible_facts['hostname'] }}"
+__sap_hana_install_fact_main_host: "{{ ansible_hostname }}"
 
 # Sets default value of Scale-Out detection.
 # Detection for scaleout is based on addhosts string.

--- a/roles/sap_install_media_detect/README.md
+++ b/roles/sap_install_media_detect/README.md
@@ -167,7 +167,7 @@ Based on this setting, the commands for listing and extracting RAR files are bei
 ### sap_install_media_detect_epel_gpg_key_url
 
 - _Type:_ `str`
-- _Default:_ `https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}`
+- _Default:_ `https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}`
 
 URL for the EPEL GPG key
 

--- a/roles/sap_install_media_detect/defaults/main.yml
+++ b/roles/sap_install_media_detect/defaults/main.yml
@@ -11,7 +11,7 @@ sap_install_media_detect_rar_package: 'EPEL'
 #sap_install_media_detect_rar_package: 'linux-rar'
 
 # URL for the EPEL GPG key
-sap_install_media_detect_epel_gpg_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
+sap_install_media_detect_epel_gpg_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 # The EPEL GPG key can be removed with the rpm_key module and the URL for the key, or by using the rpm -e command.
 # For using the rpm -e command, set this variable to 'false'.

--- a/roles/sap_install_media_detect/tasks/cleanup/disable-epel-repo.yml
+++ b/roles/sap_install_media_detect/tasks/cleanup/disable-epel-repo.yml
@@ -4,7 +4,7 @@
 # Note: This file is only included from tasks/main.yml if the epel-release package had not been initially detected.
 
 - name: SAP Install Media Detect - Cleanup - Get all GPG keys
-  ansible.builtin.shell: set -o pipefail && rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | awk '/gpg/&&/Fedora/{gsub ("\\(epel", "EPEL "); gsub (" \\(", " "); if ($0 ~ /EPEL {{ ansible_facts['distribution_major_version'] }}/)print}'
+  ansible.builtin.shell: set -o pipefail && rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | awk '/gpg/&&/Fedora/{gsub ("\\(epel", "EPEL "); gsub (" \\(", " "); if ($0 ~ /EPEL {{ ansible_distribution_major_version }}/)print}'
   register: __sap_install_media_detect_register_rpm_q_gpg_pubkeys
   failed_when: false
   changed_when: false
@@ -30,7 +30,7 @@
     - __sap_install_media_detect_register_rpm_q_gpg_pubkeys.stdout_lines | length == 1
 
 - name: SAP Install Media Detect - Cleanup - Get the GPG keys for this OS version after removal, rpm -e
-  ansible.builtin.shell: set -o pipefail && rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep 'EPEL ({{ ansible_facts['distribution_major_version'] }})'
+  ansible.builtin.shell: set -o pipefail && rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep 'EPEL ({{ ansible_distribution_major_version }})'
   register: __sap_install_media_detect_register_rpm_q_gpg_pubkeys_after_removal
   changed_when: false
   failed_when: false

--- a/roles/sap_install_media_detect/tasks/main.yml
+++ b/roles/sap_install_media_detect/tasks/main.yml
@@ -98,7 +98,7 @@
   when:
     - sap_install_media_detect_rar_handling
     - sap_install_media_detect_rar_package == 'EPEL'
-    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_os_family == 'RedHat'
     - __sap_install_media_detect_register_rpm_q_epel.stdout != 'epel-release'
 
 - name: SAP Install Media Detect - Cleanup - Remove sapfile utility

--- a/roles/sap_install_media_detect/tasks/prepare/enable_rar_handling.yml
+++ b/roles/sap_install_media_detect/tasks/prepare/enable_rar_handling.yml
@@ -4,7 +4,7 @@
 - name: SAP Install Media Detect - Prepare - Install the unar package from EPEL
   when:
     - sap_install_media_detect_rar_package == 'EPEL'
-    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_os_family == 'RedHat'
   block:
 
 # Reason for noqa: Too much effort for now to examine the output of the yum module for the presence of a package
@@ -33,12 +33,12 @@
 
 #        - name: SAP Install Media Detect - Prepare - EPEL - Set fact for the EPEL URL
 #          ansible.builtin.set_fact:
-#            sap_install_media_detect_epel_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+#            sap_install_media_detect_epel_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 
         - name: SAP Install Media Detect - Prepare - EPEL - Enable the EPEL repo
           ansible.builtin.package:
 #            name: "{{ sap_install_media_detect_epel_url }}"
-            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
             state: present
           retries: 10
 
@@ -60,7 +60,7 @@
 
 - name: SAP Install Media Detect - Prepare - Install the unar package (SLES)
   when:
-    - ansible_facts['os_family'] == 'Suse'
+    - ansible_os_family == 'Suse'
   block:
 
     # Requires SLES Basesystem_Module_* to obtain package

--- a/roles/sap_maintain_etc_hosts/README.md
+++ b/roles/sap_maintain_etc_hosts/README.md
@@ -123,7 +123,7 @@ Following dictionary keys can be defined:
     - _Type:_ `string`
 
 - **node_domain**<br>
-    Domain name of the managed node. Defaults to `sap_domain` if set or `ansible_facts['domain']`.<br>
+    Domain name of the managed node. Defaults to `sap_domain` if set or `ansible_domain`.<br>
     **Required** for adding new entries to `/etc/hosts`.</br>
     _Optional_ for removing entries, when `node_name` is used.
 

--- a/roles/sap_maintain_etc_hosts/defaults/main.yml
+++ b/roles/sap_maintain_etc_hosts/defaults/main.yml
@@ -16,7 +16,7 @@
 #      When deleting a node use only when node_ip is not defined
 # - node_domain
 #      Domainname of the node
-#      Defaults to sap_domain, if set, otherwise ansible_facts['domain'] is the default
+#      Defaults to sap_domain, if set, otherwise ansible_domain is the default
 #      When deleting a node use only when node_name is defined
 # - aliases
 #      List of aliases for the node

--- a/roles/sap_maintain_etc_hosts/meta/argument_specs.yml
+++ b/roles/sap_maintain_etc_hosts/meta/argument_specs.yml
@@ -30,7 +30,7 @@ argument_specs:
             type: str
             description:
               - Domainname of the node
-              - _Optional. Defaults to sap_domain, if set, otherwise ansible_facts['domain'] is the default_
+              - _Optional. Defaults to sap_domain, if set, otherwise ansible_domain is the default_
               - _Optional. when deleting a node use only when node_name is defined_
           aliases:
             type: list

--- a/roles/sap_maintain_etc_hosts/tasks/main.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/main.yml
@@ -43,19 +43,19 @@
 
 - name: Ensure required defaults are read from setup module
   when: >
-    not ((ansible_facts['hostname'] is defined) and
-    (ansible_facts['domain'] is defined) and
-    (ansible_facts['default_ipv4'] is defined))
+    not ((ansible_hostname is defined) and
+    (ansible_domain is defined) and
+    (ansible_default_ipv4 is defined))
   ## this is equivalent to
-  # (ansible_facts['hostname'] is undefined) or
-  # (ansible_facts['domain'] is undefined) or
-  # (ansible_facts['default_ipv4'] is defined)
+  # (ansible_hostname is undefined) or
+  # (ansible_domain is undefined) or
+  # (ansible_default_ipv4 is defined)
   ansible.builtin.setup:
     gather_subset: "{{ __sap_maintain_etc_hosts_gather_subset }}"
     filter:
-      - "ansible_facts['hostname']"
-      - "ansible_facts['domain']"
-      - "ansible_facts['default_ipv4']"
+      - "ansible_hostname"
+      - "ansible_domain"
+      - "ansible_default_ipv4"
 
 # when sap_maintain_etc_hosts_list is empty, set defaults for local host
 - name: Ensure sap_maintain_etc_hosts_list is filled with defaults
@@ -65,9 +65,9 @@
     ( sap_maintain_etc_hosts_list | trim == '')
   ansible.builtin.set_fact:
     sap_maintain_etc_hosts_list:
-      - node_ip: "{{ ansible_facts['default_ipv4'].address }}"
-        node_name: "{{ ansible_facts['hostname'] }}"
-        node_domain: "{{ sap_domain | default(ansible_facts['domain']) }}"
+      - node_ip: "{{ ansible_default_ipv4.address }}"
+        node_name: "{{ ansible_hostname }}"
+        node_domain: "{{ sap_domain | default(ansible_domain) }}"
         node_comment: "managed by ansible sap_maintain_etc_hosts role"
         state: present
 

--- a/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
+++ b/roles/sap_maintain_etc_hosts/tasks/update_host_present.yml
@@ -35,7 +35,7 @@
   ansible.builtin.set_fact:
     __sap_maintain_etc_hosts_domain:
       "{{ thishost.node_domain if thishost.node_domain is defined and thishost.node_domain != ''
-        else (sap_domain if sap_domain is defined and sap_domain != '' else ansible_facts['domain'] | d('')) }}"
+        else (sap_domain if sap_domain is defined and sap_domain != '' else ansible_domain | d('')) }}"
 
 - name: Verify that variable domain_name is set
   ansible.builtin.assert:


### PR DESCRIPTION
Reverts sap-linuxlab/community.sap_install#1186, which was accidentally opened against the `main` branch instead of `dev`.