### PR TITLE
sap_ha_pacemaker_cluster: Add QDevice and Diskless SBD

### DIFF
--- a/roles/sap_ha_pacemaker_cluster/README.md
+++ b/roles/sap_ha_pacemaker_cluster/README.md
@@ -955,6 +955,21 @@ sap_ha_pacemaker_cluster_operation_defaults:
   timeout: 600
 ```
 
+### sap_ha_pacemaker_cluster_qdevice_enabled
+- _Type:_ `bool`
+- _Default:_ `false`
+
+Set this variable to `true` to enable QDevice for the cluster.<br>
+Requires definition of `sap_ha_pacemaker_cluster_qdevice_host` variable with the hostname of the QNetD server.<br>
+Configuration can be further adjusted using `ha_cluster` role variable `ha_cluster_quorum`.<br>
+
+### sap_ha_pacemaker_cluster_qdevice_host
+- _Type:_ `str`
+
+Hostname of the QNetD server for the cluster QDevice configuration.<br>
+This host is not configured with this role, but it can be configured separately with `ha_cluster` Ansible Role beforehand.<br>
+Ensure that the cluster nodes can reach the QNetD server.<br>
+
 ### sap_ha_pacemaker_cluster_resource_defaults
 - _Type:_ `dict`
 - _Default:_ `{'migration-threshold': 5000, 'resource-stickiness': 3000}`
@@ -991,8 +1006,13 @@ Example for SAP HANA Scale-Up:<br>
 ### sap_ha_pacemaker_cluster_sbd_devices
 - _Type:_ `list`
 
-Required if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
+Required for setup of Disk-Based SBD if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.<br>
 Provide list of block devices for Stonith SBD agent<br>
+NOTEs for using Diskless SBD:<br>
+Leave this variable with empty list `[]`.<br>
+Two node clusters require QNetD and QDevice configuration.<br>
+Set the variable `sap_ha_pacemaker_cluster_qdevice_enabled` to `true`.<br>
+Ensure that you have host with QNetd prepared and defined in `sap_ha_pacemaker_cluster_qdevice_host` variable.<br>
 
 Example:
 ```yaml

--- a/roles/sap_ha_pacemaker_cluster/defaults/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/defaults/main.yml
@@ -72,6 +72,18 @@ sap_ha_pacemaker_cluster_vip_client_interface: ''
 #   stonith-enabled: true
 #   stonith-timeout: 150  # Default value 150 is for SBD method.
 
+## SBD Variables (detailed explanation is provided in README):
+# sap_ha_pacemaker_cluster_sbd_enabled: false
+# sap_ha_pacemaker_cluster_sbd_devices: []
+# sap_ha_pacemaker_cluster_sbd_options: []
+# sap_ha_pacemaker_cluster_sbd_watchdog: '/dev/watchdog'
+# sap_ha_pacemaker_cluster_sbd_watchdog_modules: []
+
+## QNetd and QDevice variables:
+# sap_ha_pacemaker_cluster_qdevice_enabled: false
+# sap_ha_pacemaker_cluster_qdevice_host: ''
+
+
 ### Constraints:
 # score is dynamic and automatically increased for groups
 sap_ha_pacemaker_cluster_constraint_colo_base_score: 2000

--- a/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
+++ b/roles/sap_ha_pacemaker_cluster/meta/argument_specs.yml
@@ -255,8 +255,14 @@ argument_specs:
       sap_ha_pacemaker_cluster_sbd_devices:
         type: list
         description:
-          - Required if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
+          - Required for setup of Disk-Based SBD if `sap_ha_pacemaker_cluster_sbd_enabled` is enabled.
           - Provide list of block devices for Stonith SBD agent
+          - "NOTEs for using Diskless SBD:"
+          - Leave this variable with empty list `[]`.
+          - Two node clusters require QNetD and QDevice configuration.
+          - Set the variable `sap_ha_pacemaker_cluster_qdevice_enabled` to `true`.
+          - Ensure that you have host with QNetd prepared and defined in `sap_ha_pacemaker_cluster_qdevice_host` variable.
+
 
         example:
           sap_ha_pacemaker_cluster_sbd_devices:
@@ -289,6 +295,21 @@ argument_specs:
         example:
           sap_ha_pacemaker_cluster_sbd_watchdog_modules:
             - softdog
