### PR TITLE
sap_ha_pacemaker_cluster: Ansible 2.24 compatibility

### DIFF
--- a/playbooks/sample-sap-storage-setup_sap_s4hana_distributed.yml
+++ b/playbooks/sample-sap-storage-setup_sap_s4hana_distributed.yml
@@ -153,10 +153,10 @@
       ansible.builtin.include_role:
         name: community.sap_install.sap_storage_setup
       vars:
-        sap_storage_setup_sid: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_sid | default('') }}"
-        sap_storage_setup_host_type: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_host_type | list }}"
-        sap_storage_setup_definition: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_definition | list }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_nwas_abap_ascs_instance_nr | default(omit) }}"
-        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_nwas_abap_ers_instance_nr | default(omit) }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_nwas_abap_pas_instance_nr | default(omit) }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ aws_host_specifications_dictionary[ansible_hostname].sap_storage_setup_nwas_abap_aas_instance_nr | default(omit) }}"
+        sap_storage_setup_sid: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_sid | default('') }}"
+        sap_storage_setup_host_type: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_host_type | list }}"
+        sap_storage_setup_definition: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_definition | list }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_nwas_abap_ascs_instance_nr | default(omit) }}"
+        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_nwas_abap_ers_instance_nr | default(omit) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_nwas_abap_pas_instance_nr | default(omit) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ aws_host_specifications_dictionary[ansible_facts['hostname']].sap_storage_setup_nwas_abap_aas_instance_nr | default(omit) }}"

--- a/playbooks/sap_hana_preconfigure_exec.yml
+++ b/playbooks/sap_hana_preconfigure_exec.yml
@@ -6,7 +6,7 @@
 # The minimum viable set of variables which need to be defined are:
 #
 # sap_hana_group: name of group in inventory - defaults to localhost if not set
-# sap_domain: SAP domain - defaults to ansible_domain if not set, but must not be empty
+# sap_domain: SAP domain - defaults to ansible_facts['domain'] if not set, but must not be empty
 #
 # For sap_general_preconfigure:
 # sap_general_preconfigure_modify_etc_hosts: defaults to true
@@ -30,9 +30,9 @@
       ansible.builtin.debug:
         msg: |-
           The SAP HANA preconfiguration runs with the following configuration:
-          - 'Hostname                : {{ sap_hostname | d(ansible_hostname) }}'
-          - 'IP Address              : {{ sap_ip | d(ansible_default_ipv4.address) }}'
-          - 'Domain                  : {{ (sap_domain | d('') | length > 0) | ternary(sap_domain, ansible_domain) }}'
+          - 'Hostname                : {{ sap_hostname | d(ansible_facts['hostname']) }}'
+          - 'IP Address              : {{ sap_ip | d(ansible_facts['default_ipv4'].address) }}'
+          - 'Domain                  : {{ (sap_domain | d('') | length > 0) | ternary(sap_domain, ansible_facts['domain']) }}'
           - 'Modify hosts            : {{ sap_general_preconfigure_modify_etc_hosts | d('false') }}'
           - 'Update OS               : {{ sap_hana_preconfigure_update | d('false') }}'
           - 'Auto Reboot             : {{ sap_hana_preconfigure_reboot_ok | d('false') }}'

--- a/playbooks/vars/sample-variables-sap-swpm-advanced-mode-s4hana-onehost-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-advanced-mode-s4hana-onehost-install.yml
@@ -27,7 +27,7 @@ sap_swpm_inifile_custom_values_dictionary:
   DiagnosticsAgent.dasidAdmPassword: ''
   HDB_Recovery_Dialogs.backupLocation: ''
   HDB_Recovery_Dialogs.backupName: ''
-  HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+  HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
   HDB_Recovery_Dialogs.sidAdmName: hdbadm
   HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
   HDB_Schema_Check_Dialogs.schemaName: ''
@@ -41,7 +41,7 @@ sap_swpm_inifile_custom_values_dictionary:
   NW_ABAP_TMSConfig.configureTMS: true
   NW_checkMsgServer.abapMSPort: 3602
   NW_CI_Instance.ascsInstanceNumber: '02'
-  NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+  NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
   NW_CI_Instance.ciInstanceNumber: '01'
   NW_CI_Instance.ciMSPort: 3602
   NW_CI_Instance.scsInstanceNumber: ''
@@ -53,7 +53,7 @@ sap_swpm_inifile_custom_values_dictionary:
   NW_GetSidNoProfiles.sid: S4H
   NW_HDB_DB.abapSchemaName: SAPHANADB
   NW_HDB_DB.abapSchemaPassword: NewPass$321
-  NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+  NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
   NW_HDB_getDBInfo.dbsid: HDB
   NW_HDB_getDBInfo.instanceNumber: '00'
   NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -66,7 +66,7 @@ sap_swpm_inifile_custom_values_dictionary:
   NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
   NW_SCS_Instance.ascsInstallGateway: true
   NW_SCS_Instance.instanceNumber: '02'
-  NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+  NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
   nwUsers.sapsysGID: ''
   nwUsers.sidAdmUID: ''
   nwUsers.sidadmPassword: NewPass$321

--- a/playbooks/vars/sample-variables-sap-swpm-advanced-templates-mode.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-advanced-templates-mode.yml
@@ -51,7 +51,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: ''
       HDB_Recovery_Dialogs.backupName: ''
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hdbadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -65,7 +65,7 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.configureTMS: true
       NW_checkMsgServer.abapMSPort: 3602
       NW_CI_Instance.ascsInstanceNumber: '02'
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '01'
       NW_CI_Instance.ciMSPort: 3602
       NW_CI_Instance.scsInstanceNumber: ''
@@ -77,7 +77,7 @@ sap_swpm_templates_install_dictionary:
       NW_GetSidNoProfiles.sid: ''
       NW_HDB_DB.abapSchemaName: SAPHANADB
       NW_HDB_DB.abapSchemaPassword: NewPass$321
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HDB
       NW_HDB_getDBInfo.instanceNumber: '00'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -90,7 +90,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: '02'
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapsysGID: ''
       nwUsers.sidAdmUID: ''
       nwUsers.sidadmPassword: NewPass$321
