### PR TITLE
sap_storage_setup, sap_hostagent, anydb: Ansible 2.24 compatibility

### DIFF
--- a/roles/sap_anydb_install_oracle/tasks/main.yml
+++ b/roles/sap_anydb_install_oracle/tasks/main.yml
@@ -12,16 +12,16 @@
   loop: "{{ __var_files }}"
   vars:
     __vars_file: "{{ role_path }}/vars/{{ item }}"
-    __distribution_major: "{{ ansible_distribution ~ '_' ~ ansible_distribution_major_version }}"
-    __distribution_minor: "{{ ansible_distribution ~ '_' ~ ansible_distribution_version }}"
+    __distribution_major: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_version'] }}"
     # Enables loading of shared vars between SLES and SLES_SAP
-    __distribution_major_split: "{{ ansible_distribution.split('_')[0] ~ '_' ~ ansible_distribution_major_version }}"
-    __distribution_minor_split: "{{ ansible_distribution.split('_')[0] ~ '_' ~ ansible_distribution_version }}"
+    __distribution_major_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_version'] }}"
     __var_files: >-
       {{
         [
-          ansible_os_family ~ '.yml',
-          (ansible_distribution ~ '.yml') if ansible_distribution != ansible_os_family else None,
+          ansible_facts['os_family'] ~ '.yml',
+          (ansible_facts['distribution'] ~ '.yml') if ansible_facts['distribution'] != ansible_facts['os_family'] else None,
           (__distribution_major_split ~ '.yml') if __distribution_major_split != __distribution_major else None,
           (__distribution_minor_split ~ '.yml') if __distribution_minor_split != __distribution_minor else None,
           __distribution_major ~ '.yml',

--- a/roles/sap_anydb_install_oracle/tasks/oracledb_install_pre.yml
+++ b/roles/sap_anydb_install_oracle/tasks/oracledb_install_pre.yml
@@ -10,14 +10,14 @@
   register: __sap_anydb_install_oracle_register_patterns
   changed_when: false
   ignore_errors: true
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
   loop: "{{ __sap_anydb_install_oracle_patterns }}"
   when:
-    - ansible_os_family == 'Suse'
+    - ansible_facts['os_family'] == 'Suse'
     - item not in __sap_anydb_install_oracle_register_patterns.stdout
   changed_when: item not in __sap_anydb_install_oracle_register_patterns.stdout
 

--- a/roles/sap_anydb_install_oracle/tasks/oracledb_installer_minimal.yml
+++ b/roles/sap_anydb_install_oracle/tasks/oracledb_installer_minimal.yml
@@ -50,7 +50,7 @@
     setenv INVENTORY_LOCATION "{{ sap_anydb_install_oracle_inventory_central }}"
     setenv oracle.install.db.config.starterdb.globalDBName "{{ sap_anydb_install_oracle_sid }}"
     setenv oracle.install.db.config.starterdb.SID "{{ sap_anydb_install_oracle_sid }}"
-    setenv oracle.install.db.config.starterdb.memoryLimit "{{ (ansible_memtotal_mb*0.95) | int }}"
+    setenv oracle.install.db.config.starterdb.memoryLimit "{{ (ansible_facts['memtotal_mb']*0.95) | int }}"
     setenv oracle.install.db.config.starterdb.storageType "FILE_SYSTEM_STORAGE"
     setenv oracle.install.db.config.starterdb.fileSystemStorage.dataLocation "{{ sap_anydb_install_oracle_filesystem_storage }}"
     setenv oracle.install.db.config.starterdb.password.ALL "{{ sap_anydb_install_oracle_system_password }}"

--- a/roles/sap_anydb_install_oracle/templates/oracledb_rsp_install_dbinstall.j2
+++ b/roles/sap_anydb_install_oracle/templates/oracledb_rsp_install_dbinstall.j2
@@ -214,7 +214,7 @@ oracle.install.db.config.starterdb.memoryOption=false
 # on the system.
 # Example: oracle.install.db.config.starterdb.memoryLimit=512
 #-------------------------------------------------------------------------------
-oracle.install.db.config.starterdb.memoryLimit={{ (ansible_memtotal_mb*0.95) | int }}
+oracle.install.db.config.starterdb.memoryLimit={{ (ansible_facts['memtotal_mb']*0.95) | int }}
 
 #-------------------------------------------------------------------------------
 # This variable controls whether to load Example Schemas onto

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/db2_hadr_pcmk_cluster_create.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/db2_hadr_pcmk_cluster_create.yml
@@ -20,7 +20,7 @@
 
     - name: SAP HA AnyDB - IBM Db2 HADR - List all IBM Db2 'Integrated Linux Pacemaker' RPMs in subdirectory
       ansible.builtin.find:
-        paths: "{{ (__sap_ha_install_anydb_ibmdb2_pcmk.files[0].path | dirname) + '/Linux/' + ('rhel' if ansible_os_family == 'RedHat' else 'suse' if ansible_os_family == 'Suse') }}"
+        paths: "{{ (__sap_ha_install_anydb_ibmdb2_pcmk.files[0].path | dirname) + '/Linux/' + ('rhel' if ansible_facts['os_family'] == 'RedHat' else 'suse' if ansible_facts['os_family'] == 'Suse') }}"
         recurse: true
         file_type: file
         patterns:
@@ -36,7 +36,7 @@
         name: "{{ __sap_ha_install_anydb_ibmdb2_pcmk_rpm_files.files | map(attribute='path') | list | sort }}"
         state: present
         disable_gpg_check: true
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts['os_family'] == 'RedHat'
 
     # For SLES 15, various Zypper errors will occur when 'Integrated Linux Pacemaker' RPMs attempt installation, such as:
     ### the installed cluster-glue-libs** obsoletes 'libglue2 < **' provided by the to be installed libglue2**.db2pcmk.**
@@ -64,7 +64,7 @@
         state: absent
         disable_gpg_check: true
       when:
-        - ansible_os_family == 'Suse'
+        - ansible_facts['os_family'] == 'Suse'
         - __sap_ha_install_anydb_ibmdb2_hadr_initial_status.stdout != "HADR_CONNECT_STATUS=CONNECTED" # Use to avoid removal of OS Package on re-run
 
     - name: SAP HA AnyDB - IBM Db2 HADR - Install all IBM Db2 'Integrated Linux Pacemaker' RPMs for SLES
@@ -72,7 +72,7 @@
         name: "{{ __sap_ha_install_anydb_ibmdb2_pcmk_rpm_files.files | map(attribute='path') | list | sort }}"
         state: present
         disable_gpg_check: true
-      when: ansible_os_family == 'Suse'
+      when: ansible_facts['os_family'] == 'Suse'
 
     # SAP Note 3100287 - DB6: Db2 Support for Pacemaker Cluster Software
     # Reasons for noqa:
@@ -160,8 +160,8 @@
         export anydb_secondary="{{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}"
 
         # Assume 1 OS Network Interface until improvements can be made
-        export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_default_ipv4.interface }}"
-        export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_default_ipv4.interface }}"
+        export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_facts['default_ipv4'].interface }}"
+        export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_facts['default_ipv4'].interface }}"
 
         /db2/$ibmdb2_instance/sqllib/bin/db2cm -create -cluster -domain db2pcmkcluster -host $anydb_primary -publicEthernet $anydb_primary_nic -host $anydb_secondary -publicEthernet $anydb_secondary_nic -remote_cmd "ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
       register: __sap_ha_install_anydb_ibmdb2_config1

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/passwordless_ssh.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/passwordless_ssh.yml
@@ -141,7 +141,7 @@
         owner: root
         group: root
         block: |