+
+      sap_ha_pacemaker_cluster_qdevice_enabled:
+        type: bool
+        default: false
+        description:
+          - Set this variable to `true` to enable QDevice for the cluster.
+          - Requires definition of `sap_ha_pacemaker_cluster_qdevice_host` variable with the hostname of the QNetD server.
+          - Configuration can be further adjusted using `ha_cluster` role variable `ha_cluster_quorum`.
+
+      sap_ha_pacemaker_cluster_qdevice_host:
+        type: str
+        description:
+          - Hostname of the QNetD server for the cluster QDevice configuration.
+          - This host is not configured with this role, but it can be configured separately with `ha_cluster` Ansible Role beforehand.
+          - Ensure that the cluster nodes can reach the QNetD server.
 
       sap_ha_pacemaker_cluster_cluster_properties:
         type: dict

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/platform/prepare_vip_resources_cloud_gcp_ce_vm.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/platform/prepare_vip_resources_cloud_gcp_ce_vm.yml
@@ -102,3 +102,5 @@
     - vip_list_item.key not in (__sap_ha_pacemaker_cluster_resource_primitives | map(attribute='id'))
     - sap_ha_pacemaker_cluster_vip_method == 'gcp_anything_socat'
     - vip_list_item.key in __sap_ha_pacemaker_cluster_healthcheck_resource_list
+    # Socat health check is only for Primary VIP
+    - not vip_list_item.key == __sap_ha_pacemaker_cluster_healthcheck_hana_secondary_resource_name

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_final_hacluster_vars.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_final_hacluster_vars.yml
@@ -144,3 +144,8 @@
   when: __sap_ha_pacemaker_cluster_sbd_enabled is defined
   ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
     ha_cluster_sbd_enabled: "{{ __sap_ha_pacemaker_cluster_sbd_enabled }}"
+
+- name: "SAP HA Prepare Pacemaker - (ha_cluster) Define parameter 'ha_cluster_quorum'"
+  when: __sap_ha_pacemaker_cluster_quorum | d({}) | length > 0
+  ansible.builtin.set_fact:  # noqa var-naming[no-role-prefix]
+    ha_cluster_quorum: "{{ __sap_ha_pacemaker_cluster_quorum }}"

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_main.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_main.yml
@@ -8,16 +8,37 @@
   ansible.builtin.import_tasks: prepare_common.yml
   tags: pre_ha_cluster
 
-# STONITH tasks are split to allow for full user override using 'sap_ha_pacemaker_cluster_stonith_custom'.
+
+# STONITH tasks are split to simplify each task file.
+# The default STONITH configuration for platforms with predefined defaults.
 - name: "SAP HA Prepare Pacemaker - Include variable construction for default STONITH resources"
   ansible.builtin.import_tasks: prepare_stonith.yml
   tags: pre_ha_cluster
-  when: sap_ha_pacemaker_cluster_stonith_custom is not defined
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom is not defined
+    - not sap_ha_pacemaker_cluster_sbd_enabled | d(false)
 
+# The custom STONITH configuration if the user wants to use custom STONITH devices.
 - name: "SAP HA Prepare Pacemaker - Include variable construction for custom STONITH resources"
   ansible.builtin.import_tasks: prepare_stonith_custom.yml
   tags: pre_ha_cluster