@@ -104,7 +104,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: /software/backup_location
       HDB_Recovery_Dialogs.backupName: COMPLETE_DATA_BACKUP
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hdbadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -121,7 +121,7 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.transportPassword: ''
       NW_checkMsgServer.abapMSPort: 3602
       NW_CI_Instance.ascsInstanceNumber: '02'
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '01'
       NW_CI_Instance.ciMSPort: 3602
       NW_CI_Instance.ciVirtualHostname: ''
@@ -136,7 +136,7 @@ sap_swpm_templates_install_dictionary:
       NW_HDB_DB.abapSchemaPassword: NewPass$321
       NW_HDB_DB.javaSchemaName: ''
       NW_HDB_DB.javaSchemaPassword: ''
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HDB
       NW_HDB_getDBInfo.instanceNumber: '00'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -152,7 +152,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: '02'
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapadmUID: ''
       nwUsers.sapsysGID: ''
       nwUsers.sidadmPassword: ''
@@ -167,7 +167,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: ''
       HDB_Recovery_Dialogs.backupName: ''
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hdbadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -181,7 +181,7 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.configureTMS: true
       NW_checkMsgServer.abapMSPort: 3602
       NW_CI_Instance.ascsInstanceNumber: '02'
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '01'
       NW_CI_Instance.ciMSPort: 3602
       NW_CI_Instance.scsInstanceNumber: ''
@@ -193,7 +193,7 @@ sap_swpm_templates_install_dictionary:
       NW_GetSidNoProfiles.sid: ''
       NW_HDB_DB.abapSchemaName: SAPHANADB
       NW_HDB_DB.abapSchemaPassword: NewPass$321
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HDB
       NW_HDB_getDBInfo.instanceNumber: '00'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -206,7 +206,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: '02'
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapsysGID: ''
       nwUsers.sidAdmUID: ''
       nwUsers.sidadmPassword: NewPass$321
@@ -220,7 +220,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: /software/backup_location
       HDB_Recovery_Dialogs.backupName: COMPLETE_DATA_BACKUP
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hdbadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -237,7 +237,7 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.transportPassword: ''
       NW_checkMsgServer.abapMSPort: 3602
       NW_CI_Instance.ascsInstanceNumber: '02'
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '01'
       NW_CI_Instance.ciMSPort: 3602
       NW_CI_Instance.ciVirtualHostname: ''
@@ -252,7 +252,7 @@ sap_swpm_templates_install_dictionary:
       NW_HDB_DB.abapSchemaPassword: NewPass$321
       NW_HDB_DB.javaSchemaName: ''
       NW_HDB_DB.javaSchemaPassword: ''
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HDB
       NW_HDB_getDBInfo.instanceNumber: '00'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -268,7 +268,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: '02'
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapadmUID: ''
       nwUsers.sapsysGID: ''
       nwUsers.sidadmPassword: ''
@@ -283,7 +283,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: ''
       HDB_Recovery_Dialogs.backupName: ''
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hdbadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -300,7 +300,7 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.transportPassword: ''
       NW_checkMsgServer.abapMSPort: 3602
       NW_CI_Instance.ascsInstanceNumber: '02'
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '01'
       NW_CI_Instance.ciMSPort: 3602
       NW_CI_Instance.ciVirtualHostname: ''
@@ -315,7 +315,7 @@ sap_swpm_templates_install_dictionary:
       NW_HDB_DB.abapSchemaPassword: NewPass$321
       NW_HDB_DB.javaSchemaName: ''
       NW_HDB_DB.javaSchemaPassword: ''
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HDB
       NW_HDB_getDBInfo.instanceNumber: '00'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -331,7 +331,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: '02'
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapadmUID: ''
       nwUsers.sapsysGID: ''
       nwUsers.sidadmPassword: ''
@@ -408,7 +408,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: ''
       HDB_Recovery_Dialogs.backupName: ''
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:50013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:50013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hsaadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -425,7 +425,7 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.transportPassword: ''
       NW_checkMsgServer.abapMSPort: 3602
       NW_CI_Instance.ascsInstanceNumber: '02'
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '01'
       NW_CI_Instance.ciMSPort: 3602
       NW_CI_Instance.ciVirtualHostname: ''
@@ -440,7 +440,7 @@ sap_swpm_templates_install_dictionary:
       NW_HDB_DB.abapSchemaPassword: NewPass$321
       NW_HDB_DB.javaSchemaName: ''
       NW_HDB_DB.javaSchemaPassword: ''
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HSA
       NW_HDB_getDBInfo.instanceNumber: '00'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -456,7 +456,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: '02'
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapadmUID: ''
       nwUsers.sapsysGID: ''
       nwUsers.sidadmPassword: ''
@@ -471,7 +471,7 @@ sap_swpm_templates_install_dictionary:
       DiagnosticsAgent.dasidAdmPassword: ''
       HDB_Recovery_Dialogs.backupLocation: ''
       HDB_Recovery_Dialogs.backupName: ''
-      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_hostname }}:51013/SAPControl?wsdl"
+      HDB_Recovery_Dialogs.sapControlWsdlUrl: "http://{{ ansible_facts['hostname'] }}:51013/SAPControl?wsdl"
       HDB_Recovery_Dialogs.sidAdmName: hsjadm
       HDB_Recovery_Dialogs.sidAdmPassword: NewPass$321
       HDB_Schema_Check_Dialogs.schemaName: ''
@@ -488,12 +488,12 @@ sap_swpm_templates_install_dictionary:
       NW_ABAP_TMSConfig.transportPassword: ''
       NW_checkMsgServer.abapMSPort: 36
       NW_CI_Instance.ascsInstanceNumber: ''
-      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ascsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.ciInstanceNumber: '11'
       NW_CI_Instance.ciMSPort: 36
-      NW_CI_Instance.ciVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.ciVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_CI_Instance.scsInstanceNumber: '12'
-      NW_CI_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_CI_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       NW_DDIC_Password.ddic000Password: NewPass$321
       NW_getFQDN.FQDN: poc.cloud
       NW_getFQDN.setFQDN: true
