### PR TITLE
sap_ha_pacemaker_cluster: Fix issue 1203 sudo dash

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/templates/sudofile_20-saphana.j2
+++ b/roles/sap_ha_pacemaker_cluster/templates/sudofile_20-saphana.j2
@@ -6,23 +6,23 @@
 #  to update the SAP HANA cluster resource status.
 
 {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}
-Cmnd_Alias {{ node.hana_site | upper }}_SOK = /usr/sbin/crm_attribute -n hana_{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SOK -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
-Cmnd_Alias {{ node.hana_site | upper }}_SFAIL = /usr/sbin/crm_attribute -n hana_{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SFAIL -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
+Cmnd_Alias {{ node.hana_site | upper | replace("-", "") }}_SOK = /usr/sbin/crm_attribute -n hana_{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SOK -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
+Cmnd_Alias {{ node.hana_site | upper | replace("-", "") }}_SFAIL = /usr/sbin/crm_attribute -n hana_{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}_site_srHook_{{ node.hana_site }} -v SFAIL -t crm_config -s {{ sap_ha_pacemaker_cluster_hadr_provider_name }}
 {% endfor %}
 {% if __sap_ha_pacemaker_cluster_hana_hook_tkover and __sap_ha_pacemaker_cluster_saphanasr_angi_available %}
 Cmnd_Alias HOOK_HELPER  = /usr/bin/SAPHanaSR-hookHelper --sid={{ __sap_ha_pacemaker_cluster_hana_sid | upper }} --case=checkTakeover
 
-{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
+{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper | replace("-", "") }}_SOK, {{ node.hana_site | upper | replace("-", "") }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
 
-Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER !requiretty
+Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper | replace("-", "") }}_SOK, {{ node.hana_site | upper | replace("-", "") }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER !requiretty
 {% elif __sap_ha_pacemaker_cluster_hana_hook_tkover and not __sap_ha_pacemaker_cluster_saphanasr_angi_available %}
 Cmnd_Alias HOOK_HELPER  = /usr/sbin/SAPHanaSR-hookHelper --sid={{ __sap_ha_pacemaker_cluster_hana_sid | upper }} --case=checkTakeover
 
-{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
+{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper | replace("-", "") }}_SOK, {{ node.hana_site | upper | replace("-", "") }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER
 
-Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER !requiretty
+Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper | replace("-", "") }}_SOK, {{ node.hana_site | upper | replace("-", "") }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}, HOOK_HELPER !requiretty
 {% else %}
-{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}
+{{ __sap_ha_pacemaker_cluster_hana_sid | lower }}adm ALL=(ALL) NOPASSWD: {% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper | replace("-", "") }}_SOK, {{ node.hana_site | upper | replace("-", "") }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %}
 
-Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper }}_SOK, {{ node.hana_site | upper }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %} !requiretty
+Defaults!{% for node in sap_ha_pacemaker_cluster_cluster_nodes %}{{ node.hana_site | upper | replace("-", "") }}_SOK, {{ node.hana_site | upper | replace("-", "") }}_SFAIL{{ ", " if not loop.last else "" }}{% endfor %} !requiretty
 {% endif %}


### PR DESCRIPTION
Changes in the sudoers file template to fix the artificial sudo command alias names.

- `{{ node.hana_site | upper }}_SOK` -> `{{ node.hana_site | upper | replace("-", "") }}_SOK`
- `{{ node.hana_site | upper }}_SFAIL` -> `{{ node.hana_site | upper | replace("-", "") }}_SFAIL`

Fixes issue #1203.
Dashes in the system replication site names are allowed by HANA and are not an issue in the related cluster node attributes. The sudo command alias name is artificial and the fix is transparent to the HANA and the cluster setup.