-  when: sap_ha_pacemaker_cluster_stonith_custom is defined
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom is defined
+    - not sap_ha_pacemaker_cluster_sbd_enabled | d(false)
+
+# The SBD STONITH configuration if the user wants to use SBD as STONITH device.
+- name: "SAP HA Prepare Pacemaker - Include variable construction for SBD STONITH resources"
+  ansible.builtin.import_tasks: prepare_stonith_sbd.yml
+  tags: pre_ha_cluster
+  when: sap_ha_pacemaker_cluster_sbd_enabled | d(false)
+
+# The QDevice configuration if the user wants to use a QDevice in their cluster.
+- name: "SAP HA Prepare Pacemaker - Include variable construction for QDevice"
+  ansible.builtin.import_tasks:
+    file: prepare_qdevice.yml
+  tags: pre_ha_cluster
+  when: sap_ha_pacemaker_cluster_qdevice_enabled | d(false)
+
 
 - name: "SAP HA Prepare Pacemaker - Include variable construction for VIP resources"
   ansible.builtin.import_tasks: prepare_vip_resources.yml

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_qdevice.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_qdevice.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# QDevice is mandatory for Diskless SBD on 2-node clusters, but it can be used regardless.
+# It uses 'ha_cluster_quorum' which has no other purpose currently,
+# but it can be enhanced in the future if 'ha_cluster' role adds more quorum configuration options.
+
+- name: "SAP HA Prepare Pacemaker - (QDevice) Assert that QNetd host is provided"
+  ansible.builtin.assert:
+    that:
+      - sap_ha_pacemaker_cluster_qdevice_host is defined
+      - sap_ha_pacemaker_cluster_qdevice_host is string
+      - sap_ha_pacemaker_cluster_qdevice_host | trim | length > 0
+    fail_msg: |
+      FAIL: QDevice configuration is defined but no QNetd host is provided!
+      - Set the variable `sap_ha_pacemaker_cluster_qdevice_host` to the hostname or IP address of the QNetd host.
+
+
+# We do not import 'ha_cluster_quorum' due to its complexity and single purpose for QDevice configuration.
+# Structure is taken from LSR without transformation as we do not allow any customizations yet.
+- name: "SAP HA Prepare Pacemaker - (QDevice) Update Quorum definition"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_quorum:
+      device:
+        model: net  # Model is hardcoded as 'net', because that is only supported model.
+        model_options:
+          - name: host
+            value: "{{ sap_ha_pacemaker_cluster_qdevice_host }}"
+
+          # We can add algorithm variable in future. Current options:
+          # ffsplit: (DEFAULT) fifty-fifty split. This provides exactly one vote to the partition with the highest number of active nodes.
+          # lms: last-man-standing. If the node is the only one left in the cluster that can see the qnetd server, then it returns a vote.
+          # - name: algorithm
+          #   value: lms

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_qdevice.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_qdevice.yml
@@ -28,7 +28,36 @@
             value: "{{ sap_ha_pacemaker_cluster_qdevice_host }}"
 
           # We can add algorithm variable in future. Current options:
-          # ffsplit: (DEFAULT) fifty-fifty split. This provides exactly one vote to the partition with the highest number of active nodes.
-          # lms: last-man-standing. If the node is the only one left in the cluster that can see the qnetd server, then it returns a vote.
-          # - name: algorithm
-          #   value: lms
+          # ffsplit: (DEFAULT) fifty-fifty split.
+          # - This provides exactly one vote to the partition with the highest number of active nodes.
+          # lms: last-man-standing.
+          # - If the node is the only one left in the cluster that can see the qnetd server, then it returns a vote.
+          - name: algorithm
+            value: ffsplit
+
+
+# Watchdog timeout must be configured for QDevice configuration.
+# SLES uses 'crm init' which calculates timeout dynamically. See: crm help TimeoutFormulas
+# RHEL does not have default, resulting in failure, when watchdog timeout is not set above 30.
+
+# From crm help TimeoutFormulas:
+# When adding diskless SBD and QDevice together from crm cluster init
+# - if SBD_WATCHDOG_TIMEOUT < 35s set SBD_WATCHDOG_TIMEOUT = 35s
+# When adding diskless SBD in a cluster with QDevice already
+# - if SBD_WATCHDOG_TIMEOUT < qdevice_sync_timeout set SBD_WATCHDOG_TIMEOUT = qdevice_sync_timeout + 5s
+# - qdevice_sync_timeout is by default '30', so default SBD_WATCHDOG_TIMEOUT of '5' will be updated to '35'
+# When adding QDevice in a cluster with diskless SBD already
+# - if SBD_WATCHDOG_TIMEOUT < 35s set SBD_WATCHDOG_TIMEOUT = 35s
+
+- name: "SAP HA Prepare Pacemaker - (QDevice) Update watchdog-timeout in SBD options"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_ha_cluster_sbd_options: >-
+      {{ __sap_ha_pacemaker_cluster_ha_cluster_sbd_options | d([]) + __insert_watchdog_timeout }}
+  vars:
+    __insert_watchdog_timeout:
+      - name: 'watchdog-timeout'
+        value: '35'
+  when:
+    - "__sap_ha_pacemaker_cluster_ha_cluster_sbd_options
+      | selectattr('name', 'equalto', 'watchdog-timeout') | list | length == 0"
+    - ansible_facts['os_family'] == 'RedHat'

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_qdevice.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_qdevice.yml
@@ -51,13 +51,14 @@
 
 - name: "SAP HA Prepare Pacemaker - (QDevice) Update watchdog-timeout in SBD options"
   ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_ha_cluster_sbd_options: >-