@@ -503,7 +503,7 @@ sap_swpm_templates_install_dictionary:
       NW_HDB_DB.abapSchemaPassword: ''
       NW_HDB_DB.javaSchemaName: SAPJAVA1
       NW_HDB_DB.javaSchemaPassword: NewPass$321
-      NW_HDB_getDBInfo.dbhost: "{{ ansible_hostname }}"
+      NW_HDB_getDBInfo.dbhost: "{{ ansible_facts['hostname'] }}"
       NW_HDB_getDBInfo.dbsid: HSJ
       NW_HDB_getDBInfo.instanceNumber: '10'
       NW_HDB_getDBInfo.systemDbPassword: NewPass$321
@@ -519,7 +519,7 @@ sap_swpm_templates_install_dictionary:
       NW_Recovery_Install_HDB.sidAdmPassword: NewPass$321
       NW_SCS_Instance.ascsInstallGateway: true
       NW_SCS_Instance.instanceNumber: ''
-      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_hostname }}"
+      NW_SCS_Instance.scsVirtualHostname: "{{ ansible_facts['hostname'] }}"
       nwUsers.sapadmUID: ''
       nwUsers.sapsysGID: ''
       nwUsers.sidadmPassword: ''

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-bw4hana-onehost-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-bw4hana-onehost-install.yml
@@ -41,8 +41,8 @@ sap_swpm_ddic_000_password: "NewPass$321"
 sap_swpm_sid: B4H
 sap_swpm_pas_instance_nr: "01"
 sap_swpm_ascs_instance_nr: "02"
-sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
-sap_swpm_db_host: "{{ ansible_hostname }}"
+sap_swpm_ascs_instance_hostname: "{{ ansible_facts['hostname'] }}"
+sap_swpm_db_host: "{{ ansible_facts['hostname'] }}"
 sap_swpm_db_sid: HDB
 sap_swpm_db_instance_nr: "00"
 sap_swpm_fqdn: "poc.cloud"

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-s4hana-onehost-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-s4hana-onehost-install.yml
@@ -48,11 +48,11 @@ sap_swpm_db_sidadm_password: "NewPass$321"
 sap_swpm_sid: S4H
 sap_swpm_pas_instance_nr: "01"
 sap_swpm_ascs_instance_nr: "02"
-sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_ascs_instance_hostname: "{{ ansible_facts['hostname'] }}"
 sap_swpm_fqdn: "poc.cloud"
 
 # HDB Instance Parameters
 # For dual host installation, change the db_host to appropriate value
-sap_swpm_db_host: "{{ ansible_hostname }}"
+sap_swpm_db_host: "{{ ansible_facts['hostname'] }}"
 sap_swpm_db_sid: HDB
 sap_swpm_db_instance_nr: "00"

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-s4hana-onehost-restore.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-s4hana-onehost-restore.yml
@@ -52,12 +52,12 @@ sap_swpm_db_sidadm_password: "NewPass$321"
 sap_swpm_sid: S4H
 sap_swpm_pas_instance_nr: "01"
 sap_swpm_ascs_instance_nr: "02"
-sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_ascs_instance_hostname: "{{ ansible_facts['hostname'] }}"
 sap_swpm_fqdn: "poc.cloud"
 
 # HDB Instance Parameters
 # For dual host installation, change the db_host to appropriate value
-sap_swpm_db_host: "{{ ansible_hostname }}"
+sap_swpm_db_host: "{{ ansible_facts['hostname'] }}"
 sap_swpm_db_sid: HDB
 sap_swpm_db_instance_nr: "00"
 

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-solman-hana-abap-onehost-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-solman-hana-abap-onehost-install.yml
@@ -63,12 +63,12 @@ sap_swpm_db_sidadm_password: "NewPass$321"
 sap_swpm_sid: SHA
 sap_swpm_pas_instance_nr: "01"
 sap_swpm_ascs_instance_nr: "02"
-sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_ascs_instance_hostname: "{{ ansible_facts['hostname'] }}"
 sap_swpm_fqdn: "poc.cloud"
 #sap_swpm_deployment_load_type: 'HBR'
 
 # HDB Instance Parameters
-sap_swpm_db_host: "{{ ansible_hostname }}"
+sap_swpm_db_host: "{{ ansible_facts['hostname'] }}"
 sap_swpm_db_sid: HSA
 sap_swpm_db_instance_nr: "00"
 

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-solman-hana-java-onehost-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-solman-hana-java-onehost-install.yml
@@ -66,13 +66,13 @@ sap_swpm_db_sidadm_password: "NewPass$321"
 sap_swpm_sid: SHJ
 sap_swpm_pas_instance_nr: "11"
 sap_swpm_java_scs_instance_nr: "12"
-sap_swpm_pas_instance_hostname: "{{ ansible_hostname }}"
-sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_pas_instance_hostname: "{{ ansible_facts['hostname'] }}"
+sap_swpm_ascs_instance_hostname: "{{ ansible_facts['hostname'] }}"
 sap_swpm_fqdn: "poc.cloud"
 
 
 # HDB Instance Parameters
-sap_swpm_db_host: "{{ ansible_hostname }}"
+sap_swpm_db_host: "{{ ansible_facts['hostname'] }}"
 sap_swpm_db_sid: HSJ
 sap_swpm_db_instance_nr: "10"
 
@@ -82,4 +82,4 @@ sap_swpm_ume_j2ee_admin_password: "NewPass$321"
 sap_swpm_ume_sapjsf_password: "NewPass$321"
 sap_swpm_ume_client_nr: "000"
 sap_swpm_ume_instance_nr: "01"
-sap_swpm_ume_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_ume_instance_hostname: "{{ ansible_facts['hostname'] }}"

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-system-rename.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-system-rename.yml
@@ -22,9 +22,9 @@ sap_swpm_sapcar_file_name: SAPCAR_1010-70006178.EXE
 
 # SAP instance details
 sap_swpm_ascs_instance_nr: "02"
-sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_ascs_instance_hostname: "{{ ansible_facts['hostname'] }}"
 sap_swpm_pas_instance_nr: "01"
-sap_swpm_pas_instance_hostname: "{{ ansible_hostname }}"
+sap_swpm_pas_instance_hostname: "{{ ansible_facts['hostname'] }}"
 
 sap_swpm_sid_source: S4H
 sap_swpm_sid_target: S20
@@ -32,7 +32,7 @@ sap_swpm_sid_target: S20
 sap_swpm_sidadm_password: "NewPass$321"
 sap_swpm_abap_schema_password: "NewPass$321"
 sap_swpm_abap_schema_target: "SAPHANADB"
-sap_swpm_db_host_source: "{{ ansible_hostname }}"
+sap_swpm_db_host_source: "{{ ansible_facts['hostname'] }}"
 sap_swpm_db_type: "hdb"
 sap_swpm_db_sid_source: HDB
 sap_swpm_db_sid_target: HDB

--- a/playbooks/vars/sample-variables-sap-swpm-default-mode-webdisp-standalone-install.yml
+++ b/playbooks/vars/sample-variables-sap-swpm-default-mode-webdisp-standalone-install.yml
@@ -42,14 +42,14 @@ sap_swpm_wd_system_connectivity: 'false'
 sap_swpm_wd_activate_icf: 'false'
 sap_swpm_wd_backend_sid: 'S4H'
 sap_swpm_wd_backend_ms_http_port: '8001'
-sap_swpm_wd_backend_ms_host: "{{ ansible_hostname }}"
-sap_swpm_wd_backend_rfc_host: "{{ ansible_hostname }}"
+sap_swpm_wd_backend_ms_host: "{{ ansible_facts['hostname'] }}"
+sap_swpm_wd_backend_rfc_host: "{{ ansible_facts['hostname'] }}"
 sap_swpm_wd_backend_rfc_instance_nr: "01"
 sap_swpm_wd_backend_rfc_client_nr: "000"
 sap_swpm_wd_backend_rfc_user: "DDIC"
 sap_swpm_wd_backend_rfc_user_password: "NewPass$321"
 sap_swpm_wd_backend_scenario_size: '500'
-sap_swpm_wd_virtual_host: "{{ ansible_hostname }}"
+sap_swpm_wd_virtual_host: "{{ ansible_facts['hostname'] }}"
 
 # SAP Host Agent
 sap_swpm_install_saphostagent: 'false'

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/detect_platform_type.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/detect_platform_type.yml
@@ -5,37 +5,37 @@
 ### Facts already available to Ansible
 #
 ### Amazon Web Services EC2 Virtual Server. Not applicable for AWS Classic.
-# ansible_chassis_asset_tag: "Amazon EC2" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "i-043d3c1a889ed9016" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
-# ansible_chassis_vendor: "Amazon EC2"
-# ansible_product_name: "r5.8xlarge" # IaaS profile name
-# ansible_system_vendor: "Amazon EC2"
+# ansible_facts['chassis_asset_tag']: "Amazon EC2" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "i-043d3c1a889ed9016" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
+# ansible_facts['chassis_vendor']: "Amazon EC2"
+# ansible_facts['product_name']: "r5.8xlarge" # IaaS profile name
+# ansible_facts['system_vendor']: "Amazon EC2"
 #
 ### Google Cloud Compute Engine Virtual Machine.
-# ansible_chassis_asset_tag: "NA" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "9EAF3038-7EF5-3F1E-6620-FB3BDA7A3709" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
-# ansible_chassis_vendor: "Google"
-# ansible_product_name: "Google Compute Engine"
-# ansible_system_vendor: "Google"
+# ansible_facts['chassis_asset_tag']: "NA" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "9EAF3038-7EF5-3F1E-6620-FB3BDA7A3709" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
+# ansible_facts['chassis_vendor']: "Google"
+# ansible_facts['product_name']: "Google Compute Engine"
+# ansible_facts['system_vendor']: "Google"
 #
 ### IBM Cloud Virtual Server. Not applicable for IBM Cloud Classic Infrastructure.
-# ansible_chassis_asset_tag: "ibmcloud" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "0c7d4459-xxxx-yyyy-zzzz-abcdefghijkl" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
-# ansible_chassis_vendor: "IBM:Cloud Compute Server 1.0:mx2-16x128" # IaaS profile name as suffix (after colon)
-# ansible_product_name: "Standard PC (i440FX + PIIX, 1996)"
-# ansible_system_vendor: "QEMU"
+# ansible_facts['chassis_asset_tag']: "ibmcloud" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "0c7d4459-xxxx-yyyy-zzzz-abcdefghijkl" # SMBIOS Baseboard Asset Tag, ID of virtual machine on platform
+# ansible_facts['chassis_vendor']: "IBM:Cloud Compute Server 1.0:mx2-16x128" # IaaS profile name as suffix (after colon)
+# ansible_facts['product_name']: "Standard PC (i440FX + PIIX, 1996)"
+# ansible_facts['system_vendor']: "QEMU"
 #
 ### Microsoft Azure Virtual Machine. Not applicable for MS Azure Classic/ASM.
-# ansible_chassis_asset_tag: "7783-xxxx-yyyy-zzzz-aaaa-bbbb-cc" # SMBIOS Chassis Asset Tag
-# ansible_board_asset_tag: "None" # SMBIOS Baseboard Asset Tag
-# ansible_chassis_vendor: "Microsoft Corporation"
-# ansible_product_name: "Virtual Machine"
-# ansible_system_vendor: "70f4a858-1eea-4c35-b9e1-e179c32fc6b5" # ID of virtual machine on platform
+# ansible_facts['chassis_asset_tag']: "7783-xxxx-yyyy-zzzz-aaaa-bbbb-cc" # SMBIOS Chassis Asset Tag
+# ansible_facts['board_asset_tag']: "None" # SMBIOS Baseboard Asset Tag
+# ansible_facts['chassis_vendor']: "Microsoft Corporation"
+# ansible_facts['product_name']: "Virtual Machine"
+# ansible_facts['system_vendor']: "70f4a858-1eea-4c35-b9e1-e179c32fc6b5" # ID of virtual machine on platform
 #
 ### VMware vSphere