-          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_default_ipv4.address }} {{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}
+          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_facts['default_ipv4'].address }} {{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}
               IdentityFile /root/.ssh/anydb_ibmdb2_hadr_{{ sap_ha_install_anydb_ibmdb2_hostname_primary }}
       when: sap_ha_install_anydb_ibmdb2_hostname_primary == inventory_hostname_short
 
@@ -155,7 +155,7 @@
         owner: db2{{ sap_ha_install_anydb_ibmdb2_sid | lower }}
         group: db{{ sap_ha_install_anydb_ibmdb2_sid | lower }}adm
         block: |
-          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_default_ipv4.address }} {{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}
+          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_facts['default_ipv4'].address }} {{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}
               IdentityFile /db2/db2{{ sap_ha_install_anydb_ibmdb2_sid | lower }}/.ssh/anydb_ibmdb2_hadr_{{ sap_ha_install_anydb_ibmdb2_hostname_primary }}
       when: sap_ha_install_anydb_ibmdb2_hostname_primary == inventory_hostname_short
 
@@ -214,7 +214,7 @@
         owner: root
         group: root
         block: |
-          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_default_ipv4.address }} {{ sap_ha_install_anydb_ibmdb2_hostname_primary }}
+          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_facts['default_ipv4'].address }} {{ sap_ha_install_anydb_ibmdb2_hostname_primary }}
               IdentityFile /root/.ssh/anydb_ibmdb2_hadr_{{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}
       when: sap_ha_install_anydb_ibmdb2_hostname_secondary == inventory_hostname_short
 
@@ -228,7 +228,7 @@
         owner: db2{{ sap_ha_install_anydb_ibmdb2_sid | lower }}
         group: db{{ sap_ha_install_anydb_ibmdb2_sid | lower }}adm
         block: |
-          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_default_ipv4.address }} {{ sap_ha_install_anydb_ibmdb2_hostname_primary }}
+          Host {{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_facts['default_ipv4'].address }} {{ sap_ha_install_anydb_ibmdb2_hostname_primary }}
               IdentityFile /db2/db2{{ sap_ha_install_anydb_ibmdb2_sid | lower }}/.ssh/anydb_ibmdb2_hadr_{{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}
       when: sap_ha_install_anydb_ibmdb2_hostname_secondary == inventory_hostname_short
 

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/ascertain_platform_type.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/ascertain_platform_type.yml
@@ -5,37 +5,37 @@
 ### Facts already available to Ansible
 #
 ### Amazon Web Services EC2 Virtual Server. Not applicable for AWS Classic.
-# ansible_chassis_asset_tag: "Amazon EC2" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "i-043d3c1a889ed9016" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
-# ansible_chassis_vendor: "Amazon EC2"
-# ansible_product_name: "r5.8xlarge" # IaaS profile name
-# ansible_system_vendor: "Amazon EC2"
+# ansible_facts['chassis_asset_tag'] : "Amazon EC2" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "i-043d3c1a889ed9016" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
+# ansible_facts['chassis_vendor']: "Amazon EC2"
+# ansible_facts['product_name']: "r5.8xlarge" # IaaS profile name
+# ansible_facts['system_vendor']: "Amazon EC2"
 #
 ### Google Cloud Compute Engine Virtual Machine.
-# ansible_chassis_asset_tag: "NA" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "9EAF3038-7EF5-3F1E-6620-FB3BDA7A3709" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
-# ansible_chassis_vendor: "Google"
-# ansible_product_name: "Google Compute Engine"
-# ansible_system_vendor: "Google"
+# ansible_facts['chassis_asset_tag'] : "NA" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "9EAF3038-7EF5-3F1E-6620-FB3BDA7A3709" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
+# ansible_facts['chassis_vendor']: "Google"
+# ansible_facts['product_name']: "Google Compute Engine"
+# ansible_facts['system_vendor']: "Google"
 #
 ### IBM Cloud Virtual Server. Not applicable for IBM Cloud Classic Infrastructure.
-# ansible_chassis_asset_tag: "ibmcloud" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "0c7d4459-xxxx-yyyy-zzzz-abcdefghijkl" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
-# ansible_chassis_vendor: "IBM:Cloud Compute Server 1.0:mx2-16x128" # IaaS profile name as suffix (after colon)
-# ansible_product_name: "Standard PC (i440FX + PIIX, 1996)"
-# ansible_system_vendor: "QEMU"
+# ansible_facts['chassis_asset_tag'] : "ibmcloud" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "0c7d4459-xxxx-yyyy-zzzz-abcdefghijkl" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
+# ansible_facts['chassis_vendor']: "IBM:Cloud Compute Server 1.0:mx2-16x128" # IaaS profile name as suffix (after colon)
+# ansible_facts['product_name']: "Standard PC (i440FX + PIIX, 1996)"
+# ansible_facts['system_vendor']: "QEMU"
 #
 ### Microsoft Azure Virtual Machine. Not applicable for MS Azure Classic/ASM.
-# ansible_chassis_asset_tag: "7783-xxxx-yyyy-zzzz-aaaa-bbbb-cc" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "None" # SMBIOS Baseboard Asset Tag
-# ansible_chassis_vendor: "Microsoft Corporation"
-# ansible_product_name: "Virtual Machine"
-# ansible_system_vendor: "70f4a858-1eea-4c35-b9e1-e179c32fc6b5" # ID of virtual machine on platform
+# ansible_facts['chassis_asset_tag'] : "7783-xxxx-yyyy-zzzz-aaaa-bbbb-cc" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "None" # SMBIOS Baseboard Asset Tag
+# ansible_facts['chassis_vendor']: "Microsoft Corporation"
+# ansible_facts['product_name']: "Virtual Machine"
+# ansible_facts['system_vendor']: "70f4a858-1eea-4c35-b9e1-e179c32fc6b5" # ID of virtual machine on platform
 #
 ### VMware vSphere
-# ansible_product_name: "VMware7,1",
-# ansible_system_vendor: "VMware, Inc.",
-# ansible_virtualization_type: "VMware"
+# ansible_facts['product_name']: "VMware7,1",
+# ansible_facts['system_vendor']: "VMware, Inc.",
+# ansible_facts['virtualization_type']: "VMware"
 #
 ### End of comment
 
@@ -50,40 +50,40 @@
   ansible.builtin.set_fact:
     __sap_ha_install_anydb_ibmdb2_platform: cloud_aws_ec2_vs
   when:
-    - '"amazon" in ansible_system_vendor | lower
-      or "amazon" in ansible_product_name | lower'
+    - '"amazon" in ansible_facts["system_vendor"] | lower
+      or "amazon" in ansible_facts["product_name"] | lower'
 
 - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is Google Cloud Compute Engine Virtual Machine
   ansible.builtin.set_fact:
     __sap_ha_install_anydb_ibmdb2_platform: cloud_gcp_ce_vm
   when:
-    - ansible_product_name == 'Google Compute Engine'
+    - ansible_facts['product_name'] == 'Google Compute Engine'
 
 - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is IBM Cloud Virtual Server
   ansible.builtin.set_fact:
     __sap_ha_install_anydb_ibmdb2_platform: cloud_ibmcloud_vs
   when:
-    - ansible_chassis_asset_tag == 'ibmcloud'
+    - ansible_facts['chassis_asset_tag'] == 'ibmcloud'
 
 - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is Microsoft Azure Virtual Machine
   ansible.builtin.set_fact:
     __sap_ha_install_anydb_ibmdb2_platform: cloud_msazure_vm
   when:
-    - ansible_product_name == 'Virtual Machine'
-    - ansible_chassis_vendor == 'Microsoft Corporation'
+    - ansible_facts['product_name'] == 'Virtual Machine'
+    - ansible_facts['chassis_vendor'] == 'Microsoft Corporation'
 
 # - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is IBM Power - RSCT binary check
 #   ansible.builtin.shell: |
 #     set -o pipefail && rpm -qa | grep -E -e "rsct.basic"
 #   register: __sap_ha_install_anydb_ibmdb2_power_rsct_check
 #   changed_when: false
-#   when: ansible_architecture == "ppc64le"
+#   when: ansible_facts['architecture'] == "ppc64le"
 
 # - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is IBM Power - RSCT binary check
 #   ansible.builtin.fail:
 #     msg: Please install RSCT from IBM Power Systems service and productivity tools repository
 #   when:
-#     - ansible_architecture == "ppc64le"
+#     - ansible_facts['architecture'] == "ppc64le"
 #     - __sap_ha_install_anydb_ibmdb2_power_rsct_check.stdout == ""
 
 # - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is IBM Power - RSCT binary check
@@ -92,25 +92,25 @@
 #   register: __sap_ha_install_anydb_ibmdb2_power_rsct_hscid
 #   changed_when: false
 #   when:
-#     - ansible_architecture == "ppc64le"
+#     - ansible_facts['architecture'] == "ppc64le"
 #     - __sap_ha_install_anydb_ibmdb2_power_rsct_check.stdout != ""
 
 # - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is IBM Power Virtual Server from IBM Cloud
 #   ansible.builtin.set_fact:
 #     __sap_ha_install_anydb_ibmdb2_platform: cloud_ibmcloud_powervs
 #   when:
-#     - ansible_architecture == "ppc64le"
+#     - ansible_facts['architecture'] == "ppc64le"
 #     - '"ibmcloud" in __sap_ha_install_anydb_ibmdb2_power_rsct_hscid.stdout'
 
 # - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is IBM PowerVM
 #   ansible.builtin.set_fact:
 #     __sap_ha_install_anydb_ibmdb2_platform: hyp_ibmpower_vm
 #   when:
-#     - ansible_architecture == "ppc64le"
+#     - ansible_facts['architecture'] == "ppc64le"
 #     - '"ibmcloud" not in __sap_ha_install_anydb_ibmdb2_power_rsct_hscid.stdout'
 
 # - name: SAP HA AnyDB - IBM Db2 HADR - Check if platform is VMware vSphere"
 #   ansible.builtin.set_fact:
 #     __sap_ha_install_anydb_ibmdb2_platform: hyp_vmware_vsphere_vm
 #   when:
-#     - ansible_virtualization_type == 'VMware'
+#     - ansible_facts['virtualization_type'] == 'VMware'

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_aws_ec2_vs.yml
@@ -7,7 +7,7 @@
       - fence-agents-aws
       - awscli
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (AWS) - Fence Agent Packages for SLES
   ansible.builtin.package:
@@ -15,7 +15,7 @@
       - fence-agents
       - awscli
     state: present
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 # IBM Db2 HADR on AWS EC2 VS
 # www.ibm.com/support/pages/node/6829815
@@ -91,8 +91,8 @@
     export anydb_secondary="{{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}"
 
     # Assume 1 OS Network Interface until improvements can be made
-    export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_default_ipv4.interface }}"
-    export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_default_ipv4.interface }}"
+    export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_facts['default_ipv4'].interface }}"
+    export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_facts['default_ipv4'].interface }}"
 
     /db2/$ibmdb2_instance/sqllib/bin/db2cm -enable -all
     /db2/$ibmdb2_instance/sqllib/bin/db2cm -enable -instance $ibmdb2_instance -host $anydb_primary -publicEthernet $anydb_primary_nic -host $anydb_secondary -publicEthernet $anydb_secondary_nic -remote_cmd "ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_gcp_ce_vm.yml