-      {{ __sap_ha_pacemaker_cluster_ha_cluster_sbd_options | d([]) + __insert_watchdog_timeout }}
+    __sap_ha_pacemaker_cluster_sbd_options: >-
+      {{ __sap_ha_pacemaker_cluster_sbd_options | d([]) + __insert_watchdog_timeout }}
   vars:
     __insert_watchdog_timeout:
       - name: 'watchdog-timeout'
         value: '35'
   when:
-    - "__sap_ha_pacemaker_cluster_ha_cluster_sbd_options
-      | selectattr('name', 'equalto', 'watchdog-timeout') | list | length == 0"
+    - __sap_ha_pacemaker_cluster_sbd_options is not defined
+      or __sap_ha_pacemaker_cluster_sbd_options
+        | selectattr('name', 'equalto', 'watchdog-timeout') | list | length == 0
     - ansible_facts['os_family'] == 'RedHat'

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith.yml
@@ -96,7 +96,7 @@
 - name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
   when:
     - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
-    - sap_ha_pacemaker_cluster_cluster_properties is not defined  # We cannot append to user defined properties.
+    - __sap_ha_pacemaker_cluster_cluster_properties | d({}) | length > 0
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_properties:
       - attrs: |-

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_custom.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_custom.yml
@@ -54,7 +54,7 @@
 - name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
   when:
     - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
-    - sap_ha_pacemaker_cluster_cluster_properties is defined
+    - __sap_ha_pacemaker_cluster_cluster_properties | d({}) | length > 0
   ansible.builtin.set_fact:
     __sap_ha_pacemaker_cluster_cluster_properties:
       - attrs: |-
@@ -68,70 +68,6 @@
             ]) -%}
           {%- endfor %}
           {{ attrs }}