-# ansible_product_name: "VMware7,1",
-# ansible_system_vendor: "VMware, Inc.",
-# ansible_virtualization_type: "VMware"
+# ansible_facts['product_name']: "VMware7,1",
+# ansible_facts['system_vendor']: "VMware, Inc.",
+# ansible_facts['virtualization_type']: "VMware"
 #
 ### End of comment
 
@@ -49,28 +49,28 @@
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is Amazon Web Services EC2 Virtual Server"
   when:
-    - '"amazon" in ansible_system_vendor | lower
-      or "amazon" in ansible_product_name | lower
-      or "amazon" in ansible_product_version | lower'
+    - '"amazon" in ansible_facts["system_vendor"] | lower
+      or "amazon" in ansible_facts["product_name"] | lower
+      or "amazon" in ansible_facts["product_version"] | lower'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: cloud_aws_ec2_vs
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is Google Cloud Compute Engine Virtual Machine"
   when:
-    - ansible_product_name == 'Google Compute Engine'
+    - ansible_facts['product_name'] == 'Google Compute Engine'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: cloud_gcp_ce_vm
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is IBM Cloud Virtual Server"
   when:
-    - ansible_chassis_asset_tag == 'ibmcloud'
+    - ansible_facts['chassis_asset_tag'] == 'ibmcloud'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: cloud_ibmcloud_vs
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is Microsoft Azure Virtual Machine"
   when:
-    - ansible_product_name == 'Virtual Machine'
-    - ansible_chassis_vendor == 'Microsoft Corporation'
+    - ansible_facts['product_name'] == 'Virtual Machine'
+    - ansible_facts['chassis_vendor'] == 'Microsoft Corporation'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: cloud_msazure_vm
 
@@ -80,13 +80,13 @@
   register: __sap_ha_pacemaker_cluster_power_rsct_check
   changed_when: false
   check_mode: false
-  when: ansible_architecture == "ppc64le"
+  when: ansible_facts['architecture'] == "ppc64le"
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - Fail if RSCT binary is missing"
   ansible.builtin.fail:
     msg: Please install RSCT from IBM Power Systems service and productivity tools repository
   when:
-    - ansible_architecture == "ppc64le"
+    - ansible_facts['architecture'] == "ppc64le"
     - __sap_ha_pacemaker_cluster_power_rsct_check.stdout == ""
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power - Run 'ctgethscid'"
@@ -96,26 +96,26 @@
   changed_when: false
   check_mode: false
   when:
-    - ansible_architecture == "ppc64le"
+    - ansible_facts['architecture'] == "ppc64le"
     - __sap_ha_pacemaker_cluster_power_rsct_check.stdout != ""
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is IBM Power Virtual Server from IBM Cloud"
   when:
-    - ansible_architecture == "ppc64le"
+    - ansible_facts['architecture'] == "ppc64le"
     - '"ibmcloud" in __sap_ha_pacemaker_cluster_power_rsct_hscid.stdout'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: cloud_ibmcloud_powervs
 
 - name: "SAP HA Prepare Pacemaker - Check if platform is IBM PowerVM"
   when:
-    - ansible_architecture == "ppc64le"
+    - ansible_facts['architecture'] == "ppc64le"
     - '"ibmcloud" not in __sap_ha_pacemaker_cluster_power_rsct_hscid.stdout'
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_platform: hyp_ibmpower_vm
 
 # - name: "SAP HA Prepare Pacemaker - Check if platform is VMware vSphere"
 #   when:
-#     - ansible_virtualization_type == 'VMware'
+#     - ansible_facts['virtualization_type'] == 'VMware'
 #   ansible.builtin.set_fact:
 #     __sap_ha_pacemaker_cluster_platform: hyp_vmware_vsphere_vm
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_common.yml
@@ -13,9 +13,9 @@
 # Assumption: The local loopback "lo" is always in the list.
 - name: "SAP HA Prepare Pacemaker - Set network interface name when only one interface is present"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_vip_client_interface: "{{ ansible_default_ipv4.interface }}"
+    __sap_ha_pacemaker_cluster_vip_client_interface: "{{ ansible_facts['default_ipv4'].interface }}"
   when:
-    - ansible_interfaces | length <= 2
+    - ansible_facts['interfaces'] | length <= 2
     - sap_ha_pacemaker_cluster_vip_client_interface == ''
 
 
@@ -30,16 +30,16 @@
   loop: "{{ __var_files }}"
   vars:
     __vars_file: "{{ role_path }}/vars/{{ item }}"
-    __distribution_major: "{{ ansible_distribution ~ '_' ~ ansible_distribution_major_version }}"
-    __distribution_minor: "{{ ansible_distribution ~ '_' ~ ansible_distribution_version }}"
+    __distribution_major: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_version'] }}"
     # Enables loading of shared vars between SLES and SLES_SAP