@@ -7,7 +7,7 @@
 #       - fence-agents-gce
 #       - resource-agents-gcp
 #     state: present
-#   when: ansible_os_family == 'RedHat'
+#   when: ansible_facts['os_family'] == 'RedHat'
 
 # - name: SAP HA AnyDB - IBM Db2 HADR (Google Cloud) - Fence Agent Packages for SLES
 #   ansible.builtin.package:
@@ -15,7 +15,7 @@
 #       - fence-agents
 #       - resource-agents-gcp
 #     state: present
-#   when: ansible_os_family == 'Suse'
+#   when: ansible_facts['os_family'] == 'Suse'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (Google Cloud) - GCloud Repo Key
   ansible.builtin.rpm_key:
@@ -32,20 +32,20 @@
     gpgkey:
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
 
 # Reasons for noqa:
 # - no-changed-when: SUSEConnect command will not perform changes if already exists
 - name: SAP HA AnyDB - IBM Db2 HADR (Google Cloud) - GCloud Repo Add for SLES # noqa no-changed-when
   ansible.builtin.shell: |
-    SUSEConnect --product sle-module-public-cloud/{{ ansible_distribution_version }}/x86_64
-  when: ansible_os_family == 'Suse'
+    SUSEConnect --product sle-module-public-cloud/{{ ansible_facts['distribution_version'] }}/x86_64
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (Google Cloud) - GCloud CLI Package for RHEL
   ansible.builtin.package:
     name: google-cloud-cli
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (Google Cloud) - GCloud CLI Package for SLES
   ansible.builtin.package:
@@ -54,7 +54,7 @@
       - google-guest-configs
       - google-guest-oslogin
     state: present
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 
 # IBM Db2 HADR on GCP CE VMs
@@ -140,8 +140,8 @@
     export anydb_secondary="{{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}"
 
     # Assume 1 OS Network Interface until improvements can be made
-    export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_default_ipv4.interface }}"
-    export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_default_ipv4.interface }}"
+    export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_facts['default_ipv4'].interface }}"
+    export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_facts['default_ipv4'].interface }}"
 
     /db2/$ibmdb2_instance/sqllib/bin/db2cm -enable -all
     /db2/$ibmdb2_instance/sqllib/bin/db2cm -enable -instance $ibmdb2_instance -host $anydb_primary -publicEthernet $anydb_primary_nic -host $anydb_secondary -publicEthernet $anydb_secondary_nic -remote_cmd "ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_ibmcloud_vs.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_ibmcloud_vs.yml
@@ -14,7 +14,7 @@
       - fence-agents-ibm-vpc
       - haproxy
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (IBM Cloud) - Fence Agent Packages for SLES
   ansible.builtin.package:
@@ -22,7 +22,7 @@
       - fence-agents
       - haproxy
     state: present
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 
 # Reasons for noqa:

--- a/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_msazure_vm.yml
+++ b/roles/sap_ha_install_anydb_ibmdb2/tasks/platform/db2cm_cloud_msazure_vm.yml
@@ -7,7 +7,7 @@
       - fence-agents-azure-arm
       - socat
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (MS Azure) - Fence Agent Packages for SLES
   ansible.builtin.package:
@@ -15,7 +15,7 @@
       - fence-agents
       - socat
     state: present
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (MS Azure) - Azure CLI Repo Key
   ansible.builtin.rpm_key:
@@ -27,16 +27,16 @@
     name: https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
     state: present
   when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "9"
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution_major_version'] == "9"
 
 - name: SAP HA AnyDB - IBM Db2 HADR (MS Azure) - Azure CLI Repo Package for RHEL 8
   ansible.builtin.package:
     name: https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
     state: present
   when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "8"
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution_major_version'] == "8"
 
 - name: SAP HA AnyDB - IBM Db2 HADR (MS Azure) - Azure CLI Repo for SLES
   community.general.zypper_repository:
@@ -44,7 +44,7 @@
     repo: https://packages.microsoft.com/yumrepos/azure-cli
     state: present
     auto_import_keys: true
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: SAP HA AnyDB - IBM Db2 HADR (MS Azure) - Azure CLI Package
   ansible.builtin.package:
@@ -128,8 +128,8 @@
     export anydb_secondary="{{ sap_ha_install_anydb_ibmdb2_hostname_secondary }}"
 
     # Assume 1 OS Network Interface until improvements can be made
-    export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_default_ipv4.interface }}"
-    export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_default_ipv4.interface }}"
+    export anydb_primary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_primary].ansible_facts['default_ipv4'].interface }}"
+    export anydb_secondary_nic="{{ hostvars[sap_ha_install_anydb_ibmdb2_hostname_secondary].ansible_facts['default_ipv4'].interface }}"
 
     /db2/$ibmdb2_instance/sqllib/bin/db2cm -enable -all
     /db2/$ibmdb2_instance/sqllib/bin/db2cm -enable -instance $ibmdb2_instance -host $anydb_primary -publicEthernet $anydb_primary_nic -host $anydb_secondary -publicEthernet $anydb_secondary_nic -remote_cmd "ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/roles/sap_hostagent/tasks/config_ssl.yml