-
-
-# SBD Configuration is executed only when all conditions are met:
-# sap_ha_pacemaker_cluster_sbd_enabled is true
-# sap_ha_pacemaker_cluster_sbd_devices is defined, list and not empty
-# sap_ha_pacemaker_cluster_stonith_custom is defined, list and not empty
-# __sap_ha_pacemaker_cluster_sbd_enabled is not defined
-- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Prepare SBD configuration"
-  when:
-    - ha_cluster_sbd_enabled is not defined or ha_cluster_sbd_enabled | bool  # We cannot overwrite due to precedence.
-    - sap_ha_pacemaker_cluster_sbd_enabled | d(false)
-    - sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0
-    - sap_ha_pacemaker_cluster_stonith_custom | length > 0
-  block:
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create sbd_options"
-      when:
-        - ha_cluster_sbd_options is not defined
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_sbd_options: >-
-          {%- if sap_ha_pacemaker_cluster_sbd_options | d([]) | length > 0 -%}
-            {{ sap_ha_pacemaker_cluster_sbd_options }}
-          {%- else -%}
-            {{ [{'name': 'startmode', 'value': __sbd_startmode}] }}
-          {%- endif -%}
-      vars:
-        __sbd_startmode: "{{ 'clean' if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0 else 'always' }}"
-
-
-    # Create dictionary with SBD specific parameters for ha_cluster
-    # Omit parameters if they are already present in provided dictionary sap_ha_pacemaker_cluster_ha_cluster
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
-          {{
-            dict(
-              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices
-                if sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0 and not __ha_cluster_sbd_devices_exists
-                else omit),
-              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
-                if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
-                else omit),
-              sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
-                if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
-                else omit)
-            )
-          }}
-      vars:
-        # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
-        __ha_cluster_sbd_devices_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | d([]) | length > 0 else false }}"
-        __ha_cluster_sbd_watchdog_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | d([]) | length > 0 else false }}"
-        __ha_cluster_sbd_watchdog_modules_exists:
-          "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | d([]) | length > 0 else false }}"
-
-
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_fence_agent_packages:
-          "{{ __sap_ha_pacemaker_cluster_fence_agent_packages + ['sbd'] }}"
-
-    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set __sap_ha_pacemaker_cluster_sbd_enabled"
-      ansible.builtin.set_fact:
-        __sap_ha_pacemaker_cluster_sbd_enabled: true
 
 
 - name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_sbd.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_sbd.yml
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# SBD is different to custom fencing resource, because it has dedicated 'sbd' variables and Diskless mode.
+
+# Show warning and disable fencing if user STONITH resources are not defined.
+- name: Block when STONITH list is defined but empty
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length == 0
+    # Custom STONITH resource must be empty for Diskless SBD.
+    - not sap_ha_pacemaker_cluster_sbd_devices | d([]) | length == 0
+  block:
+
+    # Ensure that property 'stonith-enabled' is set to 'false' if no Stonith resources are defined.
+    # STONITH property will be disabled only if 'sap_ha_pacemaker_cluster_cluster_properties' is not defined.
+    - name: "SAP HA Prepare Pacemaker - (STONITH) Set to disabled when no fencing resource is defined"
+      when:
+        - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+        - sap_ha_pacemaker_cluster_cluster_properties is not defined
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_cluster_properties:
+          "{{ __sap_ha_pacemaker_cluster_cluster_properties | combine({'stonith-enabled': false}) }}"
+
+    - name: "SAP HA Prepare Pacemaker - Warning when no STONITH resources are defined"
+      ansible.builtin.pause:
+        seconds: 5
+        prompt: |
+          WARNING: The variable 'sap_ha_pacemaker_cluster_stonith_custom' is defined, but empty!
+          {% if ha_cluster_cluster_properties is not defined and sap_ha_pacemaker_cluster_cluster_properties is not defined %}
+          No STONITH resources are defined and STONITH will be disabled!
+          The cluster property "stonith-enabled: false" will be configured to disable fencing.
+          {% else %}
+          No STONITH resources are defined!
+          {% endif %}
+
+          Please configure appropriate fencing resources for your environment by following steps:
+          - Add a STONITH resource(s) using the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+          - Add a cluster property "stonith-enabled: true" to 'sap_ha_pacemaker_cluster_cluster_properties'.
+
+
+- name: "SAP HA Prepare Pacemaker - Warning when pcmk_delay_max is missing"
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | map(attribute='instance_attrs', default=[]) | flatten
+        | map(attribute='attrs', default=[]) | flatten | selectattr('name', 'equalto', 'pcmk_delay_max') | length == 0
+  ansible.builtin.debug:
+    msg: |
+      WARNING: The STONITH resource is missing 'pcmk_delay_max'!
+
+      Without a delay, both cluster nodes may attempt to fence each other simultaneously
+      during a split-brain event ("Double STONITH"), leading to a total cluster outage.
+      Add pcmk_delay_max=15 (or similar) to STONITH resource defined in the variable 'sap_ha_pacemaker_cluster_stonith_custom'.
+
+
+# Prepare structure compatible with the variable 'ha_cluster_cluster_properties'.
+- name: "SAP HA Prepare Pacemaker - (STONITH) Define cluster properties"
+  when:
+    - ha_cluster_cluster_properties is not defined  # We cannot append to defined variable due to precedence.
+    - __sap_ha_pacemaker_cluster_cluster_properties | d({}) | length > 0
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_cluster_properties:
+      - attrs: |-
+          {% set attrs = [] -%}
+          {%- for default_cluster_properties in (__sap_ha_pacemaker_cluster_cluster_properties | dict2items) -%}
+            {% set role_attrs = attrs.extend([
+              {
+                'name': default_cluster_properties.key,
+                'value': default_cluster_properties.value
+              }
+            ]) -%}
+          {%- endfor %}
+          {{ attrs }}
+
+
+- name: Block for Diskless SBD
+  when: sap_ha_pacemaker_cluster_sbd_devices | d([]) | length == 0
+  block:
+
+    # Diskless SBD requires:
+    # - properties 'stonith-watchdog-timeout' or 'fencing-watchdog-timeout'
+    # - or QNetd host configured in 'sap_ha_pacemaker_cluster_qdevice_host'
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Fail if Diskless SBD configuration is insufficient"
+      ansible.builtin.fail:
+        msg: |
+          FAIL: The variable 'sap_ha_pacemaker_cluster_sbd_devices' is not defined or empty,
+          which indicates Diskless SBD configuration.
+
+          Diskless SBD requires either of the following:
+          - Watchdog timeout property ('stonith-watchdog-timeout' or 'fencing-watchdog-timeout')
+            configured in the variable 'sap_ha_pacemaker_cluster_cluster_properties'.
+          - QNet host configured in the variable 'sap_ha_pacemaker_cluster_qdevice_host'.
+      when:
+        - not sap_ha_pacemaker_cluster_cluster_properties['stonith-watchdog-timeout'] is defined
+        - not sap_ha_pacemaker_cluster_cluster_properties['fencing-watchdog-timeout'] is defined
+        - not sap_ha_pacemaker_cluster_qdevice_host | d('') | length > 0
+
+    # Diskless SBD cannot be configured on 2-node cluster without QDevice,
+    # because of the risk of split-brain due to simultaneous fencing without watchdog.
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Fail if Diskless SBD configuration is missing QDevice on 2-node cluster"
+      ansible.builtin.fail:
+        msg: |
+          FAIL: Diskless SBD is defined without QDevice configuration on 2-node cluster!
+          Two-node clusters require QNetD and QDevice configuration to maintain proper quorum.
+          - Set the variable `sap_ha_pacemaker_cluster_qdevice_enabled` to `true`.
+          - Ensure that you have host with QNetd prepared and defined in `sap_ha_pacemaker_cluster_qdevice_host` variable.
+      when:
+        - ansible_play_hosts | length == 2
+        - not (sap_ha_pacemaker_cluster_qdevice_enabled | d(false)
+            and sap_ha_pacemaker_cluster_qdevice_host | d('') | length > 0)
+
+    # Diskless SBD cannot be configured on 2-node cluster without QDevice,
+    # because of the risk of split-brain due to simultaneous fencing without watchdog.
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Fail if Diskless SBD is in conflict with custom STONITH resource"
+      ansible.builtin.fail:
+        msg: |
+          FAIL: Diskless SBD is defined but the variable 'sap_ha_pacemaker_cluster_stonith_custom' is also defined.
+          Diskless SBD is not compatible with STONITH resources.
+
+          Either:
+          - Define SBD devices in the variable 'sap_ha_pacemaker_cluster_sbd_devices' to continue with Disk based SBD.
+          - Or remove the variable 'sap_ha_pacemaker_cluster_stonith_custom' to continue with Diskless SBD.
+      when: sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
+
+
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set fact with sbd_options if defined"
+  when:
+    - ha_cluster_sbd_options is not defined
+    - sap_ha_pacemaker_cluster_sbd_options | d([]) | length > 0
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_sbd_options: "{{ sap_ha_pacemaker_cluster_sbd_options }}"
+
+
+# NOTE: These are recommended values and if needed, it can be turned into dictionary
+# and moved to vars/main or vars/OS files.
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set default SBD options for Disk based SBD"
+  when:
+    - ha_cluster_sbd_options is not defined
+    - sap_ha_pacemaker_cluster_sbd_options | d([]) | length == 0
+    - sap_ha_pacemaker_cluster_sbd_devices | d([]) | length > 0
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_sbd_options:
+      - name: startmode
+        value: "{{ 'clean' if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0 else 'always' }}"
+      # # It's required that SBD_DELAY_START is set to 36
+      # - name: delay-start
+      #   value: 36
+
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set default SBD options for Diskless SBD"
+  when:
+    - ha_cluster_sbd_options is not defined
+    - sap_ha_pacemaker_cluster_sbd_options | d([]) | length == 0
+    - sap_ha_pacemaker_cluster_sbd_devices | d([]) | length == 0
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_sbd_options:
+      - name: startmode
+        value: "{{ 'clean' if sap_ha_pacemaker_cluster_host_type | select('search', 'hana') | length > 0 else 'always' }}"
+      # It's required that SBD_DELAY_START is set to 36
+      - name: delay-start
+        value: 36
+
+
+# Create dictionary with SBD specific parameters for ha_cluster
+# Omit parameters if they are already present in provided dictionary sap_ha_pacemaker_cluster_ha_cluster
+# sbd_devices omits only if already defined, which allows for empty list for Diskless SBD configuration.
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
+      {{
+        dict(
+          sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices | d([])
+            if not __ha_cluster_sbd_devices_exists
+            else omit),
+          sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
+            if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
+            else omit),
+          sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
+            if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
+            else omit)
+        )
+      }}
+  vars:
+    # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
+    __ha_cluster_sbd_devices_exists:
+      "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_devices | d([]) | length > 0 else false }}"
+    __ha_cluster_sbd_watchdog_exists:
+      "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | d([]) | length > 0 else false }}"
+    __ha_cluster_sbd_watchdog_modules_exists:
+      "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | d([]) | length > 0 else false }}"
+
+
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_fence_agent_packages:
+      "{{ __sap_ha_pacemaker_cluster_fence_agent_packages + ['sbd'] }}"
+
+- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Set fact with SBD enabled"
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_sbd_enabled: true
+
+
+- name: "SAP HA Prepare Pacemaker - (STONITH) Assemble the resources from custom definition"
+  when:
+    - sap_ha_pacemaker_cluster_stonith_custom | d([]) | length > 0
+    - stonith_item.id | d('') | length > 0
+    - stonith_item.id not in (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | map(attribute='id'))
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_stonith_resource:
+      "{{ __sap_ha_pacemaker_cluster_stonith_resource | d([]) + [stonith_item] }}"
+  loop: "{{ sap_ha_pacemaker_cluster_stonith_custom }}"
+  loop_control:
+    label: "{{ stonith_item.id }}"
+    loop_var: stonith_item
+
+
+# The STONITH resource is an element in the cluster_resource_primitives list
+- name: "SAP HA Prepare Pacemaker - (STONITH) Construct resources definition"
+  when:
+    - __sap_ha_pacemaker_cluster_stonith_resource is defined
+  ansible.builtin.set_fact:
+    __sap_ha_pacemaker_cluster_resource_primitives:
+      "{{ __sap_ha_pacemaker_cluster_resource_primitives
+        + (__sap_ha_pacemaker_cluster_stonith_resource | d([]) | from_yaml) }}"
+  no_log: true  # stonith resources can contain secrets

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_sbd.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_sbd.yml
@@ -79,6 +79,7 @@
     # Diskless SBD requires:
     # - properties 'stonith-watchdog-timeout' or 'fencing-watchdog-timeout'
     # - or QNetd host configured in 'sap_ha_pacemaker_cluster_qdevice_host'