-    __distribution_major_split: "{{ ansible_distribution.split('_')[0] ~ '_' ~ ansible_distribution_major_version }}"
-    __distribution_minor_split: "{{ ansible_distribution.split('_')[0] ~ '_' ~ ansible_distribution_version }}"
+    __distribution_major_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_version'] }}"
     __var_files: >-
       {{
         [
-          ansible_os_family ~ '.yml',
-          (ansible_distribution ~ '.yml') if ansible_distribution != ansible_os_family else None,
+          ansible_facts['os_family'] ~ '.yml',
+          (ansible_facts['distribution'] ~ '.yml') if ansible_facts['distribution'] != ansible_facts['os_family'] else None,
           (__distribution_major_split ~ '.yml') if __distribution_major_split != __distribution_major else None,
           (__distribution_minor_split ~ '.yml') if __distribution_minor_split != __distribution_minor else None,
           __distribution_major ~ '.yml',

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_hana.yml
@@ -74,7 +74,7 @@
         else sap_ha_pacemaker_cluster_hanacontroller_resource_name }}"
 
     __sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name:
-      "{{ ('mst' if ansible_os_family == 'Suse' else 'cln') ~ '_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
+      "{{ ('mst' if ansible_facts['os_family'] == 'Suse' else 'cln') ~ '_SAPHanaCon_' ~ __sap_ha_pacemaker_cluster_hana_sid ~ '_HDB' ~ __sap_ha_pacemaker_cluster_hana_instance_nr
         if sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name | string | length == 0
         else sap_ha_pacemaker_cluster_hanacontroller_resource_clone_name }}"
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_platform.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/include_platform.yml
@@ -16,7 +16,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
-        {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].ansible_board_asset_tag }}
+        {{ hostvars[node].ansible_facts['hostname'] }}:{{ hostvars[node].ansible_facts['board_asset_tag'] }}
       {%- if not loop.last %};{% endif %}
       {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_aws_ec2_vs"
@@ -35,7 +35,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
-        {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].__sap_ha_pacemaker_cluster_register_ibmcloud_powervs_host.stdout }}
+        {{ hostvars[node].ansible_facts['hostname'] }}:{{ hostvars[node].__sap_ha_pacemaker_cluster_register_ibmcloud_powervs_host.stdout }}
       {%- if not loop.last %};{% endif %}
       {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_ibmcloud_powervs"
@@ -55,7 +55,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
-        {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}
+        {{ hostvars[node].ansible_facts['hostname'] }}:{{ hostvars[node].sap_ha_pacemaker_cluster_ibmpower_vm_hmc_system_partition_name }}
       {%- if not loop.last %};{% endif %}
       {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "hyp_ibmpower_vm"
@@ -66,7 +66,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
-        {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].__sap_ha_pacemaker_cluster_register_ibmcloud_vs_host.stdout }}
+        {{ hostvars[node].ansible_facts['hostname'] }}:{{ hostvars[node].__sap_ha_pacemaker_cluster_register_ibmcloud_vs_host.stdout }}
       {%- if not loop.last %};{% endif %}
       {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_ibmcloud_vs"
@@ -77,7 +77,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_pcmk_host_map: |-
       {% for node in ansible_play_hosts_all -%}
-        {{ hostvars[node].ansible_hostname }}:{{ hostvars[node].ansible_hostname }}
+        {{ hostvars[node].ansible_facts['hostname'] }}:{{ hostvars[node].ansible_facts['hostname'] }}
       {%- if not loop.last %};{% endif %}
       {% endfor %}
   when: __sap_ha_pacemaker_cluster_platform == "cloud_msazure_vm"

--- a/roles/sap_ha_pacemaker_cluster/tasks/include_vars/validate_input_parameters.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/include_vars/validate_input_parameters.yml
@@ -143,16 +143,16 @@
     fail_msg: |
       Multiple interfaces are found on the system.
 
-      {{ ansible_interfaces | to_nice_yaml }}
+      {{ ansible_facts['interfaces'] | to_nice_yaml }}
 
       In this case 'sap_ha_pacemaker_cluster_vip_client_interface' must be defined.
   when:
-    - ansible_interfaces | length > 2
+    - ansible_facts['interfaces'] | length > 2
 
 - name: "SAP HA Prepare Pacemaker - Verify that the custom NIC name exists"
   ansible.builtin.assert:
     that:
-      - sap_ha_pacemaker_cluster_vip_client_interface in ansible_interfaces
+      - sap_ha_pacemaker_cluster_vip_client_interface in ansible_facts['interfaces']
     fail_msg: "The interface '{{ sap_ha_pacemaker_cluster_vip_client_interface }}' does not exist on this system!"
   when:
     - sap_ha_pacemaker_cluster_vip_client_interface | length > 0

--- a/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_nwas_cs_ers.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/pre_tasks/pre_nwas_cs_ers.yml
@@ -195,5 +195,5 @@
       else __sap_ha_pacemaker_cluster_nwas_ascs_sapinstance_instance_name
       }}"
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
   ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_common.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_common.yml
@@ -37,8 +37,8 @@
     - not sap_ha_pacemaker_cluster_ha_cluster is defined
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_ha_cluster:
-      node_name: "{{ ansible_hostname }}"
-      pcs_address: "{{ ansible_default_ipv4.address }}"
+      node_name: "{{ ansible_facts['hostname'] }}"
+      pcs_address: "{{ ansible_facts['default_ipv4'].address }}"
 
 
 # Combine following extra packages together:
@@ -61,7 +61,7 @@
       (sap_ha_pacemaker_cluster_zypper_patterns
       + __sap_ha_pacemaker_cluster_sap_zypper_patterns)
       | unique | select() }}"
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 # Combine following fence packages together:
 # __sap_ha_pacemaker_cluster_fence_agent_packages_minimal -> os default

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_final_hacluster_vars.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_final_hacluster_vars.yml
@@ -89,7 +89,7 @@
     ha_cluster_extra_packages: "{{ __sap_ha_pacemaker_cluster_extra_packages }}"
 
 - name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_zypper_patterns'"
-  when: __sap_ha_pacemaker_cluster_zypper_patterns is defined and ansible_os_family == 'Suse'
+  when: __sap_ha_pacemaker_cluster_zypper_patterns is defined and ansible_facts['os_family'] == 'Suse'
   ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_zypper_patterns: "{{ __sap_ha_pacemaker_cluster_zypper_patterns }}"
 

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_hana_scaleup.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_hana_scaleup.yml
@@ -72,7 +72,7 @@
           attrs:
             # SUSE recommended monitor interval is 60
             - name: interval
-              value: "{{ 60 if ansible_os_family == 'Suse' else 59 }}"
+              value: "{{ 60 if ansible_facts['os_family'] == 'Suse' else 59 }}"
             - name: role
               value: Master
             - name: timeout
@@ -116,7 +116,7 @@
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_hana_resource_clone_name: "{{ __sap_ha_pacemaker_cluster_hana_resource_clone_msl_name }}"
   when:
-    - ansible_os_family == 'Suse'
+    - ansible_facts['os_family'] == 'Suse'
 
 
 - name: "SAP HA Prepare Pacemaker - Add resource clone: SAP HANA DB"