+++ b/roles/sap_hostagent/tasks/config_ssl.yml
@@ -31,7 +31,7 @@
     -p SAPSSLS.pse
     -x "{{ sap_hostagent_ssl_passwd }}"
     -r /tmp/myhost-csr.p10
-    "CN={{ ansible_fqdn }}, O={{ sap_hostagent_ssl_org }}, C={{ sap_hostagent_ssl_country }}"
+    "CN={{ ansible_facts['fqdn'] }}, O={{ sap_hostagent_ssl_org }}, C={{ sap_hostagent_ssl_country }}"
   become: true
   become_user: sapadm
   args:

--- a/roles/sap_storage_setup/tasks/generic_tasks/configure_multipathing.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/configure_multipathing.yml
@@ -32,7 +32,7 @@
       - "hardware"
 
 # Similar to generic device discovery and fs mapping (main.yml), but using different
-# information from the ansible_devices facts to map the WWN instead of dynamic device names.
+# information from the ansible_facts['devices'] facts to map the WWN instead of dynamic device names.
 
 # Logic: Collect devices which have
 # - no "holders"
@@ -45,7 +45,7 @@
   ansible.builtin.set_fact:
     __sap_storage_setup_fact_available_devices_multipath: |
       {% set av_disks = [] %}
-      {% set all_disks = (ansible_devices | dict2items) %}
+      {% set all_disks = (ansible_facts['devices'] | dict2items) %}
       {% for disk in all_disks %}
         {%- if disk.value.wwn is defined
             and disk.value.links.uuids | length == 0

--- a/roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml
+++ b/roles/sap_storage_setup/tasks/generic_tasks/map_single_disks_to_filesystems.yml
@@ -3,7 +3,7 @@
 ##########
 # Creating a list of unused devices that match the requested filesystem sizes, using
 # - definition of unconfigured filesystems: __sap_storage_setup_fact_new_mounts
-# - ansible facts: ansible_devices
+# - ansible facts: ansible_facts['devices']
 #
 #########
 
@@ -11,7 +11,7 @@
   ansible.builtin.set_fact:
     __sap_storage_setup_fact_available_devices: |
       {%- set av_disks = [] -%}
-      {%- set all_disks = (ansible_devices | dict2items) -%}
+      {%- set all_disks = (ansible_facts['devices'] | dict2items) -%}
       {%- for disk in all_disks -%}
         {%- for fs in __sap_storage_setup_fact_new_mounts -%}
           {%- if disk.value.size | regex_search('.*TB$') -%}
@@ -33,7 +33,7 @@
 # !!
 # If the DISK MATCHING syntax has changed in the above, it must also
 # be adjusted in the next task.
-# As ansible_devices returns only human-readable format, handling
+# As ansible_facts['devices'] returns only human-readable format, handling
 # for TB is provided and default is GB; use of MB and PB will error.
 # !!
 
@@ -121,7 +121,7 @@
 # Sources:
 # - __sap_storage_setup_fact_new_mounts derived from extravars: sap_storage_setup_definition
 #   and is dynamically generated during runtime to list only unconfigured filesystems
-# - Ansible host facts: hostvars[host_node].ansible_devices
+# - Ansible host facts: hostvars[host_node].ansible_facts['devices']
 - name: SAP Storage Setup - Set fact for device to filesystem mapping
   when:
     - map_item.nfs_path is not defined

--- a/roles/sap_storage_setup/tasks/main.yml
+++ b/roles/sap_storage_setup/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: SAP Storage Setup - Include OS specific vars
   ansible.builtin.include_vars:
-    file: "{{ ansible_os_family }}.yml"
+    file: "{{ ansible_facts['os_family'] }}.yml"
 
 - name: SAP Storage Setup - Install additional OS packages
   when: __sap_storage_setup_extra_packages is defined
@@ -34,12 +34,12 @@
     - new_mounts_item.nfs_path is not defined
     - (
         new_mounts_item.mountpoint is defined
-        and new_mounts_item.mountpoint not in ansible_mounts | map(attribute="mount")
+        and new_mounts_item.mountpoint not in ansible_facts['mounts'] | map(attribute="mount")
       )
       or
       (
         new_mounts_item.filesystem_type == 'swap'
-        and ansible_swaptotal_mb < (new_mounts_item.disk_size * 1000)
+        and ansible_facts['swaptotal_mb'] < (new_mounts_item.disk_size * 1000)
       )
     # Calculating with 1000 instead of 1024, because existing swaptotal is likely to be
     # reported at a slightly reduced size due to volume/filesystem metadata.


### PR DESCRIPTION
## Changes
Ansible-core 2.20 has changed how Ansible Facts are handled and new deprecation warning started because of this change https://docs.ansible.com/projects/ansible-core/2.20/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars.

```yaml
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/mmamula/workspace/tests/debug.yml:23:14

21     - name: Test ansible_hostname
22       ansible.builtin.debug:
23         msg: "{{ ansible_hostname }}"
                ^ column 14

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```