+    # TODO: Add explanation and conditionals for 'fencing-watchdog-timeout' which is part of pacemaker 3.0.1 and later.
     - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Fail if Diskless SBD configuration is insufficient"
       ansible.builtin.fail:
         msg: |
@@ -86,12 +87,12 @@
           which indicates Diskless SBD configuration.
 
           Diskless SBD requires either of the following:
-          - Watchdog timeout property ('stonith-watchdog-timeout' or 'fencing-watchdog-timeout')
+          - Watchdog timeout property 'stonith-watchdog-timeout'
             configured in the variable 'sap_ha_pacemaker_cluster_cluster_properties'.
           - QNet host configured in the variable 'sap_ha_pacemaker_cluster_qdevice_host'.
       when:
         - not sap_ha_pacemaker_cluster_cluster_properties['stonith-watchdog-timeout'] is defined
-        - not sap_ha_pacemaker_cluster_cluster_properties['fencing-watchdog-timeout'] is defined
+        # - not sap_ha_pacemaker_cluster_cluster_properties['fencing-watchdog-timeout'] is defined
         - not sap_ha_pacemaker_cluster_qdevice_host | d('') | length > 0
 
     # Diskless SBD cannot be configured on 2-node cluster without QDevice,
@@ -162,22 +163,7 @@
 # Create dictionary with SBD specific parameters for ha_cluster
 # Omit parameters if they are already present in provided dictionary sap_ha_pacemaker_cluster_ha_cluster
 # sbd_devices omits only if already defined, which allows for empty list for Diskless SBD configuration.