@@ -142,7 +142,7 @@
               value: "true"
   when:
     - __clone_hana.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
-    - ansible_os_family != 'Suse'
+    - ansible_facts['os_family'] != 'Suse'
 
 - name: "SAP HA Prepare Pacemaker - Add master slave resource clone: SAP HANA DB"
   ansible.builtin.set_fact:
@@ -167,7 +167,7 @@
       ms: true
   when:
     - __clone_hana.resource_id not in (__sap_ha_pacemaker_cluster_resource_clones | map(attribute='resource_id'))
-    - ansible_os_family == 'Suse'
+    - ansible_facts['os_family'] == 'Suse'
 
 # First start Topology, then HANA (automatically stops in reverse order)
 - name: "SAP HA Prepare Pacemaker - Add order constraint: Topology starts before DB"

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_nwas_abap_ascs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_nwas_abap_ascs_ers_simple_mount.yml
@@ -21,7 +21,7 @@
             - name: timeout
               value: 20s
             - name: interval
-              value: "{{ '120s' if ansible_os_family == 'Suse' else '0s' }}"
+              value: "{{ '120s' if ansible_facts['os_family'] == 'Suse' else '0s' }}"
             - name: enabled
               value: 'false'
   when:
@@ -45,7 +45,7 @@
             - name: timeout
               value: 20s
             - name: interval
-              value: "{{ '120s' if ansible_os_family == 'Suse' else '0s' }}"
+              value: "{{ '120s' if ansible_facts['os_family'] == 'Suse' else '0s' }}"
             - name: enabled
               value: 'false'
   when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_nwas_java_scs_ers_simple_mount.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_nwas_java_scs_ers_simple_mount.yml
@@ -21,7 +21,7 @@
             - name: timeout
               value: 20s
             - name: interval
-              value: "{{ '120s' if ansible_os_family == 'Suse' else '0s' }}"
+              value: "{{ '120s' if ansible_facts['os_family'] == 'Suse' else '0s' }}"
             - name: enabled
               value: 'false'
   when:
@@ -45,7 +45,7 @@
             - name: timeout
               value: 20s
             - name: interval
-              value: "{{ '120s' if ansible_os_family == 'Suse' else '0s' }}"
+              value: "{{ '120s' if ansible_facts['os_family'] == 'Suse' else '0s' }}"
             - name: enabled
               value: 'false'
   when:

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_vip_constraints_hana.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_vip_constraints_hana.yml
@@ -15,7 +15,7 @@
           if __sap_ha_pacemaker_cluster_saphanasr_angi_available
            else __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         # SUSE SAPHanaSR is using Master Slave clone using Master/Slave roles
-        role: "{{ 'master' if ansible_os_family == 'Suse' and not __sap_ha_pacemaker_cluster_saphanasr_angi_available
+        role: "{{ 'master' if ansible_facts['os_family'] == 'Suse' and not __sap_ha_pacemaker_cluster_saphanasr_angi_available
          else 'promoted' }}"
       resource_follower:
         id: "{{ __res_or_grp }}"
@@ -76,7 +76,7 @@
           if __sap_ha_pacemaker_cluster_saphanasr_angi_available
           else __sap_ha_pacemaker_cluster_hana_resource_clone_name }}"
         # SUSE SAPHanaSR is using Master Slave clone using Master/Slave roles
-        role: "{{ 'slave' if ansible_os_family == 'Suse' and not __sap_ha_pacemaker_cluster_saphanasr_angi_available
+        role: "{{ 'slave' if ansible_facts['os_family'] == 'Suse' and not __sap_ha_pacemaker_cluster_saphanasr_angi_available
          else 'unpromoted' }}"
       resource_follower:
         id: "{{ __res_or_grp }}"

--- a/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/RedHat.yml
@@ -3,42 +3,42 @@
 # Default repositories if platform does not override them.
 # This selection does not affect imported __ha_cluster_repos due to precedence.
 __sap_ha_pacemaker_cluster_repos:
-  - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+  - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rpms"
     name: High Availability
 
 # Dictionary with repos for each platform
 __sap_ha_pacemaker_cluster_repos_dict:
   cloud_aws_ec2_vs:
-    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
+    - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rhui-rpms"
       name: High Availability
   cloud_gcp_ce_vm:
-    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
+    - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rhui-rpms"
       name: High Availability
   cloud_ibmcloud_powervs:
-    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+    - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rpms"
       name: High Availability E4S (4-Year) for Power, little endian
-    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
+    # - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-eus-rpms"
     #   name: High Availability EUS (2-Year) for Power, little endian
-    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
+    # - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-rpms"
     #   name: High Availability for Power, little endian
   cloud_ibmcloud_vs:
-    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+    - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rpms"
       name: High Availability E4S (4-Year)
-    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
+    # - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-eus-rpms"
     #   name: High Availability EUS (2-Year)
-    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
+    # - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-rpms"
     #   name: High Availability
   cloud_msazure_vm:
-    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rhui-rpms"
+    - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rhui-rpms"
       name: High Availability
-    - id: "rhui-microsoft-azure-rhel{{ ansible_distribution_major_version }}-sap-ha"
-      name: Microsoft Azure RPMs for Red Hat Enterprise Linux {{ ansible_distribution_major_version }} (rhel{{ ansible_distribution_major_version }}-sap-ha)
+    - id: "rhui-microsoft-azure-rhel{{ ansible_facts['distribution_major_version'] }}-sap-ha"
+      name: Microsoft Azure RPMs for Red Hat Enterprise Linux {{ ansible_facts['distribution_major_version'] }} (rhel{{ ansible_facts['distribution_major_version'] }}-sap-ha)
   hyp_ibmpower_vm:
-    - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-e4s-rpms"
+    - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-e4s-rpms"
       name: High Availability E4S (4-Year) for Power, little endian
-    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-eus-rpms"
+    # - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-eus-rpms"
     #   name: High Availability EUS (2-Year) for Power, little endian
