### PR TITLE
sap_hana_install: Update Pseudo-Idempotency

### DIFF
--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -377,7 +377,7 @@ Installs SAP HANA on `host1` and `host2`, while running on host `host0` where ex
 ```yaml
 ---
 - name: Ansible Play for SAP HANA installation - Add hosts
-  hosts: host0, host1
+  hosts: host0, host1, host2
   become: true
   tasks:
     - name: Execute Ansible Role sap_hana_install

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -34,10 +34,9 @@ sap_hana_install_keep_copied_sarfiles: false
 # For installing SAP HANA with fapolicyd support, set the following variable to `true`:
 sap_hana_install_configure_fapolicyd: false
 
-# (RedHat specific) desired fapolicyd service status (only if sap_hana_install_configure_fapolicyd is 'true')
-# For not enabling and not starting the fapolicyd service after the installation has finished, set the following
-# variable to `false`:
-sap_hana_install_enable_fapolicyd: true
+# (RedHat specific) desired fapolicyd service status (only if 'sap_hana_install_configure_fapolicyd' is set to 'true').
+# For enabling and starting the fapolicyd service after the installation has finished, set the following variable to 'true'.
+sap_hana_install_enable_fapolicyd: false
 
 # (RedHat specific) fapolicyd integrity level
 # When using fapolicyd, you can set the following variable to one of `none`, `size`, `sha256`, or `ima`. Note that before setting

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -274,3 +274,7 @@ sap_hana_install_create_initial_tenant: 'y'
 
 # Display SAP HANA hdblcm unattended mode output (hdblcm stdout)
 sap_hana_install_display_unattended_output: false
+
+# (Optional) Set to `true` to skip the filesystem check during SAP HANA installation.
+# This is not recommended, but can be used in case of a non-Production environment.
+sap_hana_install_skip_filesystem_check: false

--- a/roles/sap_hana_install/tasks/hana_addhosts.yml
+++ b/roles/sap_hana_install/tasks/hana_addhosts.yml
@@ -52,7 +52,7 @@
     cmd: "{{ __sap_hana_install_hdblcm_command }}"
   register: __sap_hana_install_register_hdblcm_add_hosts
   args:
-    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
+    chdir: "{{ __sap_hana_install_shared_path }}/hdblcm"
   changed_when: "'SAP HANA Lifecycle Management' in __sap_hana_install_register_hdblcm_add_hosts.stdout"
   when: not ansible_check_mode
 

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -88,6 +88,12 @@
 # - Configuration - Run always to ensure idempotent outcome.
 
 - name: Block for Installation tasks
+  # Stop execution of remaining tasks in the role, if any task in the block failed on any host.
+  # This ensures that the role does not proceed skipping failed host, but fails the entire role execution.
+  # 'any_errors_fatal' is not documented to work on task level, therefore we use simple block.
+  # http://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#aborting-on-the-first-error-any-errors-fatal
+  # Runs on all hosts in Scale-Out scenario, but allows independent failures for single host installations.
+  any_errors_fatal: "{{ true if __sap_hana_install_fact_is_scaleout else false }}"
   when:
     - sap_hana_install_new_system
       or (ansible_run_tags | d([])
@@ -115,6 +121,12 @@
 
 
 - name: Block for Addhosts tasks
+  # Stop execution of remaining tasks in the role, if any task in the block failed on any host.
+  # This ensures that the role does not proceed skipping failed host, but fails the entire role execution.
+  # 'any_errors_fatal' is not documented to work on task level, therefore we use simple block.
+  # http://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#aborting-on-the-first-error-any-errors-fatal
+  # Runs on all hosts in addhosts scenario.
+  any_errors_fatal: true
   when:
     - not sap_hana_install_new_system
       and (__sap_hana_install_fact_is_scaleout

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -46,15 +46,13 @@
   tags: always
 
 # SAP HANA presence has to be validated for both new system and adding new hosts.
+# Condition is removed, because detection is executed always.
 - name: SAP HANA - Main - Validate presence of existing SAP HANA database
   ansible.builtin.include_tasks:
     file: pre_tasks/hana_exists.yml
     apply:
       tags:
         - sap_hana_install_check_hana_exists
-  when:
-    - (sap_hana_install_new_system and not sap_hana_install_force)
-      or not sap_hana_install_new_system
   tags:
     - sap_hana_install_check_hana_exists
 
@@ -148,7 +146,7 @@
         gsub ("^\\s*hosts?: ", ""); gsub (", ", ","); print; a=0}
       }'
   args:
-    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
+    chdir: "{{ __sap_hana_install_shared_path }}/hdblcm"
   register: __sap_hana_install_register_completion_result
   changed_when: false
   when:

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -45,11 +45,22 @@
       tags: always
   tags: always
 
+
+# Process all hosts in play and define flag facts based on their intended role during installation.
+# - Detect Scale-Out and Addhosts operations.
+# - Set host identification flags
+# - Validate addhosts list against hosts in the play.
+- name: SAP HANA - Main - Identify hosts in play
+  ansible.builtin.include_tasks:
+    file: pre_tasks/identify_hosts.yml
+
+
 # SAP HANA presence has to be validated for both new system and adding new hosts.
-# Condition is removed, because detection is executed always.
+# - Detection is executed even in force mode, but fails are skipped to allow execution of the role.
+# - Host identification flags are used to ignore /hana/shared file detection check for Scale-Out addhosts hosts.
 - name: SAP HANA - Main - Validate presence of existing SAP HANA database
   ansible.builtin.include_tasks:
-    file: pre_tasks/hana_exists.yml
+    file: pre_tasks/detect_hana.yml
     apply:
       tags:
         - sap_hana_install_check_hana_exists
@@ -57,9 +68,11 @@
     - sap_hana_install_check_hana_exists
 
 
-- name: SAP HANA - Main - Identify hosts in play based on addhosts
+# Validate detected SAP installations against allowed Scale-Out scenarios.
+- name: SAP HANA - Main - Validate hosts in play
   ansible.builtin.include_tasks:
-    file: pre_tasks/identify_hosts.yml
+    file: pre_tasks/validate_hosts.yml
+  when: __sap_hana_install_fact_is_scaleout
 
 
 - name: SAP HANA - Main - Ensure SAP HANA is running for existing systems or addhosts operations
@@ -75,10 +88,12 @@
 # - Configuration - Run always to ensure idempotent outcome.
 
 - name: Block for Installation tasks
-  when: sap_hana_install_new_system or
-    ('sap_hana_install_create_configfile' in ansible_run_tags | d([])) or
-    ('sap_hana_install_hdblcm_commandline' in ansible_run_tags | d([]))
+  when:
+    - sap_hana_install_new_system
+      or (ansible_run_tags | d([])
+        | intersect(['sap_hana_install_create_configfile', 'sap_hana_install_hdblcm_commandline'])) | length > 0
   block:
+    # Task file contains pseudo-idempotency checks and cannot be skipped for installed system.
     - name: SAP HANA - Install - Pre-Tasks
       ansible.builtin.include_tasks:
         file: pre_install.yml
@@ -89,9 +104,9 @@
     - name: SAP HANA - Install
       ansible.builtin.include_tasks:
         file: hana_install.yml
-      when: >
-        (not __sap_hana_install_fact_is_installed and __sap_hana_install_fact_is_main_host) or
-        ('sap_hana_install_hdblcm_commandline' in ansible_run_tags | d([]))
+      when:
+        - (not __sap_hana_install_fact_is_installed and __sap_hana_install_fact_is_main_host)
+          or (ansible_run_tags | d([]) | intersect(['sap_hana_install_hdblcm_commandline'])) | length > 0
       tags: sap_hana_install_hdblcm_commandline
 
     - name: SAP HANA - Install - Post-tasks
@@ -100,20 +115,20 @@
 
 
 - name: Block for Addhosts tasks
-  when: >
-    not sap_hana_install_new_system and
-    ((__sap_hana_install_fact_is_scaleout and __sap_hana_install_fact_is_installed) or
-    ('sap_hana_install_hdblcm_commandline' in ansible_run_tags | d([])) or
-    ('sap_hana_install_create_configfile' in ansible_run_tags | d([])))
+  when:
+    - not sap_hana_install_new_system
+      and (__sap_hana_install_fact_is_scaleout
+        or (ansible_run_tags | d([])
+          | intersect(['sap_hana_install_create_configfile', 'sap_hana_install_hdblcm_commandline'])) | length > 0)
   block:
     # Execute only if new hosts are to be added.
     - name: SAP HANA - Addhosts - Pre-Tasks
       ansible.builtin.include_tasks:
         file: pre_addhosts.yml
-      when: >
-        (__sap_hana_install_fact_addhosts_hosts_new | d([]) | length > 0) or
-        ('sap_hana_install_hdblcm_commandline' in ansible_run_tags | d([])) or
-        ('sap_hana_install_create_configfile' in ansible_run_tags | d([]))
+      when:
+        - __sap_hana_install_fact_addhosts_hosts_new | d([]) | length > 0
+          or (ansible_run_tags | d([])
+            | intersect(['sap_hana_install_create_configfile', 'sap_hana_install_hdblcm_commandline'])) | length > 0
       tags:
         - sap_hana_install_hdblcm_commandline
         - sap_hana_install_create_configfile
@@ -122,9 +137,9 @@
       ansible.builtin.include_tasks:
         file: hana_addhosts.yml
       when:
-        (__sap_hana_install_fact_addhosts_hosts_new | d([]) | length > 0 and __sap_hana_install_fact_is_main_host) or
-        ('sap_hana_install_hdblcm_commandline' in ansible_run_tags | d([])) or
-        ('sap_hana_install_create_configfile' in ansible_run_tags | d([]))
+        - (__sap_hana_install_fact_addhosts_hosts_new | d([]) | length > 0 and __sap_hana_install_fact_is_main_host)
+          or (ansible_run_tags | d([])
+            | intersect(['sap_hana_install_create_configfile', 'sap_hana_install_hdblcm_commandline'])) | length > 0
       tags:
         - sap_hana_install_hdblcm_commandline
         - sap_hana_install_create_configfile
@@ -162,11 +177,6 @@
       SID              -       {{ sap_hana_install_sid }}
       NR               -       {{ sap_hana_install_number }}
 
-      {% if sap_hana_install_new_system and __sap_hana_install_fact_is_installed and __sap_hana_install_fact_addhosts_hosts_new | length > 0 %}
-      The new hosts defined in the variable 'sap_hana_install_addhosts' were not added: {{ __sap_hana_install_fact_addhosts_hosts_new | join(', ') }}.
-      Execute this role with the variable 'sap_hana_install_new_system' set to false to add new hosts.
-      {% endif %}
-
       {% if sap_hana_install_configure_firewall %}
       Firewall is enabled and SAP HANA ports are open.
       {% endif %}
@@ -177,8 +187,8 @@
       Fapolicyd is configured for SAP folders ({{ sap_hana_install_directories | map('quote') | join(', ') }}).
       {% endif %}
   vars:
-    __sap_hana_install_fact_hana_version: "{{ __sap_hana_install_register_completion_result.stdout.split(';')[0] }}"
-    __sap_hana_install_fact_hana_hosts: "{{ __sap_hana_install_register_completion_result.stdout.split(';')[1] }}"
+    __sap_hana_install_fact_hana_version: "{{ __sap_hana_install_register_completion_result.stdout.split(';')[0] | d('N/A') }}"
+    __sap_hana_install_fact_hana_hosts: "{{ __sap_hana_install_register_completion_result.stdout.split(';')[1] | d('N/A') }}"
   when:
     - not ansible_check_mode
     - __sap_hana_install_fact_is_main_host

--- a/roles/sap_hana_install/tasks/post_addhosts.yml
+++ b/roles/sap_hana_install/tasks/post_addhosts.yml
@@ -27,3 +27,6 @@
     # Ensure fapolicyd is checked only on supported systems.
     - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_configure_fapolicyd
+    # Added to ensure that fapolicyd is configured only on new installations
+    # to ensure trusting potentially compromised files.
+    - __sap_hana_install_fact_is_new_addhost_host

--- a/roles/sap_hana_install/tasks/post_addhosts.yml
+++ b/roles/sap_hana_install/tasks/post_addhosts.yml
@@ -28,5 +28,5 @@
     - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_configure_fapolicyd
     # Added to ensure that fapolicyd is configured only on new installations
-    # to ensure trusting potentially compromised files.
+    # to avoid trusting potentially compromised files in existing installation.
     - __sap_hana_install_fact_is_new_addhost_host

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -5,6 +5,7 @@
 - name: Block with tasks for new HANA Systems
   when:
     - not __sap_hana_install_fact_is_installed
+    # Execute only on main host and skip execution on addhosts.
     - __sap_hana_install_fact_is_main_host
   block:
 

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -76,5 +76,5 @@
     - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_configure_fapolicyd
     # Added to ensure that fapolicyd is configured only on new installations
-    # to ensure trusting potentially compromised files.
+    # to avoid trusting potentially compromised files in existing installation.
     - not __sap_hana_install_fact_is_installed

--- a/roles/sap_hana_install/tasks/post_install.yml
+++ b/roles/sap_hana_install/tasks/post_install.yml
@@ -75,3 +75,6 @@
     # Ensure fapolicyd is checked only on supported systems.
     - ansible_facts['os_family'] == "RedHat"
     - __sap_hana_install_configure_fapolicyd
+    # Added to ensure that fapolicyd is configured only on new installations
+    # to ensure trusting potentially compromised files.
+    - not __sap_hana_install_fact_is_installed

--- a/roles/sap_hana_install/tasks/post_tasks/check_installation.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/check_installation.yml
@@ -39,7 +39,7 @@
 - name: SAP HANA - Post-Tasks - Construct an hdbcheck command line
   ansible.builtin.set_fact:
     __sap_hana_install_fact_installation_check_command: "set -o pipefail && ./hdbcheck -b --read_password_from_stdin=xml
-      --property_file={{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/global/hdb/install/support/hdbcheck.xml
+      --property_file={{ __sap_hana_install_shared_path }}/global/hdb/install/support/hdbcheck.xml
       --remote_execution=ssh
       --scope=system
       -b < {{ __sap_hana_install_register_tmpdir.path }}/configfile.cfg.xml"
@@ -61,7 +61,7 @@
 - name: SAP HANA - Post-Tasks - hdbcheck - Perform the check # noqa command-instead-of-shell
   ansible.builtin.shell: "{{ __sap_hana_install_fact_installation_check_command }}"
   args:
-    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/global/hdb/install/bin"
+    chdir: "{{ __sap_hana_install_shared_path }}/global/hdb/install/bin"
   register: __sap_hana_install_register_installation_check
   changed_when: false
   when: sap_hana_install_use_hdbcheck | d(true)
@@ -77,7 +77,7 @@
 - name: SAP HANA - Post-Tasks - hdblcm - Perform the check # noqa command-instead-of-shell
   ansible.builtin.shell: "{{ __sap_hana_install_fact_installation_check_command }}"
   args:
-    chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
+    chdir: "{{ __sap_hana_install_shared_path }}/hdblcm"
   register: __sap_hana_install_register_installation_check
   changed_when: false
   when: not sap_hana_install_use_hdbcheck | d(true)

--- a/roles/sap_hana_install/tasks/post_tasks/user_expiration.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/user_expiration.yml
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
+# NOTE: This can be replaced completely by 'ansible.builtin.user' module when we increase minimum ansible version to 2.18!
+# Argument '-I' is set by module parameter 'password_expire_account_disable' added in 2.18.
+# ansible.builtin.user:
+#   name: "{{ user_item }}"
+#   password_expire_min: 0  # chage -m 0
+#   password_expire_max: 99999  # chage -M 99999
+#   password_expire_account_disable: -1  # chage -I -1
+#   expires: -1  # chage -E -1
+
+# Current use of 'chage' will always be marked as change in Ansible logs, regardless of outcome.
 - name: SAP HANA - Post-Tasks - Set '{{ sap_hana_install_sid | lower }}adm' to not expire
   ansible.builtin.shell: |
       chage -m 0 -M 99999 -I -1 -E -1 {{ sap_hana_install_sid | lower }}adm

--- a/roles/sap_hana_install/tasks/pre_addhosts.yml
+++ b/roles/sap_hana_install/tasks/pre_addhosts.yml
@@ -81,6 +81,7 @@
 - name: SAP HANA - Addhosts - Pre-Tasks - Check shared filesystems
   ansible.builtin.include_tasks:
     file: pre_tasks/check_filesystems.yml
+  when: not sap_hana_install_skip_filesystem_check | d(false)
 
 
 # Update HANA directory permissions

--- a/roles/sap_hana_install/tasks/pre_addhosts.yml
+++ b/roles/sap_hana_install/tasks/pre_addhosts.yml
@@ -17,17 +17,16 @@
         key: sapadm
       failed_when: false
 
-    # hana_exists already found existing database, this is additional check.
-    # getent_group['sapsys'][1] and getent_passwd['sapadm'][2] are Group ID.
-    - name: SAP HANA - Addhosts - Pre-Tasks - Assert that user 'sapadm' is present with group 'sapsys'
-      ansible.builtin.assert:
-        that:
-          - "'sapsys' in getent_group"
-          - "'sapadm' in getent_passwd"
-          # Ensure sapadm user is assigned to sapsys group
-          - getent_group['sapsys'][1] == getent_passwd['sapadm'][2]
-        fail_msg: >-
-          FAIL: User 'sapadm' with group 'sapsys' does not exist!
+    # detect_hana already found existing database, this is additional check.
+    # ansible_facts["getent_group"]['sapsys'][1] and ansible_facts["getent_passwd"]['sapadm'][2] are Group ID.
+    - name: SAP HANA - Addhosts - Pre-Tasks - Fail if user 'sapadm' is not present with group 'sapsys'
+      ansible.builtin.fail:
+        msg: |
+          FAIL: User 'sapadm' with group 'sapsys' does not exist or it has incorrect group ID!
+      when:
+        - ansible_facts["getent_group"]['sapsys'] is not defined
+          or ansible_facts["getent_passwd"]['sapadm'] is not defined
+          or ansible_facts["getent_group"]['sapsys'][1] != ansible_facts["getent_passwd"]['sapadm'][2]
 
     # TODO: Issue#1123 Remove default to master
     - name: SAP HANA - Addhosts - Pre-Tasks - Generate password hash for 'sap_hana_install_sapadm_password'

--- a/roles/sap_hana_install/tasks/pre_install.yml
+++ b/roles/sap_hana_install/tasks/pre_install.yml
@@ -42,7 +42,9 @@
 - name: SAP HANA - Install - Pre-Tasks - Check shared filesystems
   ansible.builtin.include_tasks:
     file: pre_tasks/check_filesystems.yml
-  when: __sap_hana_install_fact_is_scaleout
+  when:
+    - __sap_hana_install_fact_is_scaleout
+    - not sap_hana_install_skip_filesystem_check | d(false)
 
 
 # We need to change permissions only after filesystem check has passed.

--- a/roles/sap_hana_install/tasks/pre_tasks/check_filesystems.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/check_filesystems.yml
@@ -17,26 +17,33 @@
       "{{ ansible_facts['mounts'] | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | first }}"
   when: ansible_facts['mounts'] | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | length > 0
 
-- name: SAP HANA - Install - Pre-Tasks - Assert that filesystem is shared - {{ sap_hana_install_shared_path }}
-  ansible.builtin.assert:
-    that:
-      - __sap_hana_install_fact_mount_hana_shared is defined
-      - __sap_hana_install_fact_mount_hana_shared.fstype is defined
-      - __sap_hana_install_fact_mount_hana_shared.fstype in __sap_hana_install_shared_filesystem_types
-    success_msg: >-
-      PASS: The directory {{ sap_hana_install_shared_path }} is mounted as one of supported
-      filesystem types {{ __sap_hana_install_shared_filesystem_types | join(', ') }}.
-    fail_msg: |
-      FAIL: The directory {{ sap_hana_install_shared_path }} is not mounted as shared filesystem.
-      This is required for SAP HANA Scale-Out systems.
+- name: Block to fail if any host fails
+  # Stop execution of remaining tasks in the role, if any task in the block failed on any host.
+  # This ensures that the role does not proceed skipping failed host, but fails the entire role execution.
+  # 'any_errors_fatal' is not documented to work on task level, therefore we use simple block.
+  # http://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#aborting-on-the-first-error-any-errors-fatal
+  any_errors_fatal: true
+  block:
+    - name: SAP HANA - Install - Pre-Tasks - Assert that filesystem is shared - {{ sap_hana_install_shared_path }}
+      ansible.builtin.assert:
+        that:
+          - __sap_hana_install_fact_mount_hana_shared is defined
+          - __sap_hana_install_fact_mount_hana_shared.fstype is defined
+          - __sap_hana_install_fact_mount_hana_shared.fstype in __sap_hana_install_shared_filesystem_types
+        success_msg: >-
+          PASS: The directory {{ sap_hana_install_shared_path }} is mounted as one of supported
+          filesystem types {{ __sap_hana_install_shared_filesystem_types | join(', ') }}.
+        fail_msg: |
+          FAIL: The directory {{ sap_hana_install_shared_path }} is not mounted as shared filesystem.
+          This is required for SAP HANA Scale-Out systems.
 
-      Please ensure this is a correctly mounted shared filesystem before proceeding.
-      This role validates prerequisites but does not configure system mounts.
+          Please ensure this is a correctly mounted shared filesystem before proceeding.
+          This role validates prerequisites but does not configure system mounts.
 
-      {% if __sap_hana_install_fact_mount_hana_shared.fstype is defined %}
-      Detected filesystem type: {{ __sap_hana_install_fact_mount_hana_shared.fstype }}
-      {% endif %}
-      Supported filesystem types: {{ __sap_hana_install_shared_filesystem_types | join(', ') }}
+          {% if __sap_hana_install_fact_mount_hana_shared.fstype is defined %}
+          Detected filesystem type: {{ __sap_hana_install_fact_mount_hana_shared.fstype }}
+          {% endif %}
+          Supported filesystem types: {{ __sap_hana_install_shared_filesystem_types | join(', ') }}
 
 
 # /lss/shared - Required for SAP HANA 2.0 SPS08 and higher.
@@ -44,6 +51,11 @@
   when:
     - hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_is_lss_required'] is defined
     - hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_is_lss_required']
+  # Stop execution of remaining tasks in the role, if any task in the block failed on any host.
+  # This ensures that the role does not proceed skipping failed host, but fails the entire role execution.
+  # 'any_errors_fatal' is not documented to work on task level, therefore we use simple block.
+  # http://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#aborting-on-the-first-error-any-errors-fatal
+  any_errors_fatal: true
   block:
     - name: SAP HANA - Install - Pre-Tasks - Set fact for 'lss_inst_path'
       ansible.builtin.set_fact:

--- a/roles/sap_hana_install/tasks/pre_tasks/check_filesystems.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/check_filesystems.yml
@@ -17,33 +17,26 @@
       "{{ ansible_facts['mounts'] | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | first }}"
   when: ansible_facts['mounts'] | selectattr('mount', 'equalto', sap_hana_install_shared_path) | list | length > 0
 
-- name: Block to fail if any host fails
-  # Stop execution of remaining tasks in the role, if any task in the block failed on any host.
-  # This ensures that the role does not proceed skipping failed host, but fails the entire role execution.
-  # 'any_errors_fatal' is not documented to work on task level, therefore we use simple block.
-  # http://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#aborting-on-the-first-error-any-errors-fatal
-  any_errors_fatal: true
-  block:
-    - name: SAP HANA - Install - Pre-Tasks - Assert that filesystem is shared - {{ sap_hana_install_shared_path }}
-      ansible.builtin.assert:
-        that:
-          - __sap_hana_install_fact_mount_hana_shared is defined
-          - __sap_hana_install_fact_mount_hana_shared.fstype is defined
-          - __sap_hana_install_fact_mount_hana_shared.fstype in __sap_hana_install_shared_filesystem_types
-        success_msg: >-
-          PASS: The directory {{ sap_hana_install_shared_path }} is mounted as one of supported
-          filesystem types {{ __sap_hana_install_shared_filesystem_types | join(', ') }}.
-        fail_msg: |
-          FAIL: The directory {{ sap_hana_install_shared_path }} is not mounted as shared filesystem.
-          This is required for SAP HANA Scale-Out systems.
+- name: SAP HANA - Install - Pre-Tasks - Assert that filesystem is shared - {{ sap_hana_install_shared_path }}
+  ansible.builtin.assert:
+    that:
+      - __sap_hana_install_fact_mount_hana_shared is defined
+      - __sap_hana_install_fact_mount_hana_shared.fstype is defined
+      - __sap_hana_install_fact_mount_hana_shared.fstype in __sap_hana_install_shared_filesystem_types
+    success_msg: >-
+      PASS: The directory {{ sap_hana_install_shared_path }} is mounted as one of supported
+      filesystem types {{ __sap_hana_install_shared_filesystem_types | join(', ') }}.
+    fail_msg: |
+      FAIL: The directory {{ sap_hana_install_shared_path }} is not mounted as shared filesystem.
+      This is required for SAP HANA Scale-Out systems.
 
-          Please ensure this is a correctly mounted shared filesystem before proceeding.
-          This role validates prerequisites but does not configure system mounts.
+      Please ensure this is a correctly mounted shared filesystem before proceeding.
+      This role validates prerequisites but does not configure system mounts.
 
-          {% if __sap_hana_install_fact_mount_hana_shared.fstype is defined %}
-          Detected filesystem type: {{ __sap_hana_install_fact_mount_hana_shared.fstype }}
-          {% endif %}
-          Supported filesystem types: {{ __sap_hana_install_shared_filesystem_types | join(', ') }}
+      {% if __sap_hana_install_fact_mount_hana_shared.fstype is defined %}
+      Detected filesystem type: {{ __sap_hana_install_fact_mount_hana_shared.fstype }}
+      {% endif %}
+      Supported filesystem types: {{ __sap_hana_install_shared_filesystem_types | join(', ') }}
 
 
 # /lss/shared - Required for SAP HANA 2.0 SPS08 and higher.
@@ -51,11 +44,6 @@
   when:
     - hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_is_lss_required'] is defined
     - hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_is_lss_required']
-  # Stop execution of remaining tasks in the role, if any task in the block failed on any host.
-  # This ensures that the role does not proceed skipping failed host, but fails the entire role execution.
-  # 'any_errors_fatal' is not documented to work on task level, therefore we use simple block.
-  # http://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html#aborting-on-the-first-error-any-errors-fatal
-  any_errors_fatal: true
   block:
     - name: SAP HANA - Install - Pre-Tasks - Set fact for 'lss_inst_path'
       ansible.builtin.set_fact:

--- a/roles/sap_hana_install/tasks/pre_tasks/create_users_groups.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/create_users_groups.yml
@@ -8,7 +8,7 @@
 - name: SAP HANA - Addhosts - Pre-Tasks - Create 'sapsys' group on new host
   ansible.builtin.group:
     name: sapsys
-    gid: "{{ hostvars[__sap_hana_install_fact_main_host]['getent_group']['sapsys'][1] }}"
+    gid: "{{ hostvars[__sap_hana_install_fact_main_host]['ansible_facts']['getent_group']['sapsys'][1] }}"
     state: present
   become: true
 
@@ -16,9 +16,9 @@
 - name: SAP HANA - Addhosts - Pre-Tasks - Create 'sapadm' user on new host
   ansible.builtin.user:
     name: sapadm
-    uid: "{{ hostvars[__sap_hana_install_fact_main_host]['getent_passwd']['sapadm'][1] }}"
-    home: "{{ hostvars[__sap_hana_install_fact_main_host]['getent_passwd']['sapadm'][4] }}"
-    shell: "{{ hostvars[__sap_hana_install_fact_main_host]['getent_passwd']['sapadm'][5] }}"
+    uid: "{{ hostvars[__sap_hana_install_fact_main_host]['ansible_facts']['getent_passwd']['sapadm'][1] }}"
+    home: "{{ hostvars[__sap_hana_install_fact_main_host]['ansible_facts']['getent_passwd']['sapadm'][4] }}"
+    shell: "{{ hostvars[__sap_hana_install_fact_main_host]['ansible_facts']['getent_passwd']['sapadm'][5] }}"
     groups: sapsys
     append: true
     state: present

--- a/roles/sap_hana_install/tasks/pre_tasks/detect_hana.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/detect_hana.yml
@@ -10,11 +10,13 @@
 # 1. SKIP - 'root' saphostctrl check finds the desired SID and instance number.
 # 2. INSTALL - 'root' saphostctrl check does not find the desired SID and instance number, and no other indicators are found.
 # 3. FAIL - 'root' saphostctrl check does not find the desired SID and instance number, and any other indicators are found.
+#         - Conditions apply when handling Scale-Out systems, where additional hosts share filesystem.
 
 # 'saphostctrl' is not present:
 # 4. SKIP - 'sidadm' sapcontrol check finds the desired SID and instance number.
 # 5. INSTALL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and no other indicators are found.
 # 6. FAIL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and any other indicators are found.
+#         - Conditions apply when handling Scale-Out systems, where additional hosts share filesystem.
 
 # Breakdown of potential scenarios and actions:
 # | saphostctrl | sapcontrol | Instance Found | Files Found | Action
@@ -179,11 +181,6 @@
       or (__sap_hana_install_register_saphostctrl_list_instances.rc is defined
         and __sap_hana_install_register_saphostctrl_list_instances.rc != 0)
 
-- name: SAP HANA - Pre-Tasks - Detect - Show saphostctrl command output in verbose mode
-  ansible.builtin.debug:
-    var: __sap_hana_install_register_saphostctrl_list_instances
-  when: ansible_verbosity >= 2
-
 
 # Check 4: Use 'sapcontrol' and search for SID and instance number in 'GetInstanceProperties' output.
 # The `sapcontrol` command from SAP kernel files can be used to obtain instance information.
@@ -268,19 +265,33 @@
     - not __sap_hana_install_fact_detect_sapcontrol | d(false)
   block:
 
-    # /hana/shared/<SID> directory
-    - name: SAP HANA - Pre-Tasks - Get status of the path '{{ __sap_hana_install_shared_path }}'
-      ansible.builtin.stat:
-        path: "{{ __sap_hana_install_shared_path }}"
-      register: __sap_hana_install_register_stat_hana_shared_sid
+    # Shared directory cannot be used for validation for additional hosts in Scale-Out, because it is:
+    # not empty - Main host is installed and additional hosts are being added.
+    # empty - Main host is being installed together with additional hosts.
+    - name: Block for shared directory
+      when: not __sap_hana_install_fact_is_addhost_host | d(false)
+      block:
+        # /hana/shared/<SID> directory
+        - name: SAP HANA - Pre-Tasks - Get status of the path '{{ __sap_hana_install_shared_path }}'
+          ansible.builtin.stat:
+            path: "{{ __sap_hana_install_shared_path }}"
+          register: __sap_hana_install_register_stat_hana_shared_sid
 
-    - name: SAP HANA - Pre-Tasks - Get contents of the path '{{ __sap_hana_install_shared_path }}'
-      ansible.builtin.find:
-        paths: "{{ __sap_hana_install_shared_path }}"
-        patterns: '*'
-        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
-      register: __sap_hana_install_register_files_in_hana_shared_sid
-      when: __sap_hana_install_register_stat_hana_shared_sid.stat.exists
+        - name: SAP HANA - Pre-Tasks - Get contents of the path '{{ __sap_hana_install_shared_path }}'
+          ansible.builtin.find:
+            paths: "{{ __sap_hana_install_shared_path }}"
+            patterns: '*'
+            file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
+          register: __sap_hana_install_register_files_in_hana_shared_sid
+          when: __sap_hana_install_register_stat_hana_shared_sid.stat.exists
+
+        - name: SAP HANA - Pre-Tasks - Set fact if SAP files were found
+          ansible.builtin.set_fact:
+            __sap_hana_install_fact_detect_shared_files: true
+          when:
+            - __sap_hana_install_register_stat_hana_shared_sid.stat.exists
+            - __sap_hana_install_register_files_in_hana_shared_sid.matched | int != 0
+
 
     # /usr/sap/<SID> directory
     - name: SAP HANA - Pre-Tasks - Get status of the path '/usr/sap/{{ __sap_hana_install_sid }}'
@@ -296,27 +307,29 @@
       register: __sap_hana_install_register_files_in_usr_sap_sid
       when: __sap_hana_install_register_stat_usr_sap_sid.stat.exists
 
-
     - name: SAP HANA - Pre-Tasks - Set fact if SAP files were found
       ansible.builtin.set_fact:
-        __sap_hana_install_fact_detect_files: true
+        __sap_hana_install_fact_detect_local_files: true
       when:
-        - (__sap_hana_install_register_stat_hana_shared_sid.stat.exists
-            and __sap_hana_install_register_files_in_hana_shared_sid.matched | int != 0)
-          or (__sap_hana_install_register_stat_usr_sap_sid.stat.exists
-            and __sap_hana_install_register_files_in_usr_sap_sid.matched | int != 0 )
+        - __sap_hana_install_register_stat_usr_sap_sid.stat.exists
+        - __sap_hana_install_register_files_in_usr_sap_sid.matched | int != 0
 
 
 ### Decision section based on collected facts.
 
 # 3. FAIL - 'root' saphostctrl check does not find the desired SID and instance number, and any other indicators are found
 # 6. FAIL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and any other indicators are found
+#         - Conditions apply when handling Scale-Out systems, where additional hosts share filesystem.
 - name: SAP HANA - Pre-Tasks - Detect - Fail if potential installation was detected
   ansible.builtin.fail:
     msg: |
       FAIL: Potential existing SAP HANA installation detected based on the presence of identifiable indicators.
+      {% if __sap_hana_install_fact_detect_local_files | d(false) %}
       - Existence of files in '/usr/sap/{{ __sap_hana_install_sid }}/' directory.
+      {% endif %}
+      {% if __sap_hana_install_fact_detect_shared_files | d(false) %}
       - Existence of files in '{{ __sap_hana_install_shared_path }}/' directory.
+      {% endif %}
       These checks trigger failure only when 'saphostctrl' and 'sapcontrol' fail to detect the instance.
 
       Please verify the details above and ensure that you are not trying to install over an existing installation.
@@ -325,11 +338,16 @@
     - not sap_hana_install_force | d(false)
     - not __sap_hana_install_fact_detect_saphostctrl | d(false)
     - not __sap_hana_install_fact_detect_sapcontrol | d(false)
-    - __sap_hana_install_fact_detect_files | d(false)
+    # Always fail when local files are found,
+    # but fail only for shared files if this is not an addhost in Scale-Out.
+    - __sap_hana_install_fact_detect_local_files | d(false)
+      or (__sap_hana_install_fact_detect_shared_files | d(false)
+          and not __sap_hana_install_fact_is_addhost_host | d(false))
 
 
 # 1. SKIP - 'root' saphostctrl check finds the desired SID and instance number.
 # 4. SKIP - 'sidadm' sapcontrol check finds the desired SID and instance number.
+# NOTE: Do not trust directory check enough to skip installation.
 - name: Block for SKIP
   when:
     - __sap_hana_install_fact_detect_saphostctrl | d(false)
@@ -370,7 +388,9 @@
   when:
     - not __sap_hana_install_fact_detect_saphostctrl | d(false)
     - not __sap_hana_install_fact_detect_sapcontrol | d(false)
-    - not __sap_hana_install_fact_detect_files | d(false)
+    - not __sap_hana_install_fact_detect_local_files | d(false)
+    - not (__sap_hana_install_fact_detect_shared_files | d(false)
+        and __sap_hana_install_fact_is_main_host)
 
 
 - name: Block to prepare status message
@@ -379,7 +399,8 @@
     - not ansible_check_mode
   block:
     - name: SAP HANA - Pre-Tasks - Run 'hdblcm --list_systems' for existing database
-      ansible.builtin.shell: |
+      ansible.builtin.shell:
+        cmd: |
           set -o pipefail && ./hdblcm --list_systems | awk '/\/hana\/shared\/{{ __sap_hana_install_sid }}/{a=1}
           /version:/{if (a==1){
             gsub ("^\\s*version: ", "");printf ("%s;", $NF)}
@@ -392,23 +413,53 @@
       register: __sap_hana_install_register_existing_systems
       changed_when: false
 
-    # Scale-Out will show as installed because of filesystem check so we need to
-    # ensure that we show output only if it is valid.
-    - name: Block to show only if output is valid
-      when: __sap_hana_install_register_existing_systems.stdout.split(';') | length == 2
-      block:
-        - name: SAP HANA - Pre-Tasks - Set facts for existing SAP HANA
-          ansible.builtin.set_fact:
-            __sap_hana_install_fact_existing_hana_version:
-              "{{ __sap_hana_install_register_existing_systems.stdout.split(';')[0] }}"
-            __sap_hana_install_fact_existing_hana_hosts:
-              "{{ __sap_hana_install_register_existing_systems.stdout.split(';')[1] }}"
+    - name: SAP HANA - Pre-Tasks - Fail if command 'hdblcm --list_systems' has failed
+      ansible.builtin.fail:
+        msg: |
+          FAIL: Command 'hdblcm --list_systems' failed to execute successfully
+          or results could not be reliably parsed to identify version and hosts of existing installation.
+          Return code: {{ __sap_hana_install_register_existing_systems.rc | d('1') }}
+          Output:      {{ __sap_hana_install_register_existing_systems.stdout | d('') }}
+          Error:       {{ __sap_hana_install_register_existing_systems.stderr | d('') }}
+      when:
+        - __sap_hana_install_register_existing_systems.rc != 0
+          or __sap_hana_install_register_existing_systems.stdout.split(';') | length != 2
 
-        - name: SAP HANA - Pre-Tasks - Display details of existing SAP HANA
-          ansible.builtin.debug:
-            msg: |
-              SAP HANA database is installed and running:
-              HANA Version     -       {{ __sap_hana_install_fact_existing_hana_version }}
-              Hosts            -       {{ __sap_hana_install_fact_existing_hana_hosts }}
-              SID              -       {{ __sap_hana_install_sid }}
-              NR               -       {{ sap_hana_install_number }}
+
+    - name: SAP HANA - Pre-Tasks - Set facts for existing SAP HANA installation
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_existing_hana_version:
+          "{{ __sap_hana_install_register_existing_systems.stdout.split(';')[0] }}"
+        __sap_hana_install_fact_existing_hana_hosts:
+          "{{ __sap_hana_install_register_existing_systems.stdout.split(';')[1] }}"
+
+    - name: SAP HANA - Pre-Tasks - Display details of existing SAP HANA installation
+      ansible.builtin.debug:
+        msg: |
+          SAP HANA database is installed and running:
+          HANA Version     -       {{ __sap_hana_install_fact_existing_hana_version }}
+          Hosts            -       {{ __sap_hana_install_fact_existing_hana_hosts }}
+          SID              -       {{ __sap_hana_install_sid }}
+          NR               -       {{ sap_hana_install_number }}
+
+
+- name: SAP HANA - Pre-Tasks - Detect - Show detection details in verbose mode
+  ansible.builtin.debug:
+    msg: |
+      Detection results:
+      - force mode: {{ sap_hana_install_force }}
+      - saphostctrl found: {{ __sap_hana_install_fact_detect_saphostctrl | d(false) }}
+      - sapcontrol found: {{ __sap_hana_install_fact_detect_sapcontrol | d(false) }}
+      - local files found: {{ __sap_hana_install_fact_detect_local_files | d(false) }}
+      - shared files found: {{ __sap_hana_install_fact_detect_shared_files | d(false) }}
+      - is installed: {{ __sap_hana_install_fact_is_installed | d(false) }}
+      - existing HANA version: {{ __sap_hana_install_fact_existing_hana_version | d('N/A') }}
+      - existing HANA hosts: {{ __sap_hana_install_fact_existing_hana_hosts | d('N/A') }}
+
+      Host identification flags:
+      - is main host: {{ __sap_hana_install_fact_is_main_host | d(false) }}
+      - is addhost host: {{ __sap_hana_install_fact_is_addhost_host | d(false) }}
+      - is scaleout: {{ __sap_hana_install_fact_is_scaleout | d(false) }}
+      - main host: {{ __sap_hana_install_fact_main_host | d('N/A') }}
+      - addhosts: {{ __sap_hana_install_fact_addhosts_hosts | d([]) | join(', ') }}
+  when: ansible_verbosity >= 2

--- a/roles/sap_hana_install/tasks/pre_tasks/hana_exists.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/hana_exists.yml
@@ -1,204 +1,376 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: SAP HANA - Pre-Tasks - Check if saphostctrl is installed
-  ansible.builtin.stat:
-    path: /usr/sap/hostctrl/exe/saphostctrl
-  check_mode: false
-  register: __sap_hana_install_register_stat_saphostctrl
+### List of scenarios for determining next steps.
+# This ensures that installation can be skipped when needed to prevent any potential issues affecting existing installations.
+# Optional override is available in defaults/main.yml to execute regardless of warning.
+# NOTE: SAP Host Agent can be skipped during installation using 'install_hostagent=n'.
+
+## 'saphostctrl' is present:
+# 1. SKIP - 'root' saphostctrl check finds the desired SID and instance number.
+# 2. INSTALL - 'root' saphostctrl check does not find the desired SID and instance number, and no other indicators are found.
+# 3. FAIL - 'root' saphostctrl check does not find the desired SID and instance number, and any other indicators are found.
+
+# 'saphostctrl' is not present:
+# 4. SKIP - 'sidadm' sapcontrol check finds the desired SID and instance number.
+# 5. INSTALL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and no other indicators are found.
+# 6. FAIL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and any other indicators are found.
+
+# Breakdown of potential scenarios and actions:
+# | saphostctrl | sapcontrol | Instance Found | Files Found | Action
+# |-------------|------------|----------------|-------------|--------
+# | Yes         | N/A        | Yes            | N/A         | SKIP
+# | Yes         | N/A        | No             | No          | INSTALL
+# | Yes         | N/A        | No             | Any         | FAIL
+# | No          | Yes        | Yes            | N/A         | SKIP
+# | No          | Yes        | No             | Any         | FAIL
+# | No          | No         | No             | No          | INSTALL
+
+# List of non-saphostctrl indicators for potential existing SAP HANA installation:
+# A. Files found in /hana/shared/<SID> directory.
+# B. Files found in /usr/sap/<SID> directory.
+
+
+# Check 1: Check if the group 'sapsys' exists with correct ID.
+# The role supports specifying the 'sapsys' group id in variable `sap_hana_install_groupid`.
+# The installation will fail if there is already a group named sapsys but with a different ID.
+# NOTE: This is executed even if the above checks detect an existing installation, because we want to identify conflicts.
+
+# This is also used for validation before using 'sidadm' sapcontrol.
+- name: SAP HANA - Pre-Tasks - Detect - Get details of the 'sapsys' group
+  ansible.builtin.getent:
+    database: group
+    key: sapsys
+  # Hide output if group does not exist.
   failed_when: false
 
-
-# Check 1: Use found saphostctrl to get list of SAP instances.
-# Only valid combination of SID and Instance Number will pass.
-- name: SAP HANA - Pre-Tasks - Check if SAP instances are installed with saphostctrl
-  when: __sap_hana_install_register_stat_saphostctrl.stat.exists
-  block:
-
-    - name: SAP HANA - Pre-Tasks - Get list of installed SAP instances
-      ansible.builtin.shell:
-        cmd: set -o pipefail && /usr/sap/hostctrl/exe/saphostctrl -function ListInstances | cut -d":" -f2-
-      register: __sap_hana_install_register_instancelist
-      changed_when: false
-
-    - name: SAP HANA - Pre-Tasks - Display instances
-      ansible.builtin.debug:
-        msg: "{{ __sap_hana_install_register_instancelist.stdout_lines }}"
-        verbosity: 1
-      when: __sap_hana_install_register_instancelist.stdout_lines is defined
-
-    - name: SAP HANA - Pre-Tasks - Desired SAP HANA is installed and running
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_is_installed: true
-      when:
-        - __sap_hana_install_loop_instance.split('-')[0] | trim == sap_hana_install_sid
-        - __sap_hana_install_loop_instance.split('-')[1] | trim == sap_hana_install_number
-      loop: "{{ __sap_hana_install_register_instancelist.stdout_lines }}"
-      loop_control:
-        loop_var: __sap_hana_install_loop_instance
-        label: "{{ __sap_hana_install_loop_instance.split('-')[0] | trim }}"
-
-    - name: SAP HANA - Pre-Tasks - Fail if existing SAP HANA was detected with same instance number but different SID
-      ansible.builtin.fail:
-        msg: >-
-          The instance number {{ sap_hana_install_number }} is already used by
-          SAP HANA system {{ __sap_hana_install_loop_instance.split('-')[0] | trim }}!
-      when:
-        - __sap_hana_install_loop_instance.split('-')[0] | trim != sap_hana_install_sid
-        - __sap_hana_install_loop_instance.split('-')[1] | trim == sap_hana_install_number
-      loop: "{{ __sap_hana_install_register_instancelist.stdout_lines }}"
-      loop_control:
-        loop_var: __sap_hana_install_loop_instance
-        label: "{{ __sap_hana_install_loop_instance.split('-')[0] | trim }}"
-
-    - name: SAP HANA - Pre-Tasks - Fail if existing SAP HANA was detected with same SID but different instance number
-      ansible.builtin.fail:
-        msg: >-
-          The SAP HANA system {{ sap_hana_install_sid }} already exists with different instance number
-            {{ __sap_hana_install_loop_instance.split('-')[1] | trim }}!
-      when:
-        - __sap_hana_install_loop_instance.split('-')[0] | trim  == sap_hana_install_sid
-        - __sap_hana_install_loop_instance.split('-')[1] | trim != sap_hana_install_number
-      loop: "{{ __sap_hana_install_register_instancelist.stdout_lines }}"
-      loop_control:
-        loop_var: __sap_hana_install_loop_instance
-        label: "{{ __sap_hana_install_loop_instance.split('-')[0] | trim }}"
-
-
-# Check 2: Check presence of directories if saphostctrl was not found.
-# hdblcm installs 'saphostctrl' by default unless executed with 'install_hostagent=n'.
-# These checks do not set '__sap_hana_install_fact_is_installed' as they pass only if directories are empty.
-- name: SAP HANA - Pre-Tasks - Check directories if no saphostctrl is found
-  when: not __sap_hana_install_register_stat_saphostctrl.stat.exists
-  block:
-
-    - name: SAP HANA - Pre-Tasks - Get status of '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}'
-      ansible.builtin.stat:
-        path: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}"
-      check_mode: false
-      register: __sap_hana_install_register_stat_hana_shared_sid_assert
-      failed_when: false
-
-    - name: SAP HANA - Pre-Tasks - Get contents of '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}'
-      ansible.builtin.find:
-        paths: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}"
-        patterns: '*'
-        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
-      register: __sap_hana_install_register_files_in_hana_shared_sid_assert
-      when: __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
-
-    - name: SAP HANA - Pre-Tasks - Fail if the directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty
-      ansible.builtin.fail:
-        msg: |
-          FAIL: The directory '{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}' exists and is not empty!
-          Cleanup existing files in directory to install new system
-          or execute this role with 'sap_hana_install_new_system: false' to add new hosts to existing installation.
-      when:
-        - __sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
-        - __sap_hana_install_register_files_in_hana_shared_sid_assert.matched | int != 0
-        # Fail for new Install, but proceed for Addhosts
-        - sap_hana_install_new_system
-
-    - name: SAP HANA - Pre-Tasks - Get status of '/usr/sap/{{ sap_hana_install_sid }}'
-      ansible.builtin.stat:
-        path: "/usr/sap/{{ sap_hana_install_sid }}"
-      check_mode: false
-      register: __sap_hana_install_register_stat_usr_sap_sid_assert
-      failed_when: false
-
-    - name: SAP HANA - Pre-Tasks - Get contents of '/usr/sap/{{ sap_hana_install_sid }}'
-      ansible.builtin.find:
-        paths: "/usr/sap/{{ sap_hana_install_sid }}"
-        patterns: '*'
-        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
-      register: __sap_hana_install_register_files_in_usr_sap_sid_assert
-      when: __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
-
-    - name: SAP HANA - Pre-Tasks - Fail if the directory '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty
-      ansible.builtin.fail:
-        msg: |
-          FAIL: The directory '/usr/sap/{{ sap_hana_install_sid }}' exists and is not empty!
-          Cleanup existing files in directory to install new system
-          or execute this role with 'sap_hana_install_new_system: false' to add new hosts to existing installation.
-      when:
-        - __sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
-        - __sap_hana_install_register_files_in_usr_sap_sid_assert.matched | int != 0
-        # Fail for new Install, but proceed for Addhosts
-        - sap_hana_install_new_system
-
-    # SAP HANA was detected without SAP Host Agent and we will validate if it can be started in next task.
-    - name: SAP HANA - Pre-Tasks - Desired SAP HANA is installed without SAP Host Agent
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_is_installed: true
-      when:
-        - not sap_hana_install_new_system
-        - (__sap_hana_install_register_stat_hana_shared_sid_assert.stat.exists
-            and __sap_hana_install_register_files_in_hana_shared_sid_assert.matched | int != 0)
-          or (__sap_hana_install_register_stat_usr_sap_sid_assert.stat.exists
-            and __sap_hana_install_register_files_in_usr_sap_sid_assert.matched | int != 0 )
-
-
-# Check 3: Check if the group 'sapsys' exists with correct ID.
-# The role supports specifying the SAP HANA group id in variable `sap_hana_install_groupid`, which is the id of the sapsys group.
-# The SAP HANA installation will fail if there is already a group named sapsys but with a different ID. Let's better fail before.
-- name: SAP HANA - Pre-Tasks - Check SAP HANA admin group
+# getent_group will be populated, with fields:
+# [0] - 'X' if the password is set.
+# [1] - Group ID.
+# [2] - Group members.
+- name: SAP HANA - Pre-Tasks - Detect - Fail if conflict exists for group ID 'sapsys'
+  ansible.builtin.fail:
+    msg: |
+      FAIL: Group 'sapsys' exists but with a different group ID.
+      Expected: '{{ sap_hana_install_groupid }}'
+      Found: '{{ ansible_facts["getent_group"]['sapsys'][1] }}'
   when:
     - sap_hana_install_groupid is defined
     - sap_hana_install_groupid is string
     - sap_hana_install_groupid | trim | length > 0
-    - not __sap_hana_install_fact_is_installed
-  block:
-
-    # getent_groups will be populated, with fields:
-    # [0] - 'X' if the password is set.
-    # [1] - Group ID.
-    # [2] - Group members.
-    - name: SAP HANA - Pre-Tasks - Get details of the 'sapsys' group
-      ansible.builtin.getent:
-        database: group
-        key: sapsys
-      failed_when: false
-
-    - name: SAP HANA - Pre-Tasks - In case there is a group 'sapsys', assert that its group ID is identical to 'sap_hana_install_groupid'
-      ansible.builtin.assert:
-        that:
-          - getent_group['sapsys'][1] | int == sap_hana_install_groupid | int
-        success_msg: "PASS: The group ID of 'sapsys' is identical to the value of variable
-                      sap_hana_install_groupid, which is '{{ sap_hana_install_groupid }}'"
-        fail_msg: >-
-          FAIL: Group 'sapsys' exists but with a different group ID than '{{ sap_hana_install_groupid }}'
-            defined in the variable 'sap_hana_install_groupid'!
-      when:
-        - getent_group is defined
-        - "'sapsys' in getent_group"
+    # Actual comparison of Group ID
+    - ansible_facts["getent_group"]['sapsys'][1] is defined
+    - ansible_facts["getent_group"]['sapsys'][1] | int != sap_hana_install_groupid | int
 
 
-# Check 4: Check if the user 'sidadm' exists.
-- name: SAP HANA - Pre-Tasks - SAP HANA admin user check
+# Check 2: Check if the user 'sidadm' exists with correct ID.
+# The role supports specifying the 'sidadm' id in variable `sap_hana_install_userid`.
+# The installation will fail if there is already a user named sidadm but with a different ID.
+# NOTE: This is executed even if the above checks detect an existing installation, because we want to identify conflicts.
+
+# This is also used for validation before using 'sidadm' sapcontrol.
+- name: SAP HANA - Pre-Tasks - Detect - Get details about user '{{ __sap_hana_install_sidadm_user }}'
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ __sap_hana_install_sidadm_user }}"
+  # Hide output if user does not exist.
+  failed_when: false
+
+# getent_passwd will be populated, with fields:
+# [0] - 'X' if the password is set.
+# [1] - User ID.
+# [2] - Group ID.
+- name: SAP HANA - Pre-Tasks - Detect - Fail if conflict exists for user ID '{{ __sap_hana_install_sidadm_user }}'
+  ansible.builtin.fail:
+    msg: |
+      FAIL: User '{{ __sap_hana_install_sidadm_user }}' exists but with a different user ID.
+      Expected: '{{ sap_hana_install_userid }}'
+      Found: '{{ ansible_facts["getent_passwd"][__sap_hana_install_sidadm_user][1] }}'
   when:
-    - sap_hana_install_check_sidadm_user | d(true)
-    - not __sap_hana_install_fact_is_installed
-  vars:
-    __sap_hana_install_sidadm: "{{ sap_hana_install_sid | lower }}adm"
+    - sap_hana_install_userid is defined
+    - sap_hana_install_userid is string
+    - sap_hana_install_userid | trim | length > 0
+    # Actual comparison of User ID
+    - ansible_facts["getent_passwd"][__sap_hana_install_sidadm_user][1] is defined
+    - ansible_facts["getent_passwd"][__sap_hana_install_sidadm_user][1] | int != sap_hana_install_userid | int
+
+
+# Check 3: Use 'saphostctrl' and search for SID and instance number in 'ListInstances' output.
+- name: SAP HANA - Pre-Tasks - Detect - Stat /usr/sap/hostctrl/exe/saphostctrl file
+  ansible.builtin.stat:
+    path: /usr/sap/hostctrl/exe/saphostctrl
+  check_mode: false
+  register: __sap_hana_install_register_saphostctrl_stat
+
+- name: Block for saphostctrl checks
+  when:
+    - __sap_hana_install_register_saphostctrl_stat.stat.exists
+    - __sap_hana_install_register_saphostctrl_stat.stat.executable
   block:
 
-    - name: SAP HANA - Pre-Tasks - Get info about user '{{ __sap_hana_install_sidadm }}'
-      ansible.builtin.getent:
-        database: passwd
-        key: "{{ __sap_hana_install_sidadm }}"
+    # Output example:
+    # Inst Info : H01 - 90 - h01hana - 754, patch 622, changelist 2286174
+    - name: SAP HANA - Pre-Tasks - Detect - Execute saphostctrl function ListInstances
+      ansible.builtin.command:
+        cmd: /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
+      register: __sap_hana_install_register_saphostctrl_list_instances
+      changed_when: false
+      # Hides failed output, but 'rc' can be still used for verification.
       failed_when: false
 
-    - name: SAP HANA - Pre-Tasks - Fail if the user '{{ __sap_hana_install_sidadm }}' exists
-      ansible.builtin.fail:
+    # saphostctrl can return non-zero exit code when sapstartsrv process is not running.
+    - name: Block if saphostctrl ListInstances command executed successfully
+      when: __sap_hana_install_register_saphostctrl_list_instances.rc == 0
+      block:
+
+        - name: SAP HANA - Pre-Tasks - Detect - Set fact if desired SAP HANA was detected with saphostctrl command
+          ansible.builtin.set_fact:
+            __sap_hana_install_fact_detect_saphostctrl: true
+          when:
+            - (' ' ~ __sap_hana_install_sid ~ ' - ' ~ sap_hana_install_number ~ ' ')
+                in __sap_hana_install_register_saphostctrl_list_instances.stdout
+
+        - name: SAP HANA - Pre-Tasks - Detect - Fail if instance number conflict was found (Same NR, Different SID)
+          ansible.builtin.fail:
+            msg: |
+              FAIL: Conflict detected for SID and instance number!
+              The instance number {{ sap_hana_install_number }} is already used by
+              system {{ (__sap_hana_install_loop_instance.split(':')[-1].split('-')[0]) | trim }}!
+          when:
+            - (__sap_hana_install_loop_instance.split(':')[-1].split('-')[0]) | trim != __sap_hana_install_sid
+            - (__sap_hana_install_loop_instance.split(':')[-1].split('-')[1]) | trim == sap_hana_install_number
+          loop: "{{ __sap_hana_install_register_saphostctrl_list_instances.stdout_lines }}"
+          loop_control:
+            loop_var: __sap_hana_install_loop_instance
+            label: "{{ __sap_hana_install_loop_instance.split(':')[-1].split('-')[0] | trim }}"
+
+        - name: SAP HANA - Pre-Tasks - Detect - Fail if SID conflict was found (Same SID, Different NR)
+          ansible.builtin.fail:
+            msg: |
+              FAIL: Conflict detected for SID and instance number!
+              The SID {{ __sap_hana_install_sid }} is already registered with
+              instance number {{ (__sap_hana_install_loop_instance.split(':')[-1].split('-')[1]) | trim }}!
+          when:
+            - (__sap_hana_install_loop_instance.split(':')[-1].split('-')[0]) | trim == __sap_hana_install_sid
+            - (__sap_hana_install_loop_instance.split(':')[-1].split('-')[1]) | trim != sap_hana_install_number
+          loop: "{{ __sap_hana_install_register_saphostctrl_list_instances.stdout_lines }}"
+          loop_control:
+            loop_var: __sap_hana_install_loop_instance
+            label: "{{ __sap_hana_install_loop_instance.split(':')[-1].split('-')[0] | trim }}"
+
+- name: SAP HANA - Pre-Tasks - Detect - Show reason why saphostctrl check was skipped
+  ansible.builtin.debug:
+    msg: |
+      INFO: Detection of existing SAP HANA installation with 'saphostctrl' command was skipped.
+      {% if not __sap_hana_install_register_saphostctrl_stat.stat.exists %}
+      The executable '/usr/sap/hostctrl/exe/saphostctrl' is not available.
+      {% elif not __sap_hana_install_register_saphostctrl_stat.stat.executable %}
+      The executable '/usr/sap/hostctrl/exe/saphostctrl' is not executable.
+      {% endif %}
+      {% if __sap_hana_install_register_saphostctrl_list_instances.rc is defined
+        and __sap_hana_install_register_saphostctrl_list_instances.rc != 0 %}
+      Return code: {{ __sap_hana_install_register_saphostctrl_list_instances.rc | d('1') }}
+      Output:      {{ __sap_hana_install_register_saphostctrl_list_instances.stdout | d('') }}
+      Error:       {{ __sap_hana_install_register_saphostctrl_list_instances.stderr | d('') }}
+      {% endif %}
+  when:
+    - not __sap_hana_install_register_saphostctrl_stat.stat.exists
+      or not __sap_hana_install_register_saphostctrl_stat.stat.executable
+      or (__sap_hana_install_register_saphostctrl_list_instances.rc is defined
+        and __sap_hana_install_register_saphostctrl_list_instances.rc != 0)
+
+- name: SAP HANA - Pre-Tasks - Detect - Show saphostctrl command output in verbose mode
+  ansible.builtin.debug:
+    var: __sap_hana_install_register_saphostctrl_list_instances
+  when: ansible_verbosity >= 2
+
+
+# Check 4: Use 'sapcontrol' and search for SID and instance number in 'GetInstanceProperties' output.
+# The `sapcontrol` command from SAP kernel files can be used to obtain instance information.
+- name: Block for sapcontrol checks
+  when:
+    - ansible_facts["getent_group"]['sapsys'][1] is defined
+    - ansible_facts["getent_passwd"][__sap_hana_install_sidadm_user][1] is defined
+    - not __sap_hana_install_fact_detect_saphostctrl | d(false)
+  block:
+
+    # Reason for noqa: Switch to user requires shell module to load environment variables.
+    - name: SAP HANA - Pre-Tasks - Detect - Check if 'sapcontrol' command is available  # noqa: command-instead-of-shell
+      ansible.builtin.shell:
+        cmd: "bash -lc 'which sapcontrol'"
+      become: true
+      become_user: "{{ __sap_hana_install_sidadm_user }}"
+      register: __sap_hana_install_register_which_sapcontrol
+      changed_when: false
+      ignore_errors: true
+
+    - name: SAP HANA - Pre-Tasks - Detect - Show reason why sapcontrol check was skipped - unavailable
+      ansible.builtin.debug:
         msg: |
-          FAIL: The user '{{ __sap_hana_install_sidadm }}' already exists!
-          Cleanup existing '{{ __sap_hana_install_sidadm }}' user to install new system
-          or execute this role with 'sap_hana_install_new_system: false' to add new hosts to existing installation.
+          INFO: Detection of existing SAP HANA installation with 'sapcontrol' command was skipped.
+          Command 'sapcontrol' is not available for user '{{ __sap_hana_install_sidadm_user }}'.
+      when: __sap_hana_install_register_which_sapcontrol.rc != 0
+
+    - name: Block if sapcontrol is available
+      when: __sap_hana_install_register_which_sapcontrol.rc == 0
+      block:
+
+        # Reason for noqa: Switch to user requires shell module to load environment variables.
+        - name: SAP HANA - Pre-Tasks - Detect - Execute sapcontrol function GetInstanceProperties  # noqa: command-instead-of-shell
+          ansible.builtin.shell:
+            cmd: "bash -lc 'sapcontrol -nr {{ sap_hana_install_number }} -function GetInstanceProperties'"
+          become: true
+          become_user: "{{ __sap_hana_install_sidadm_user }}"
+          register: __sap_hana_install_register_sapcontrol_instance_properties
+          changed_when: false
+          # Hides failed output, but 'rc' can be still used for verification.
+          failed_when: false
+
+        - name: SAP HANA - Pre-Tasks - Detect - Show reason why sapcontrol check was skipped - command failed
+          ansible.builtin.debug:
+            msg: |
+              INFO: Detection of existing SAP HANA installation with 'sapcontrol' command was skipped.
+              Return code: {{ __sap_hana_install_register_sapcontrol_instance_properties.rc | d('1') }}
+              Output:      {{ __sap_hana_install_register_sapcontrol_instance_properties.stdout | d('') }}
+              Error:       {{ __sap_hana_install_register_sapcontrol_instance_properties.stderr | d('') }}
+          when:
+            - __sap_hana_install_register_sapcontrol_instance_properties.rc is defined
+            - __sap_hana_install_register_sapcontrol_instance_properties.rc != 0
+
+        - name: SAP HANA - Pre-Tasks - Detect - Set fact if desired SAP HANA was detected with sapcontrol command
+          ansible.builtin.set_fact:
+            __sap_hana_install_fact_detect_sapcontrol: true
+          vars:
+            # We create a list of lines that match either the SID or the Instance Number.
+            # This list must be 2 items, that way we know instance exists correctly.
+            # Syntax: SAPSYSTEMNAME, Attribute, H01
+            # Syntax: INSTANCE_NAME, Attribute, HDB90
+            __lines_found: >-
+              {{ __sap_hana_install_register_sapcontrol_instance_properties.stdout_lines
+                  | select('search', 'SAPSYSTEMNAME.*' ~ __sap_hana_install_sid) | list
+                + __sap_hana_install_register_sapcontrol_instance_properties.stdout_lines
+                  | select('search', 'INSTANCE_NAME.*HDB' ~ sap_hana_install_number) | list }}
+          when:
+            - __sap_hana_install_register_sapcontrol_instance_properties.rc is defined
+            - __sap_hana_install_register_sapcontrol_instance_properties.rc == 0
+            - __lines_found | length == 2
+
+        - name: SAP HANA - Pre-Tasks - Detect - Show sapcontrol command output in verbose mode
+          ansible.builtin.debug:
+            var: __sap_hana_install_register_sapcontrol_instance_properties
+          when: ansible_verbosity >= 2
+
+
+# Check 5: Check presence of directories if Scenario 1 and 4 were not reached.
+- name: Block for directory checks
+  when:
+    - not __sap_hana_install_fact_detect_saphostctrl | d(false)
+    - not __sap_hana_install_fact_detect_sapcontrol | d(false)
+  block:
+
+    # /hana/shared/<SID> directory
+    - name: SAP HANA - Pre-Tasks - Get status of the path '{{ __sap_hana_install_shared_path }}'
+      ansible.builtin.stat:
+        path: "{{ __sap_hana_install_shared_path }}"
+      register: __sap_hana_install_register_stat_hana_shared_sid
+
+    - name: SAP HANA - Pre-Tasks - Get contents of the path '{{ __sap_hana_install_shared_path }}'
+      ansible.builtin.find:
+        paths: "{{ __sap_hana_install_shared_path }}"
+        patterns: '*'
+        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
+      register: __sap_hana_install_register_files_in_hana_shared_sid
+      when: __sap_hana_install_register_stat_hana_shared_sid.stat.exists
+
+    # /usr/sap/<SID> directory
+    - name: SAP HANA - Pre-Tasks - Get status of the path '/usr/sap/{{ __sap_hana_install_sid }}'
+      ansible.builtin.stat:
+        path: "/usr/sap/{{ __sap_hana_install_sid }}"
+      register: __sap_hana_install_register_stat_usr_sap_sid
+
+    - name: SAP HANA - Pre-Tasks - Get contents of '/usr/sap/{{ __sap_hana_install_sid }}'
+      ansible.builtin.find:
+        paths: "/usr/sap/{{ __sap_hana_install_sid }}"
+        patterns: '*'
+        file_type: 'any'  # New install does not have files and default 'file' will ignore directories.
+      register: __sap_hana_install_register_files_in_usr_sap_sid
+      when: __sap_hana_install_register_stat_usr_sap_sid.stat.exists
+
+
+    - name: SAP HANA - Pre-Tasks - Set fact if SAP files were found
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_detect_files: true
       when:
-        - getent_passwd is defined
-        - __sap_hana_install_sidadm in getent_passwd
-        # Fail for new Install, but proceed for Addhosts
-        - sap_hana_install_new_system
+        - (__sap_hana_install_register_stat_hana_shared_sid.stat.exists
+            and __sap_hana_install_register_files_in_hana_shared_sid.matched | int != 0)
+          or (__sap_hana_install_register_stat_usr_sap_sid.stat.exists
+            and __sap_hana_install_register_files_in_usr_sap_sid.matched | int != 0 )
+
+
+### Decision section based on collected facts.
+
+# 3. FAIL - 'root' saphostctrl check does not find the desired SID and instance number, and any other indicators are found
+# 6. FAIL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and any other indicators are found
+- name: SAP HANA - Pre-Tasks - Detect - Fail if potential installation was detected
+  ansible.builtin.fail:
+    msg: |
+      FAIL: Potential existing SAP HANA installation detected based on the presence of identifiable indicators.
+      - Existence of files in '/usr/sap/{{ __sap_hana_install_sid }}/' directory.
+      - Existence of files in '{{ __sap_hana_install_shared_path }}/' directory.
+      These checks trigger failure only when 'saphostctrl' and 'sapcontrol' fail to detect the instance.
+
+      Please verify the details above and ensure that you are not trying to install over an existing installation.
+      If you want to proceed with the installation regardless, please set 'sap_hana_install_force' variable to true.
+  when:
+    - not sap_hana_install_force | d(false)
+    - not __sap_hana_install_fact_detect_saphostctrl | d(false)
+    - not __sap_hana_install_fact_detect_sapcontrol | d(false)
+    - __sap_hana_install_fact_detect_files | d(false)
+
+
+# 1. SKIP - 'root' saphostctrl check finds the desired SID and instance number.
+# 4. SKIP - 'sidadm' sapcontrol check finds the desired SID and instance number.
+- name: Block for SKIP
+  when:
+    - __sap_hana_install_fact_detect_saphostctrl | d(false)
+      or __sap_hana_install_fact_detect_sapcontrol | d(false)
+  block:
+    - name: SAP HANA - Pre-Tasks - Detect - Set fact if installation was detected
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_is_installed: true
+
+    - name: SAP HANA - Pre-Tasks - Detect - Inform that installation was detected
+      ansible.builtin.debug:
+        msg: |
+          {% if sap_hana_install_new_system %}
+          WARN: Existing SAP HANA installation was detected using 'saphostctrl' or 'sapcontrol' command checks.
+          Installation steps will be skipped!
+
+          If you intend to proceed with the installation despite this warning,
+          set 'sap_hana_install_force' variable to 'true' and execute this Ansible Role again.
+          {% else %}
+          INFO: Existing SAP HANA installation was detected using 'saphostctrl' or 'sapcontrol' command checks.
+          Installation steps for Addhosts will be executed.
+          {% endif %}
+
+
+# 2. INSTALL - 'root' saphostctrl check does not find the desired SID and instance number, and no other indicators are found.
+# 5. INSTALL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and no other indicators are found.
+- name: SAP HANA Pre-Tasks - Detect - Inform that no existing installation was detected
+  ansible.builtin.debug:
+    msg: |
+      INFO: No existing SAP HANA installation detected for SID {{ __sap_hana_install_sid }}.
+      Installation will proceed.
+
+      Detection methods used:
+      - saphostctrl command (ListInstances)
+      - sapcontrol command (GetInstanceProperties)
+      - Instance directory ({{ __sap_hana_install_shared_path }})
+      - Instance directory (/usr/sap/{{ __sap_hana_install_sid }}/)
+  when:
+    - not __sap_hana_install_fact_detect_saphostctrl | d(false)
+    - not __sap_hana_install_fact_detect_sapcontrol | d(false)
+    - not __sap_hana_install_fact_detect_files | d(false)
 
 
 - name: Block to prepare status message
@@ -208,7 +380,7 @@
   block:
     - name: SAP HANA - Pre-Tasks - Run 'hdblcm --list_systems' for existing database
       ansible.builtin.shell: |
-          set -o pipefail && ./hdblcm --list_systems | awk '/\/hana\/shared\/{{ sap_hana_install_sid }}/{a=1}
+          set -o pipefail && ./hdblcm --list_systems | awk '/\/hana\/shared\/{{ __sap_hana_install_sid }}/{a=1}
           /version:/{if (a==1){
             gsub ("^\\s*version: ", "");printf ("%s;", $NF)}
           }
@@ -216,7 +388,7 @@
             gsub ("^\\s*hosts?: ", ""); gsub (", ", ","); print; a=0}
           }'
       args:
-        chdir: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/hdblcm"
+        chdir: "{{ __sap_hana_install_shared_path }}/hdblcm"
       register: __sap_hana_install_register_existing_systems
       changed_when: false
 
@@ -238,5 +410,5 @@
               SAP HANA database is installed and running:
               HANA Version     -       {{ __sap_hana_install_fact_existing_hana_version }}
               Hosts            -       {{ __sap_hana_install_fact_existing_hana_hosts }}
-              SID              -       {{ sap_hana_install_sid }}
+              SID              -       {{ __sap_hana_install_sid }}
               NR               -       {{ sap_hana_install_number }}

--- a/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
@@ -166,7 +166,7 @@
     # Check for existing addhosts profiles and folders before removing them from list.
     - name: SAP HANA - Addhosts - Pre-Tasks - Find existing instance profiles for all hosts
       ansible.builtin.find:
-        paths: "{{ sap_hana_install_shared_path }}/{{ sap_hana_install_sid }}/profile/"
+        paths: "{{ __sap_hana_install_shared_path }}/profile/"
         patterns: "{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_*"
         file_type: file
       register: __sap_hana_install_register_existing_profiles

--- a/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
@@ -17,7 +17,8 @@
       ansible.builtin.set_fact:
         __sap_hana_install_fact_addhosts_hosts:
           "{{ sap_hana_install_addhosts.split(',') | map('trim') | reject('equalto', '')
-            | map('regex_replace', ':.*$', '') | list | difference([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]) }}"
+            | map('regex_replace', ':.*$', '') | list
+            | difference([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]) }}"
 
     - name: SAP HANA - Addhosts - Pre-Tasks - Assert that the variable 'sap_hana_install_addhosts' is valid addhosts string
       ansible.builtin.assert:
@@ -81,6 +82,7 @@
   ansible.builtin.set_fact:
     __sap_hana_install_fact_is_scaleout: true
 
+    # Replace default ansible hostname with Scale-Out master hostname.
     __sap_hana_install_fact_main_host: >-
       {%- if sap_hana_install_scaleout_master is defined
           and sap_hana_install_scaleout_master is string
@@ -124,123 +126,14 @@
         __present_hosts: "{{ hostvars | dict2items | selectattr('value.__sap_hana_install_fact_is_present', 'defined') | map(attribute='key') }}"
         __missing_hosts: "{{ ansible_play_hosts_all | difference(__present_hosts) }}"
 
-# Fail if existing HANA was found on worker without master host.
-- name: SAP HANA - Addhosts - Pre-Tasks - Fail if non-main host has HANA installed without master
-  when:
-    - __sap_hana_install_fact_is_scaleout
-    - not __sap_hana_install_fact_is_main_host
-    - __sap_hana_install_fact_is_installed
-    - __sap_hana_install_fact_existing_hana_hosts is defined
-  ansible.builtin.assert:
-    that:
-      - __sap_hana_install_fact_main_host in __sap_hana_install_fact_existing_hana_hosts
-    fail_msg: |
-      FAIL: A conflicting SAP HANA installation was found on worker host '{{ inventory_hostname }}'.
-      This host is being added to a scale-out system managed by '{{ __sap_hana_install_fact_main_host }}',
-      but it already runs a HANA system whose members are: '{{ __sap_hana_install_fact_existing_hana_hosts }}'.
-      To prevent data corruption or an inconsistent state, the 'addhosts' operation is blocked.
 
-      Please choose one of the following actions:
-        - Decommission the conflicting HANA system on '{{ inventory_hostname }}'.
-        - Remove this host from the Ansible inventory for this play.
-        - Remove this host from the 'sap_hana_install_addhosts' variable.
-
-
-# Set a fact on each host to confirm it participated in the pre-tasks.
+# Set a fact on each addhost to confirm it participated in the pre-tasks.
 # This allows a central check to detect if the playbook was improperly limited to a subset of hosts.
+# Main host is skipped and default value of 'true' is used.
 - name: SAP HANA - Pre-Tasks - Set fact with boolean flags for each host
   ansible.builtin.set_fact:
-    __sap_hana_install_fact_is_main_host:
-      "{{ __sap_hana_install_fact_main_host
-        in [ansible_facts['hostname'], inventory_hostname, inventory_hostname_short] }}"
-
-    __sap_hana_install_fact_is_addhost_host:
-      "{{ ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
-        | intersect(__sap_hana_install_fact_addhosts_hosts | d([]))) | length > 0 }}"
-
-
-- name: Block for validating existing hosts on main
-  when: __sap_hana_install_fact_is_main_host
-  block:
-
-    # Check for existing addhosts profiles and folders before removing them from list.
-    - name: SAP HANA - Addhosts - Pre-Tasks - Find existing instance profiles for all hosts
-      ansible.builtin.find:
-        paths: "{{ __sap_hana_install_shared_path }}/profile/"
-        patterns: "{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_*"
-        file_type: file
-      register: __sap_hana_install_register_existing_profiles
-
-    - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with list of existing hosts with instance profiles
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_existing_hosts_profile:
-          "{{ __sap_hana_install_register_existing_profiles.files | map(attribute='path') | map('basename')
-            | map('regex_replace', '^' + sap_hana_install_sid + '_HDB' + sap_hana_install_number + '_', '') | list }}"
-
-    - name: SAP HANA - Addhosts - Pre-Tasks - Find existing instance directories for all hosts
-      ansible.builtin.find:
-        paths: "/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/"
-        patterns: "*"
-        file_type: directory
-      register: __sap_hana_install_register_existing_dirs
-
-    - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with list of existing hosts with instance directories
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_existing_hosts_dirs:
-          "{{ __sap_hana_install_register_existing_dirs.files | map(attribute='path') | map('basename') | list }}"
-
-    - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with list of new hosts without existing profiles or directories
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_addhosts_hosts_new: >-
-          {{
-            __sap_hana_install_fact_addhosts_hosts |
-            difference(
-              __sap_hana_install_fact_existing_hosts_profile | union(__sap_hana_install_fact_existing_hosts_dirs)
-            )
-          }}
-
-    # We need to reset hosts list and remove new, if HANA is installed and 'sap_hana_install_new_system' is 'true'.
-    # This ensures that post-tasks are idempotent for those hosts that already exist, not new.
-    - name: SAP HANA - Addhosts - Pre-Tasks - Reset fact with list of new hosts if Add
-      ansible.builtin.set_fact:
-        __sap_hana_install_fact_addhosts_hosts:
-          "{{ __sap_hana_install_fact_addhosts_hosts | difference(__sap_hana_install_fact_addhosts_hosts_new) }}"
-      when:
-        - sap_hana_install_new_system
-        - __sap_hana_install_fact_is_installed
-        - __sap_hana_install_fact_addhosts_hosts_new | length > 0
-
-    - name: SAP HANA - Addhosts - Pre-Tasks - Show lists of hosts to be added
-      ansible.builtin.debug:
-        msg: "New hosts will be added: {{ __sap_hana_install_fact_addhosts_hosts_new | join(', ') }}"
-      when:
-        - __sap_hana_install_fact_addhosts_hosts_new | length > 0
-        - not (sap_hana_install_new_system and __sap_hana_install_fact_is_installed)
-
-
-- name: SAP HANA - Addhosts - Pre-Tasks - Set addhosts facts on remaining hosts
-  ansible.builtin.set_fact:
-    __sap_hana_install_fact_addhosts_hosts_new:
-      "{{ hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_addhosts_hosts_new'] }}"
-    __sap_hana_install_fact_addhosts_hosts:
-      "{{ hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_addhosts_hosts'] }}"
+    __sap_hana_install_fact_is_main_host: false
+    __sap_hana_install_fact_is_addhost_host: true
   when:
-    - __sap_hana_install_fact_is_scaleout
-    - not __sap_hana_install_fact_is_main_host
-
-- name: SAP HANA - Addhosts - Pre-Tasks - Set fact with boolean flag for new hosts
-  ansible.builtin.set_fact:
-    __sap_hana_install_fact_is_new_addhost_host:
-      "{{ ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
-        | intersect(__sap_hana_install_fact_addhosts_hosts_new | d([]))) | length > 0 }}"
-
-
-- name: SAP HANA - Addhosts - Pre-Tasks - Fail if SAP HANA is not found when addhosts is used
-  ansible.builtin.fail:
-    msg: |
-      FAIL: The existing SAP HANA System was not detected when adding new hosts!
-      This is required when the variable 'sap_hana_install_new_system' is set to false.
-  when:
-    - not sap_hana_install_new_system
-    - not __sap_hana_install_fact_is_installed
-    - __sap_hana_install_fact_is_main_host
+    - ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
+        | intersect(__sap_hana_install_fact_addhosts_hosts | d([]))) | length > 0

--- a/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/identify_hosts.yml
@@ -46,13 +46,13 @@
           PASS: The variable 'sap_hana_install_addhosts' and inventory are aligned.
         fail_msg: |
           FAIL: The variable 'sap_hana_install_addhosts' and inventory are not aligned.
-          The variable 'sap_hana_install_addhosts' should not contain Master host {{ ansible_facts['hostname'] }} and validation is done without it.
 
           Inventory hosts: {{ ansible_play_hosts_all | join(', ') }}
           Addhosts hosts: {{ __sap_hana_install_fact_addhosts_hosts | join(', ') }}
+          NOTE: Comparison was completed without the master host, because only additional hosts are expected in the 'sap_hana_install_addhosts' variable.
           {% if __inventory_diff_addhosts | length > 0 %}
 
-          Ensure that missing hosts are added to the 'sap_hana_install_addhosts' or removed from inventory.
+          Ensure that missing hosts are added to 'sap_hana_install_addhosts' or removed from inventory.
           Hosts missing in the 'sap_hana_install_addhosts': {{ __inventory_diff_addhosts | join(', ') }}
           {% endif %}
           {% if __addhosts_diff_inventory | length > 0 %}

--- a/roles/sap_hana_install/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/prepare_variables.yml
@@ -226,6 +226,15 @@
     - sap_hana_install_configure_firewall | d(false)
     - sap_hana_install_firewall_zone is defined
 
+- name: SAP HANA - Pre-Tasks - Assert that the variable 'sap_hana_install_skip_filesystem_check' is defined as a boolean
+  ansible.builtin.assert:
+    that:
+      - sap_hana_install_skip_filesystem_check is boolean
+    fail_msg: |
+      The variable 'sap_hana_install_skip_filesystem_check' is not a boolean.
+      It should be a boolean (true/false) indicating whether to skip the filesystem check during SAP HANA installation.
+  when: sap_hana_install_skip_filesystem_check is defined
+
 
 # SELinux is not currently supported by SAP using SLES4SAP
 # This can still be overwritten by extra variables.

--- a/roles/sap_hana_install/tasks/pre_tasks/validate_hosts.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/validate_hosts.yml
@@ -85,8 +85,10 @@
             )
           }}
 
-    - name: Block for new addhosts
-      when: __sap_hana_install_fact_addhosts_hosts_new | length > 0
+    - name: Block for new addhosts for existing installation
+      when:
+        - __sap_hana_install_fact_addhosts_hosts_new | length > 0
+        - __sap_hana_install_fact_is_installed
       block:
 
         # We cannot allow execution with 'sap_hana_install_new_system' set to 'true'
@@ -114,7 +116,8 @@
               Specified addhosts: {{ __sap_hana_install_fact_addhosts_hosts | d([]) | join(', ') }}
               Existing hosts: {{ __sap_hana_install_fact_existing_hana_hosts | d('N/A') }}
               New hosts: {{ __sap_hana_install_fact_addhosts_hosts_new | join(', ') }}
-          when: not sap_hana_install_new_system
+          when:
+            - not sap_hana_install_new_system
 
 
 - name: SAP HANA - Addhosts - Pre-Tasks - Set addhosts facts on remaining hosts

--- a/roles/sap_hana_install/tasks/pre_tasks/validate_hosts.yml
+++ b/roles/sap_hana_install/tasks/pre_tasks/validate_hosts.yml
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+# This task file was originally part of identify_hosts.yml,
+# but it was separated to allow usage of detection results to drive host validation logic.
+
+
+- name: SAP HANA - Addhosts - Pre-Tasks - Fail if SAP HANA installation is not found when addhosts is used
+  ansible.builtin.fail:
+    msg: |
+      FAIL: The existing SAP HANA System was not detected when adding new hosts!
+      This is required when the variable 'sap_hana_install_new_system' is set to 'false'.
+  when:
+    - not sap_hana_install_force
+    - not sap_hana_install_new_system
+    - not __sap_hana_install_fact_is_installed
+    - __sap_hana_install_fact_is_main_host
+
+
+# Fail if existing HANA was found on worker, but it is not part of hosts on main host.
+- name: SAP HANA - Addhosts - Pre-Tasks - Fail if additional host has HANA installed without master
+  ansible.builtin.fail:
+    msg: |
+      FAIL: A conflicting SAP HANA installation was found on worker host '{{ inventory_hostname }}'.
+      This host is being added to a Scale-Out system managed by '{{ __sap_hana_install_fact_main_host }}',
+      but it is not part of its hosts: {{ hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_existing_hana_hosts'] }}
+
+      This installation contains hosts: '{{ __sap_hana_install_fact_existing_hana_hosts | d('N/A') }}'.
+
+      To prevent data corruption or an inconsistent state, the 'addhosts' operation is blocked.
+
+      Please proceed with one of the following actions:
+        - Decommission the conflicting HANA system on '{{ inventory_hostname }}'.
+        - Remove this host from the Ansible inventory for this play.
+        - Remove this host from the 'sap_hana_install_addhosts' variable.
+  when:
+    - not sap_hana_install_force
+    - __sap_hana_install_fact_is_addhost_host
+    - __sap_hana_install_fact_is_installed
+    # Ensure that main host contains the fact for existing HANA hosts, which is only set if it is installed.
+    - hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_is_installed']
+    - hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_existing_hana_hosts'] is defined
+    # Compare list of existing hosts against the current host.
+    - not ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
+        | intersect(hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_existing_hana_hosts'] | d([]))) | length == 0
+
+
+- name: Block for validating existing hosts on main host
+  when: __sap_hana_install_fact_is_main_host
+  block:
+
+    # Check for existing addhosts profiles and folders before removing them from list.
+    - name: SAP HANA - Addhosts - Pre-Tasks - Find existing instance profiles for all hosts
+      ansible.builtin.find:
+        paths: "{{ __sap_hana_install_shared_path }}/profile/"
+        patterns: "{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_number }}_*"
+        file_type: file
+      register: __sap_hana_install_register_existing_profiles
+
+    - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with list of existing hosts with instance profiles
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_existing_hosts_profile:
+          "{{ __sap_hana_install_register_existing_profiles.files | map(attribute='path') | map('basename')
+            | map('regex_replace', '^' + sap_hana_install_sid + '_HDB' + sap_hana_install_number + '_', '') | list }}"
+
+    - name: SAP HANA - Addhosts - Pre-Tasks - Find existing instance directories for all hosts
+      ansible.builtin.find:
+        paths: "/usr/sap/{{ sap_hana_install_sid }}/HDB{{ sap_hana_install_number }}/"
+        patterns: "*"
+        file_type: directory
+      register: __sap_hana_install_register_existing_dirs
+
+    - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with list of existing hosts with instance directories
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_existing_hosts_dirs:
+          "{{ __sap_hana_install_register_existing_dirs.files | map(attribute='path') | map('basename') | list }}"
+
+    - name: SAP HANA - Addhosts - Pre-Tasks - Set fact with list of new hosts without existing profiles or directories
+      ansible.builtin.set_fact:
+        __sap_hana_install_fact_addhosts_hosts_new: >-
+          {{
+            __sap_hana_install_fact_addhosts_hosts |
+            difference(
+              __sap_hana_install_fact_existing_hosts_profile | union(__sap_hana_install_fact_existing_hosts_dirs)
+            )
+          }}
+
+    - name: Block for new addhosts
+      when: __sap_hana_install_fact_addhosts_hosts_new | length > 0
+      block:
+
+        # We cannot allow execution with 'sap_hana_install_new_system' set to 'true'
+        # if 'sap_hana_install_addhosts' contains new hosts to add.
+        - name: SAP HANA - Addhosts - Pre-Tasks - Fail if new addhost is detected with 'sap_hana_install_new_system' set to 'true'
+          ansible.builtin.fail:
+            msg: |
+              FAIL: New hosts cannot be added to an existing SAP HANA System
+              when the variable 'sap_hana_install_new_system' is set to 'true'.
+
+              This variable must be set to 'false' when adding new hosts to an existing system.
+
+              Specified addhosts: {{ __sap_hana_install_fact_addhosts_hosts | d([]) | join(', ') }}
+              Existing hosts: {{ __sap_hana_install_fact_existing_hana_hosts | d('N/A') }}
+              New hosts: {{ __sap_hana_install_fact_addhosts_hosts_new | join(', ') }}
+          when:
+            - not sap_hana_install_force
+            - sap_hana_install_new_system
+
+        - name: SAP HANA - Addhosts - Pre-Tasks - Show lists of hosts to be added
+          ansible.builtin.debug:
+            msg: |
+              INFO: New hosts will be added to existing SAP HANA System.
+
+              Specified addhosts: {{ __sap_hana_install_fact_addhosts_hosts | d([]) | join(', ') }}
+              Existing hosts: {{ __sap_hana_install_fact_existing_hana_hosts | d('N/A') }}
+              New hosts: {{ __sap_hana_install_fact_addhosts_hosts_new | join(', ') }}
+          when: not sap_hana_install_new_system
+
+
+- name: SAP HANA - Addhosts - Pre-Tasks - Set addhosts facts on remaining hosts
+  ansible.builtin.set_fact:
+    __sap_hana_install_fact_addhosts_hosts_new:
+      "{{ hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_addhosts_hosts_new'] }}"
+    __sap_hana_install_fact_addhosts_hosts:
+      "{{ hostvars[__sap_hana_install_fact_main_host]['__sap_hana_install_fact_addhosts_hosts'] }}"
+  when:
+    - __sap_hana_install_fact_is_scaleout
+    - not __sap_hana_install_fact_is_main_host
+
+- name: SAP HANA - Addhosts - Pre-Tasks - Set fact with boolean flag for new hosts
+  ansible.builtin.set_fact:
+    __sap_hana_install_fact_is_new_addhost_host:
+      "{{ ([ansible_facts['hostname'], inventory_hostname, inventory_hostname_short]
+        | intersect(__sap_hana_install_fact_addhosts_hosts_new | d([]))) | length > 0 }}"
+
+
+- name: SAP HANA - Pre-Tasks - Detect - Show host validation details in verbose mode
+  ansible.builtin.debug:
+    msg: |
+      Host identification flags:
+      - is main host: {{ __sap_hana_install_fact_is_main_host | d(false) }}
+      - is addhost host: {{ __sap_hana_install_fact_is_addhost_host | d(false) }}
+      - is scaleout: {{ __sap_hana_install_fact_is_scaleout | d(false) }}
+      - main host: {{ __sap_hana_install_fact_main_host | d('N/A') }}
+
+      Host validation results:
+      - new addhosts: {{ __sap_hana_install_fact_addhosts_hosts_new | d([]) | join(', ') }}
+      - existing addhosts: {{ __sap_hana_install_fact_addhosts_hosts | d([]) | join(', ') }}
+      - is new addhost: {{ __sap_hana_install_fact_is_new_addhost_host | d(false) }}
+  when: ansible_verbosity >= 2

--- a/roles/sap_hana_install/vars/main.yml
+++ b/roles/sap_hana_install/vars/main.yml
@@ -49,12 +49,7 @@ __sap_hana_install_fact_is_scaleout: false
 # Sets default value of HANA exists detection.
 __sap_hana_install_fact_is_installed: false
 
-# The list of all valid hostnames in addhosts string including Managed node.
-# - Used for running all configuration tasks for idempotency.
-__sap_hana_install_fact_all_hosts: []
-
-# The list of all valid hostnames in addhosts string.
-# - Used only for setting '__sap_hana_install_fact_addhosts_hosts_new' and '__sap_hana_install_fact_all_hosts'.
+# The list of all valid hostnames in addhosts string, without main host.
 __sap_hana_install_fact_addhosts_hosts: []
 
 # The list of all valid hostnames in addhosts string without host with existing profiles or directories.
@@ -63,7 +58,8 @@ __sap_hana_install_fact_addhosts_hosts_new: []
 
 # The flags used for separation of tasks between hosts
 # This is main host where hdblcm is executed.
-__sap_hana_install_fact_is_main_host: false
+# Always set to 'true', but changed to 'false' for Scale-Out.
+__sap_hana_install_fact_is_main_host: true
 # This is for hosts defined in addhosts string.
 __sap_hana_install_fact_is_addhost_host: false
 # This is for hosts defined in addhosts string that is not installed yet.

--- a/roles/sap_hana_install/vars/main.yml
+++ b/roles/sap_hana_install/vars/main.yml
@@ -72,6 +72,10 @@ __sap_hana_install_fact_is_new_addhost_host: false
 # Path to LSS shared directory.
 __sap_hana_install_lss_inst_path: /lss/shared
 
+# Path to HANA shared directory:
+__sap_hana_install_shared_path:
+  "{{ sap_hana_install_shared_path | regex_replace('/+$', '') }}/{{ sap_hana_install_sid }}"
+
 # Flag for SPS08+ systems where LSS is required.
 __sap_hana_install_fact_is_lss_required: false
 
@@ -88,3 +92,9 @@ __sap_hana_install_firewall_extra_packages: []
 
 # Predefined firewall service name.
 __sap_hana_install_firewall_service_name: "sap-hana-{{ sap_hana_install_number }}"
+
+# System ID (SID) in upper case.
+__sap_hana_install_sid: "{{ sap_hana_install_sid | upper }}"
+
+# Name of '<sid>adm' user.
+__sap_hana_install_sidadm_user: "{{ sap_hana_install_sid | lower }}adm"


### PR DESCRIPTION
## Changes
This pull request is created in alignment with https://github.com/sap-linuxlab/community.sap_install/pull/1213, where strict detection is added. Existing SAP HANA detection was only fairly strict, allowing to see HANA as detected just from files, which is not conclusive.

- Reworked detection
- Added internal variables that were missing (we had unsanitized HANA shared path)

### Detection Approach
New approach uses detection matrix shared with SWPM:
```
### List of scenarios for determining next steps.
# This ensures that installation can be skipped when needed to prevent any potential issues affecting existing installations.
# Optional override is available in defaults/main.yml to execute regardless of warning.
# NOTE: SAP Host Agent can be skipped during installation using 'install_hostagent=n'.