-- name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
-  ansible.builtin.set_fact:
-    __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
-      {{
-        dict(
-          sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices | d([])
-            if not __ha_cluster_sbd_devices_exists
-            else omit),
-          sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
-            if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
-            else omit),
-          sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
-            if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
-            else omit)
-        )
-      }}
+- name: Block to set SBD parameters
   vars:
     # Detect if parameters were already provided in sap_ha_pacemaker_cluster_ha_cluster
     __ha_cluster_sbd_devices_exists:
@@ -186,6 +172,33 @@
       "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog | d([]) | length > 0 else false }}"
     __ha_cluster_sbd_watchdog_modules_exists:
       "{{ true if __sap_ha_pacemaker_cluster_ha_cluster.sbd_watchdog_modules | d([]) | length > 0 else false }}"
+  block:
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Fail if watchdog modules are not defined"
+      ansible.builtin.fail:
+        msg: |
+          FAIL: Watchdog modules must be defined for SBD configuration!
+          Please define watchdog modules in the variable 'sap_ha_pacemaker_cluster_sbd_watchdog_modules'
+          with appropriate values for your environment.
+      when:
+        - sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length == 0
+        - not __ha_cluster_sbd_watchdog_modules_exists
+
+    - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Create ha_cluster parameters for SBD"
+      ansible.builtin.set_fact:
+        __sap_ha_pacemaker_cluster_ha_cluster_stonith: >-
+          {{
+            dict(
+              sbd_devices=(sap_ha_pacemaker_cluster_sbd_devices | d([])
+                if not __ha_cluster_sbd_devices_exists
+                else omit),
+              sbd_watchdog=(sap_ha_pacemaker_cluster_sbd_watchdog
+                if sap_ha_pacemaker_cluster_sbd_watchdog | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_exists
+                else omit),
+              sbd_watchdog_modules=(sap_ha_pacemaker_cluster_sbd_watchdog_modules
+                if sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length > 0 and not __ha_cluster_sbd_watchdog_modules_exists
+                else omit)
+            )
+          }}
 
 
 - name: "SAP HA Prepare Pacemaker - (STONITH SBD) Include sbd fence agent"