-    # - id: "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-highavailability-rpms"
+    # - id: "rhel-{{ ansible_facts['distribution_major_version'] }}-for-{{ ansible_facts['architecture'] }}-highavailability-rpms"
     #   name: High Availability for Power, little endian
 
 __sap_ha_pacemaker_cluster_halib_package: sap-cluster-connector
@@ -87,12 +87,12 @@ __sap_ha_pacemaker_cluster_fence_agent_packages_dict:
 # Dictionary with extra platform specific packages
 __sap_ha_pacemaker_cluster_platform_extra_packages_dict:
   cloud_aws_ec2_vs:
-    - "{{ 'resource-agents-cloud' if ansible_distribution_major_version is version('9', '>=') else 'awscli' }}"
-    - "{{ 'awscli2' if ansible_distribution_version is version('9.5', '>=') else '' }}"
+    - "{{ 'resource-agents-cloud' if ansible_facts['distribution_major_version'] is version('9', '>=') else 'awscli' }}"
+    - "{{ 'awscli2' if ansible_facts['distribution_version'] is version('9.5', '>=') else '' }}"
   cloud_gcp_ce_vm:
     - resource-agents-gcp
   cloud_msazure_vm:
-    - "{{ 'resource-agents-cloud' if ansible_distribution_major_version is version('9', '>=') else '' }}"
+    - "{{ 'resource-agents-cloud' if ansible_facts['distribution_major_version'] is version('9', '>=') else '' }}"
     - socat
 
 # Dictionary with additional cluster packages for specific scenarios

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_aws_ec2_vs.yml
@@ -110,7 +110,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
               - name: pcmk_delay_max
                 value: 45
               - name: tag
-                value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
+                value: "pacemaker"  # tag instance with pacemaker: {{ ansible_facts['hostname'] }}
               # Use AWS config profile if AWS credentials are used.
               # - name: profile
               #   value: cluster
@@ -146,7 +146,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
               - name: pcmk_delay_max
                 value: 30
               - name: tag
-                value: "pacemaker"  # tag instance with pacemaker: {{ ansible_hostname }}
+                value: "pacemaker"  # tag instance with pacemaker: {{ ansible_facts['hostname'] }}
               # Use AWS config profile if AWS credentials are used.
               # - name: profile
               #   value: cluster
@@ -240,7 +240,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
 
 # Set helper variables to simplify default stonith selection.
 __sap_ha_pacemaker_cluster_stonith_version:
-  "{{ ansible_distribution_major_version if ansible_os_family == 'Suse' else 'default' }}"
+  "{{ ansible_facts['distribution_major_version'] if ansible_facts['os_family'] == 'Suse' else 'default' }}"
 
 __sap_ha_pacemaker_cluster_stonith_type:
   "{{ 'hana' if (sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | list | length > 0) else 'nwas' }}"
@@ -249,7 +249,7 @@ __sap_ha_pacemaker_cluster_stonith_type:
 # This structure can be adjusted in future if more combinations are needed.
 # Current levels are: OS Family -> Major Version -> Type
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower][__sap_ha_pacemaker_cluster_stonith_version][__sap_ha_pacemaker_cluster_stonith_type] }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_facts['os_family'] | lower][__sap_ha_pacemaker_cluster_stonith_version][__sap_ha_pacemaker_cluster_stonith_type] }}"
 
 
 # Default corosync options - Platform specific
@@ -285,9 +285,9 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
       clear_node_high_bit: 'yes'
 
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
-  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_hana']
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_facts['os_family'] | lower ~ '_hana']
     if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0
-   else __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower ~ '_nwas'] }}"
+   else __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_facts['os_family'] | lower ~ '_nwas'] }}"
 
 
 # Dictionary with default platform specific cluster properties

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_gcp_ce_vm.yml
@@ -28,14 +28,14 @@ __sap_ha_pacemaker_cluster_repos:
 __sap_ha_pacemaker_cluster_stonith_default_dict:
   generic:
     # fence_gce agent is created for every host in cluster
-    id: "rsc_fence_gce_{{ ansible_hostname }}"
+    id: "rsc_fence_gce_{{ ansible_facts['hostname'] }}"
     agent: "stonith:fence_gce"
     instance_attrs:
       - attrs:
           # GCP does not use pcmk_host_map, instead it specifies port
           # fence_gce supports plug parameter, but all documentations mention only port.
           - name: port
-            value: "{{ ansible_hostname }}"
+            value: "{{ ansible_facts['hostname'] }}"
 
           - name: project
             value: "{{ sap_ha_pacemaker_cluster_gcp_project }}"
@@ -87,7 +87,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
       token: 20000
 
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
-  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower] }}"
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_facts['os_family'] | lower] }}"
 
 
 # Dictionary with default platform specific cluster properties

--- a/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/platform_cloud_msazure_vm.yml
@@ -95,7 +95,7 @@ __sap_ha_pacemaker_cluster_stonith_default_dict:
 
 # Select __sap_ha_pacemaker_cluster_stonith_default
 __sap_ha_pacemaker_cluster_stonith_default:
-  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_os_family | lower] }}"
+  "{{ __sap_ha_pacemaker_cluster_stonith_default_dict[ansible_facts['os_family'] | lower] }}"
 
 
 # Default corosync options - Platform specific
@@ -114,7 +114,7 @@ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict:
       consensus: 36000
 
 __sap_ha_pacemaker_cluster_corosync_totem_platform:
-  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_os_family | lower] }}"
+  "{{ __sap_ha_pacemaker_cluster_corosync_totem_platform_dict[ansible_facts['os_family'] | lower] }}"
 
 
 # Dictionary with default platform specific cluster properties


### PR DESCRIPTION
## Changes
Ansible-core 2.20 has changed how Ansible Facts are handled and new deprecation warning started because of this change https://docs.ansible.com/projects/ansible-core/2.20/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars.

```yaml
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/mmamula/workspace/tests/debug.yml:23:14

21     - name: Test ansible_hostname
22       ansible.builtin.debug:
23         msg: "{{ ansible_hostname }}"
                ^ column 14

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```