## 'saphostctrl' is present:
# 1. SKIP - 'root' saphostctrl check finds the desired SID and instance number.
# 2. INSTALL - 'root' saphostctrl check does not find the desired SID and instance number, and no other indicators are found.
# 3. FAIL - 'root' saphostctrl check does not find the desired SID and instance number, and any other indicators are found.

# 'saphostctrl' is not present:
# 4. SKIP - 'sidadm' sapcontrol check finds the desired SID and instance number.
# 5. INSTALL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and no other indicators are found.
# 6. FAIL - 'sidadm' sapcontrol check does not find the desired SID and instance number, and any other indicators are found.

# Breakdown of potential scenarios and actions:
# | saphostctrl | sapcontrol | Instance Found | Files Found | Action
# |-------------|------------|----------------|-------------|--------
# | Yes         | N/A        | Yes            | N/A         | SKIP
# | Yes         | N/A        | No             | No          | INSTALL
# | Yes         | N/A        | No             | Any         | FAIL
# | No          | Yes        | Yes            | N/A         | SKIP
# | No          | Yes        | No             | Any         | FAIL
# | No          | No         | No             | No          | INSTALL

# List of non-saphostctrl indicators for potential existing SAP HANA installation:
# A. Files found in /hana/shared/<SID> directory.
# B. Files found in /usr/sap/<SID> directory.
```

## Tests
Tested on SLES_SAP 16.0 on SAP HANA 2.0 SPS08 installation.