--- a/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_sbd.yml
+++ b/roles/sap_ha_pacemaker_cluster/tasks/prepare_vars/prepare_stonith_sbd.yml
@@ -177,8 +177,7 @@
       ansible.builtin.fail:
         msg: |
           FAIL: Watchdog modules must be defined for SBD configuration!
-          Please define watchdog modules in the variable 'sap_ha_pacemaker_cluster_sbd_watchdog_modules'
-          with appropriate values for your environment.
+          Please define at least one watchdog module in the list variable 'sap_ha_pacemaker_cluster_sbd_watchdog_modules'.
       when:
         - sap_ha_pacemaker_cluster_sbd_watchdog_modules | d([]) | length == 0
         - not __ha_cluster_sbd_watchdog_modules_exists

--- a/roles/sap_ha_pacemaker_cluster/vars/main.yml
+++ b/roles/sap_ha_pacemaker_cluster/vars/main.yml
@@ -111,6 +111,7 @@ __sap_ha_pacemaker_cluster_repos: []
 __sap_ha_pacemaker_cluster_resource_clones: []
 __sap_ha_pacemaker_cluster_resource_groups: []
 __sap_ha_pacemaker_cluster_resource_primitives: []
+__sap_ha_pacemaker_cluster_quorum: {}
 
 # Pre-define this parameter in its dictionary format:
 __sap_ha_pacemaker_cluster_corosync_totem:


### PR DESCRIPTION
## Premise
QDevice and Diskless SBD are solutions sought for by SAP customers. This PR will add functionality to use both, without dipping into area of using non-cluster host. This is still outside of bounds of this role, as designed.

## Changes
- Add QDevice configuration steps and variables. It is using `ha_cluster_quorum`, without user override or complex logic, because it does not have any other use in `ha_cluster` as of now.
- Split existing STONITH task files to separate custom STONITH from SBD, since Diskless SBD does not work with STONITH agent.
- Fix wrong GCP conditional for health check on sap_hana_secondary.

## Tests
Tested on SLES_SAP 16.1 with ASCS/ERS ENSA2 cluster with both Diskless SBD with and without QDevice.

## NOTE
This change was tested along with https://github.com/linux-system-roles/ha_cluster/pull/374 which enabled this functionality for `crmsh`.