### PR TITLE
sap_ha_install_hana_hsr: Add dedicated replication network support

### DIFF
--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -160,7 +160,7 @@ sap_ha_install_hana_hsr_cluster_nodes:
 - _Type:_ `string`
 - _Default:_ `HDB_SYSTEMDB`
 
-The hdbuserstore key used for connecting to the SYSTEMDB for administrative tasks like backups.
+The hdbuserstore key used for connecting to the SYSTEMDB for administrative tasks like backups or updating the global.ini.
 
 ### sap_ha_install_hana_hsr_db_system_password
 - _Type:_ `string`

--- a/roles/sap_ha_install_hana_hsr/README.md
+++ b/roles/sap_ha_install_hana_hsr/README.md
@@ -60,11 +60,13 @@ It is recommended to execute this role together with other roles in this collect
             node_ip: "10.10.10.10"
             node_role: primary
             hana_site: DC01
+            node_hsr_ip: "192.168.10.10"  # optional
 
           - node_name: h01hana1
             node_ip: "10.10.10.11"
             node_role: secondary
             hana_site: DC02
+            node_hsr_ip: "192.168.10.11"  # optional
 
         sap_ha_install_hana_hsr_sid: H01
         sap_ha_install_hana_hsr_instance_number: "01"
@@ -131,6 +133,11 @@ This can be inherited from the variable `sap_hana_cluster_nodes`.
     Available options: `primary`, `secondary`.<br>
 - **hana_site**<br>
     A unique logical site name (e.g., DC01, EU-WEST) (String).<br>
+- **node_hsr_ip** (optional)<br>
+    IP address of the dedicated replication network interface (String).<br>
+    When set, configures `[system_replication_hostname_resolution]` in `global.ini`
+    to map each peer's hostname to its replication IP.<br>
+    It must be defined for all nodes or none.<br>
 
 Example:
 
@@ -140,11 +147,13 @@ sap_ha_install_hana_hsr_cluster_nodes:
     node_ip: '192.168.1.11'
     node_role: 'primary'
     hana_site: 'DC01'
+    node_hsr_ip: '10.0.0.11'
 
   - node_name: 'node02'
     node_ip: '192.168.1.12'
     node_role: 'secondary'
     hana_site: 'DC02'
+    node_hsr_ip: '10.0.0.12'
 ```
 
 ### sap_ha_install_hana_hsr_hdbuserstore_system_backup_user
@@ -238,5 +247,14 @@ The specified ports are opened directly and no service definition is created.<br
 
 Optional name of firewall zone where service or ports will be configured.<br>
 Default firewall zone, usually `public`, is used if this variable is undefined.
+
+### sap_ha_install_hana_hsr_listeninterface
+- _Type:_ `string`
+
+SAP HANA System Replication listen interface.<br>
+Controls which network interface HANA listens on for incoming replication connections.<br>
+Available values: `.internal`, `.global`.<br>
+When not set, listeninterface is not configured and HANA uses its default.<br>
+Setting `.internal` requires `node_hsr_ip` to be defined on all nodes.
 
 <!-- END Role Variables -->

--- a/roles/sap_ha_install_hana_hsr/defaults/main.yml
+++ b/roles/sap_ha_install_hana_hsr/defaults/main.yml
@@ -42,7 +42,7 @@ sap_ha_install_hana_hsr_instance_number: ''
 #     node_hsr_ip: "192.168.10.2"
 sap_ha_install_hana_hsr_cluster_nodes: []
 
-# The hdbuserstore key used for connecting to the SYSTEMDB for administrative tasks like backups (String).
+# The hdbuserstore key used for connecting to the SYSTEMDB for administrative tasks like backups or updating the global.ini (String).
 sap_ha_install_hana_hsr_hdbuserstore_system_backup_user: HDB_SYSTEMDB
 
 # Password for the HANA 'SYSTEM' user (String).
@@ -112,8 +112,8 @@ sap_ha_install_hana_hsr_configure_firewall: false
 # Default firewall zone, usually `public`, is used if this variable is undefined.
 # sap_ha_install_hana_hsr_firewall_zone: ''
 
-# SAP HANA System Replication listen interface (String).
+# Optional: SAP HANA System Replication listen interface (String).
 # Controls which network interface HANA listens on for incoming replication connections.
 # Available values: '.internal', '.global'.
 # When not set, listeninterface is not configured and HANA uses its default.
-sap_ha_install_hana_hsr_listeninterface: ''
+# sap_ha_install_hana_hsr_listeninterface: ''

--- a/roles/sap_ha_install_hana_hsr/defaults/main.yml
+++ b/roles/sap_ha_install_hana_hsr/defaults/main.yml
@@ -23,16 +23,23 @@ sap_ha_install_hana_hsr_instance_number: ''
 #   node_role: (string) Role of the node in the HSR setup. Valid options: 'primary', 'secondary'.
 #   hana_site: (string) A unique logical site name (e.g., DC01, EU-WEST).
 #
+# Optional key for dedicated replication network:
+#   node_hsr_ip: (string) IP address of the dedicated replication interface.
+#     When set, configures [system_replication_hostname_resolution] in global.ini
+#     to map each peer's hostname to its replication IP.
+#
 # Example:
 # sap_ha_install_hana_hsr_cluster_nodes:
 #   - node_name: "hana01"
 #     node_ip: "10.0.0.1"
 #     node_role: primary
 #     hana_site: DC01
+#     node_hsr_ip: "192.168.10.1"
 #   - node_name: "hana02"
 #     node_ip: "10.0.0.2"
 #     node_role: secondary
 #     hana_site: DC02
+#     node_hsr_ip: "192.168.10.2"
 sap_ha_install_hana_hsr_cluster_nodes: []
 
 # The hdbuserstore key used for connecting to the SYSTEMDB for administrative tasks like backups (String).
@@ -104,3 +111,9 @@ sap_ha_install_hana_hsr_configure_firewall: false
 # Optional name of firewall zone where service or ports will be configured.
 # Default firewall zone, usually `public`, is used if this variable is undefined.
 # sap_ha_install_hana_hsr_firewall_zone: ''
+
+# SAP HANA System Replication listen interface (String).
+# Controls which network interface HANA listens on for incoming replication connections.
+# Available values: '.internal', '.global'.
+# When not set, listeninterface is not configured and HANA uses its default.
+sap_ha_install_hana_hsr_listeninterface: ''

--- a/roles/sap_ha_install_hana_hsr/tasks/main.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/main.yml
@@ -91,6 +91,16 @@
           tags: hsr_logmode
       tags: hsr_logmode
 
+    - name: SAP HSR - Configure dedicated HSR network
+      ansible.builtin.include_tasks:
+        file: pre_tasks/configure_hsr_network.yml
+        apply:
+          tags: hsr_network
+      when:
+        - __sap_ha_install_hana_hsr_fact_replication_network or
+          sap_ha_install_hana_hsr_listeninterface | d('') | length > 0
+      tags: hsr_network
+
     - name: SAP HSR - Prepare and sync PKI Files
       ansible.builtin.include_tasks:
         file: pre_tasks/sync_pki_files.yml

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/configure_hsr_network.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/configure_hsr_network.yml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: SAP HSR - Check current system_replication_hostname_resolution in global.ini
+  become: true
+  become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
+  ansible.builtin.shell:
+    cmd: |
+      /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      SELECT KEY, VALUE FROM M_INIFILE_CONTENTS
+        WHERE FILE_NAME = 'global.ini'
+        AND LAYER_NAME = 'SYSTEM'
+        AND SECTION = 'system_replication_hostname_resolution'
+        AND KEY = '{{ node_item.node_hsr_ip }}'
+        AND VALUE = '{{ node_item.node_name }}';
+      EOF
+  loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
+  loop_control:
+    label: "{{ node_item.node_hsr_ip | default('undefined') }} = {{ node_item.node_name }}"
+    loop_var: node_item
+  register: __sap_ha_install_hana_hsr_register_hostname_resolution
+  changed_when: false
+  failed_when: false
+  when: __sap_ha_install_hana_hsr_fact_replication_network
+
+- name: SAP HSR - Configure system_replication_hostname_resolution in global.ini
+  become: true
+  become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
+  ansible.builtin.shell:
+    cmd: |
+      /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini','SYSTEM')
+        SET ('system_replication_hostname_resolution','{{ node_item.node_item.node_hsr_ip }}')
+        = '{{ node_item.node_item.node_name }}' WITH RECONFIGURE;
+      EOF
+  loop: "{{ __sap_ha_install_hana_hsr_register_hostname_resolution.results }}"
+  loop_control:
+    label: "{{ node_item.node_item.node_hsr_ip | default('undefined') }} = {{ node_item.node_item.node_name }}"
+    loop_var: node_item
+  changed_when: true
+  when:
+    - __sap_ha_install_hana_hsr_fact_replication_network
+    - node_item.node_item.node_name not in node_item.stdout
+
+- name: SAP HSR - Check current listeninterface in global.ini
+  become: true
+  become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
+  ansible.builtin.shell:
+    cmd: |
+      /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      SELECT VALUE FROM M_INIFILE_CONTENTS
+        WHERE FILE_NAME = 'global.ini'
+        AND LAYER_NAME = 'SYSTEM'
+        AND SECTION = 'system_replication_communication'
+        AND KEY = 'listeninterface'
+        AND VALUE = '{{ sap_ha_install_hana_hsr_listeninterface }}';
+      EOF
+  register: __sap_ha_install_hana_hsr_register_listeninterface
+  changed_when: false
+  failed_when: false
+  when: sap_ha_install_hana_hsr_listeninterface | d('') | length > 0
+
+- name: SAP HSR - Configure listeninterface in global.ini
+  become: true
+  become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
+  ansible.builtin.shell:
+    cmd: |
+      /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini','SYSTEM')
+        SET ('system_replication_communication','listeninterface')
+        = '{{ sap_ha_install_hana_hsr_listeninterface }}' WITH RECONFIGURE;
+      EOF
+  changed_when: true
+  when:
+    - sap_ha_install_hana_hsr_listeninterface | d('') | length > 0
+    - sap_ha_install_hana_hsr_listeninterface not in __sap_ha_install_hana_hsr_register_listeninterface.stdout

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/configure_hsr_network.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/configure_hsr_network.yml
@@ -18,7 +18,7 @@
       EOF
   loop: "{{ sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
-    label: "{{ node_item.node_hsr_ip | default('undefined') }} = {{ node_item.node_name }}"
+    label: "{{ node_item.node_hsr_ip | d('undefined') }} = {{ node_item.node_name }}"
     loop_var: node_item
   register: __sap_ha_install_hana_hsr_register_hostname_resolution
   changed_when: false
@@ -39,7 +39,7 @@
       EOF
   loop: "{{ __sap_ha_install_hana_hsr_register_hostname_resolution.results }}"
   loop_control:
-    label: "{{ node_item.node_item.node_hsr_ip | default('undefined') }} = {{ node_item.node_item.node_name }}"
+    label: "{{ node_item.node_item.node_hsr_ip | d('undefined') }} = {{ node_item.node_item.node_name }}"
     loop_var: node_item
   changed_when: true
   when:

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/configure_hsr_network.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/configure_hsr_network.yml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Configure replication network settings at SYSTEM layer only. HOST layer overrides are not managed by this role.
 
 - name: SAP HSR - Check current system_replication_hostname_resolution in global.ini
   become: true

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
@@ -281,7 +281,7 @@
     that:
       - node_item.node_hsr_ip is defined
       - node_item.node_hsr_ip is string
-      - node_item.node_hsr_ip | string | length > 0
+      - node_item.node_hsr_ip | trim | string | length > 0
     success_msg: |
       PASS: Node '{{ node_item.node_name }}' has 'node_hsr_ip' defined.
     fail_msg: |

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
@@ -23,6 +23,7 @@
         FAIL: The variable 'sap_ha_install_hana_hsr_state' is not one of valid values.
         Available values: present, absent
       {% endif %}
+    quiet: true
 
 
 # SID
@@ -48,6 +49,7 @@
       {% else %}
         FAIL: The length of SAP HANA System ID '{{ __sap_ha_install_hana_hsr_sid }}' is not 3 characters!
       {% endif %}
+    quiet: true
 
 
 # Instance Number
@@ -74,6 +76,7 @@
       {% else %}
         FAIL: The SAP HANA Instance Number '{{ __sap_ha_install_hana_hsr_instance_number }}' is not 2 digits!
       {% endif %}
+    quiet: true
 
 
 # Database password
@@ -101,6 +104,7 @@
       {% else %}
         FAIL: The variable 'sap_ha_install_hana_hsr_db_system_password' is empty.
       {% endif %}
+    quiet: true
 
 
 # Domain
@@ -125,6 +129,7 @@
       {% else %}
         FAIL: The variable 'sap_ha_install_hana_hsr_domain' is empty.
       {% endif %}
+    quiet: true
 
 
 # Replication mode
@@ -145,6 +150,7 @@
         FAIL: The variable 'sap_ha_install_hana_hsr_rep_mode' is not one of valid values.
         Available values: sync, syncmem, async
       {% endif %}
+    quiet: true
 
 
 # Operation mode
@@ -165,6 +171,7 @@
         FAIL: The variable 'sap_ha_install_hana_hsr_oper_mode' is not one of valid values.
         Available values: delta_datashipping, logreplay, logreplay_readaccess
       {% endif %}
+    quiet: true
 
 
 # Backup user
@@ -181,6 +188,7 @@
       {% else %}
         FAIL: The variable 'sap_ha_install_hana_hsr_hdbuserstore_system_backup_user' is empty.
       {% endif %}
+    quiet: true
 
 
 # $HOME path
@@ -235,6 +243,7 @@
       {% else %}
       FAIL: Duplicate 'node_name' found in 'sap_ha_install_hana_hsr_cluster_nodes'. Each node must have a unique 'node_name'.
       {% endif %}
+    quiet: true
 
 - name: SAP HSR - Assert that each node in 'sap_ha_install_hana_hsr_cluster_nodes' has required attributes
   ansible.builtin.assert:
@@ -248,6 +257,7 @@
     fail_msg: |
       FAIL: Node '{{ node_item.node_name | d('undefined') }}' is missing required attributes or has empty values.
       Each node must have 'node_name', 'node_ip', 'node_role', and 'hana_site' defined with non-empty values."
+    quiet: true
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name | d('N/A') }}"
@@ -268,6 +278,7 @@
       {% else %}
       FAIL: There must be at least one 'secondary' node, but {{ secondary_nodes_count }} were found.
       {% endif %}
+    quiet: true
 
 
 # Replication network
@@ -287,6 +298,7 @@
     fail_msg: |
       FAIL: Node '{{ node_item.node_name }}' parameter 'node_hsr_ip' is undefined, empty, or invalid.
       When using a dedicated replication network, all nodes must define 'node_hsr_ip'.
+    quiet: true
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name }}"
@@ -304,6 +316,7 @@
       PASS: The variable 'sap_ha_install_hana_hsr_listeninterface' is '{{ sap_ha_install_hana_hsr_listeninterface }}'.
     fail_msg: |
       FAIL: The variable 'sap_ha_install_hana_hsr_listeninterface' must be '.internal' or '.global'.
+    quiet: true
   when: sap_ha_install_hana_hsr_listeninterface | d('') | length > 0
 
 - name: SAP HSR - Assert that 'node_hsr_ip' is defined when listeninterface is '.internal'
@@ -363,6 +376,7 @@
       3. Valid Role: The 'node_role' must be either 'primary' or 'secondary'.
 
       If this host is not supposed to be part of the HSR cluster, please remove it from hosts in Ansible Play.
+    quiet: true
 
 - name: SAP HSR - Assert that 'node_hsr_ip' is present on this host
   ansible.builtin.assert:

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
@@ -246,11 +246,11 @@
     success_msg: |
       PASS: Node '{{ node_item.node_name }}' has all required attributes.
     fail_msg: |
-      FAIL: Node '{{ node_item.node_name | default('undefined') }}' is missing required attributes or has empty values.
+      FAIL: Node '{{ node_item.node_name | d('undefined') }}' is missing required attributes or has empty values.
       Each node must have 'node_name', 'node_ip', 'node_role', and 'hana_site' defined with non-empty values."
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
-    label: "{{ node_item.node_name | default('N/A') }}"
+    label: "{{ node_item.node_name | d('N/A') }}"
     loop_var: node_item
 
 - name: SAP HSR - Assert that nodes in 'sap_ha_install_hana_hsr_cluster_nodes' have required 'node_role' values.
@@ -280,11 +280,12 @@
   ansible.builtin.assert:
     that:
       - node_item.node_hsr_ip is defined
+      - node_item.node_hsr_ip is string
       - node_item.node_hsr_ip | string | length > 0
     success_msg: |
       PASS: Node '{{ node_item.node_name }}' has 'node_hsr_ip' defined.
     fail_msg: |
-      FAIL: Node '{{ node_item.node_name }}' is missing 'node_hsr_ip'.
+      FAIL: Node '{{ node_item.node_name }}' parameter 'node_hsr_ip' is undefined, empty, or invalid.
       When using a dedicated replication network, all nodes must define 'node_hsr_ip'.
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
@@ -322,11 +323,11 @@
     __sap_ha_install_hana_hsr_connection:
       node_fqdn: "{{ node_item.node_name }}"
       node_name: "{{ node_item.node_name.split('.')[0] }}"
-      node_domain: "{{ node_item.node_name.split('.')[1:] | join('.') or __sap_ha_install_hana_hsr_domain | default('') }}"
+      node_domain: "{{ node_item.node_name.split('.')[1:] | join('.') or __sap_ha_install_hana_hsr_domain | d('') }}"
       node_ip: "{{ node_item.node_ip }}"
       node_role: "{{ node_item.node_role }}"
       hana_site: "{{ node_item.hana_site }}"
-      node_hsr_ip: "{{ node_item.node_hsr_ip | default('') }}"
+      node_hsr_ip: "{{ node_item.node_hsr_ip | d('') }}"
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name }}"
@@ -338,8 +339,8 @@
 # Sets host specific flags that are used for running tasks on specific hosts.
 - name: SAP HSR - Set fact with boolean flags for each host
   ansible.builtin.set_fact:
-    __sap_ha_install_hana_hsr_fact_is_primary: "{{ __sap_ha_install_hana_hsr_connection.node_role | default('') == 'primary' }}"
-    __sap_ha_install_hana_hsr_fact_is_secondary: "{{ __sap_ha_install_hana_hsr_connection.node_role | default('') == 'secondary' }}"
+    __sap_ha_install_hana_hsr_fact_is_primary: "{{ __sap_ha_install_hana_hsr_connection.node_role | d('') == 'primary' }}"
+    __sap_ha_install_hana_hsr_fact_is_secondary: "{{ __sap_ha_install_hana_hsr_connection.node_role | d('') == 'secondary' }}"
 
 - name: SAP HSR - Check that host is a defined member of the HSR cluster
   ansible.builtin.assert:

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
@@ -23,7 +23,6 @@
         FAIL: The variable 'sap_ha_install_hana_hsr_state' is not one of valid values.
         Available values: present, absent
       {% endif %}
-    quiet: true
 
 
 # SID
@@ -49,7 +48,6 @@
       {% else %}
         FAIL: The length of SAP HANA System ID '{{ __sap_ha_install_hana_hsr_sid }}' is not 3 characters!
       {% endif %}
-    quiet: true
 
 
 # Instance Number
@@ -76,7 +74,6 @@
       {% else %}
         FAIL: The SAP HANA Instance Number '{{ __sap_ha_install_hana_hsr_instance_number }}' is not 2 digits!
       {% endif %}
-    quiet: true
 
 
 # Database password
@@ -104,7 +101,6 @@
       {% else %}
         FAIL: The variable 'sap_ha_install_hana_hsr_db_system_password' is empty.
       {% endif %}
-    quiet: true
 
 
 # Domain
@@ -129,7 +125,6 @@
       {% else %}
         FAIL: The variable 'sap_ha_install_hana_hsr_domain' is empty.
       {% endif %}
-    quiet: true
 
 
 # Replication mode
@@ -150,7 +145,6 @@
         FAIL: The variable 'sap_ha_install_hana_hsr_rep_mode' is not one of valid values.
         Available values: sync, syncmem, async
       {% endif %}
-    quiet: true
 
 
 # Operation mode
@@ -171,7 +165,6 @@
         FAIL: The variable 'sap_ha_install_hana_hsr_oper_mode' is not one of valid values.
         Available values: delta_datashipping, logreplay, logreplay_readaccess
       {% endif %}
-    quiet: true
 
 
 # Backup user
@@ -188,7 +181,6 @@
       {% else %}
         FAIL: The variable 'sap_ha_install_hana_hsr_hdbuserstore_system_backup_user' is empty.
       {% endif %}
-    quiet: true
 
 
 # $HOME path
@@ -243,7 +235,6 @@
       {% else %}
       FAIL: Duplicate 'node_name' found in 'sap_ha_install_hana_hsr_cluster_nodes'. Each node must have a unique 'node_name'.
       {% endif %}
-    quiet: true
 
 - name: SAP HSR - Assert that each node in 'sap_ha_install_hana_hsr_cluster_nodes' has required attributes
   ansible.builtin.assert:
@@ -257,7 +248,6 @@
     fail_msg: |
       FAIL: Node '{{ node_item.node_name | d('undefined') }}' is missing required attributes or has empty values.
       Each node must have 'node_name', 'node_ip', 'node_role', and 'hana_site' defined with non-empty values."
-    quiet: true
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name | d('N/A') }}"
@@ -278,7 +268,6 @@
       {% else %}
       FAIL: There must be at least one 'secondary' node, but {{ secondary_nodes_count }} were found.
       {% endif %}
-    quiet: true
 
 
 # Replication network
@@ -298,7 +287,6 @@
     fail_msg: |
       FAIL: Node '{{ node_item.node_name }}' parameter 'node_hsr_ip' is undefined, empty, or invalid.
       When using a dedicated replication network, all nodes must define 'node_hsr_ip'.
-    quiet: true
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name }}"
@@ -316,7 +304,6 @@
       PASS: The variable 'sap_ha_install_hana_hsr_listeninterface' is '{{ sap_ha_install_hana_hsr_listeninterface }}'.
     fail_msg: |
       FAIL: The variable 'sap_ha_install_hana_hsr_listeninterface' must be '.internal' or '.global'.
-    quiet: true
   when: sap_ha_install_hana_hsr_listeninterface | d('') | length > 0
 
 - name: SAP HSR - Assert that 'node_hsr_ip' is defined when listeninterface is '.internal'
@@ -376,7 +363,6 @@
       3. Valid Role: The 'node_role' must be either 'primary' or 'secondary'.
 
       If this host is not supposed to be part of the HSR cluster, please remove it from hosts in Ansible Play.
-    quiet: true
 
 - name: SAP HSR - Assert that 'node_hsr_ip' is present on this host
   ansible.builtin.assert:

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
@@ -248,6 +248,7 @@
     fail_msg: |
       FAIL: Node '{{ node_item.node_name | d('undefined') }}' is missing required attributes or has empty values.
       Each node must have 'node_name', 'node_ip', 'node_role', and 'hana_site' defined with non-empty values."
+    quiet: true
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name | d('N/A') }}"
@@ -287,6 +288,7 @@
     fail_msg: |
       FAIL: Node '{{ node_item.node_name }}' parameter 'node_hsr_ip' is undefined, empty, or invalid.
       When using a dedicated replication network, all nodes must define 'node_hsr_ip'.
+    quiet: true
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name }}"

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/prepare_variables.yml
@@ -270,6 +270,52 @@
       {% endif %}
 
 
+# Replication network
+- name: SAP HSR - Set fact for replication network availability
+  ansible.builtin.set_fact:
+    __sap_ha_install_hana_hsr_fact_replication_network:
+      "{{ __sap_ha_install_hana_hsr_cluster_nodes | selectattr('node_hsr_ip', 'defined') | list | length > 0 }}"
+
+- name: SAP HSR - Assert that all nodes define 'node_hsr_ip' when any node does
+  ansible.builtin.assert:
+    that:
+      - node_item.node_hsr_ip is defined
+      - node_item.node_hsr_ip | string | length > 0
+    success_msg: |
+      PASS: Node '{{ node_item.node_name }}' has 'node_hsr_ip' defined.
+    fail_msg: |
+      FAIL: Node '{{ node_item.node_name }}' is missing 'node_hsr_ip'.
+      When using a dedicated replication network, all nodes must define 'node_hsr_ip'.
+  loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
+  loop_control:
+    label: "{{ node_item.node_name }}"
+    loop_var: node_item
+  when: __sap_ha_install_hana_hsr_fact_replication_network
+
+
+# Listeninterface
+- name: SAP HSR - Assert that the variable 'sap_ha_install_hana_hsr_listeninterface' is valid
+  ansible.builtin.assert:
+    that:
+      - sap_ha_install_hana_hsr_listeninterface is string
+      - sap_ha_install_hana_hsr_listeninterface in ['.internal', '.global']
+    success_msg: |
+      PASS: The variable 'sap_ha_install_hana_hsr_listeninterface' is '{{ sap_ha_install_hana_hsr_listeninterface }}'.
+    fail_msg: |
+      FAIL: The variable 'sap_ha_install_hana_hsr_listeninterface' must be '.internal' or '.global'.
+  when: sap_ha_install_hana_hsr_listeninterface | d('') | length > 0
+
+- name: SAP HSR - Assert that 'node_hsr_ip' is defined when listeninterface is '.internal'
+  ansible.builtin.assert:
+    that:
+      - __sap_ha_install_hana_hsr_fact_replication_network
+    fail_msg: |
+      FAIL: 'sap_ha_install_hana_hsr_listeninterface' is set to '.internal' but no 'node_hsr_ip' is defined.
+      HANA needs [system_replication_hostname_resolution] entries to bind to the internal interface.
+      Define 'node_hsr_ip' on all nodes in 'sap_ha_install_hana_hsr_cluster_nodes'.
+  when: sap_ha_install_hana_hsr_listeninterface | d('') == '.internal'
+
+
 # Host specific cluster configuration
 - name: SAP HSR - Set host specific connection variable
   ansible.builtin.set_fact:
@@ -280,6 +326,7 @@
       node_ip: "{{ node_item.node_ip }}"
       node_role: "{{ node_item.node_role }}"
       hana_site: "{{ node_item.hana_site }}"
+      node_hsr_ip: "{{ node_item.node_hsr_ip | default('') }}"
   loop: "{{ __sap_ha_install_hana_hsr_cluster_nodes }}"
   loop_control:
     label: "{{ node_item.node_name }}"
@@ -315,6 +362,16 @@
       3. Valid Role: The 'node_role' must be either 'primary' or 'secondary'.
 
       If this host is not supposed to be part of the HSR cluster, please remove it from hosts in Ansible Play.
+
+- name: SAP HSR - Assert that 'node_hsr_ip' is present on this host
+  ansible.builtin.assert:
+    that:
+      - __sap_ha_install_hana_hsr_connection.node_hsr_ip in ansible_facts['all_ipv4_addresses']
+    fail_msg: |
+      FAIL: The 'node_hsr_ip' ({{ __sap_ha_install_hana_hsr_connection.node_hsr_ip }})
+      is not configured on host '{{ __sap_ha_install_hana_hsr_connection.node_name }}'.
+      The replication IP must be present on a network interface before configuring HSR.
+  when: __sap_ha_install_hana_hsr_fact_replication_network
 
 # Set details of primary for connection from secondary
 - name: SAP HSR - Set connection variables for primary node

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/set_log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/set_log_mode.yml
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Set log_mode at SYSTEM layer only. HOST layer overrides are not managed by this role.
 
-- name: SAP HSR - Check current log_mode in global.ini
+- name: SAP HSR - Check current log_mode in SYSTEM global.ini
   become: true
   become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell:
@@ -22,7 +23,7 @@
 
 # This task will fail when HSR is already configured,
 # because secondary node nameserver is not running with port 3XX13.
-- name: SAP HSR - Set log_mode to normal
+- name: SAP HSR - Set log_mode to normal for SYSTEM
   become: true
   become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell:

--- a/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/set_log_mode.yml
+++ b/roles/sap_ha_install_hana_hsr/tasks/pre_tasks/set_log_mode.yml
@@ -1,19 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: SAP HSR - check log_mode
+- name: SAP HSR - Check current log_mode in global.ini
   become: true
   become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
   ansible.builtin.shell:
-    cmd: >-
-      set -o pipefail &&
-      grep "log_mode" /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/global/hdb/custom/config/global.ini | grep normal
+    cmd: |
+      /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
+      -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
+      -m <<EOF
+      SELECT VALUE FROM M_INIFILE_CONTENTS
+        WHERE FILE_NAME = 'global.ini'
+        AND LAYER_NAME = 'SYSTEM'
+        AND SECTION = 'persistence'
+        AND KEY = 'log_mode'
+        AND VALUE = 'normal';
+      EOF
   register: __sap_ha_install_hana_hsr_register_log_mode
   failed_when: false
   changed_when: false
 
-# CHECK, if ansible_facts['hostname'] needs to be replaced with interface name
-# This task will fail when HSR is already configured, because secondary node nameserver is not running with port 3XX13.
+# This task will fail when HSR is already configured,
+# because secondary node nameserver is not running with port 3XX13.
 - name: SAP HSR - Set log_mode to normal
   become: true
   become_user: "{{ __sap_ha_install_hana_hsr_sid | lower }}adm"
@@ -22,9 +30,10 @@
       /usr/sap/{{ __sap_ha_install_hana_hsr_sid }}/SYS/exe/hdb/hdbsql \
       -U {{ sap_ha_install_hana_hsr_hdbuserstore_system_backup_user }} \
       -m <<EOF
-      ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'SYSTEM') SET ('persistence', 'log_mode') = 'normal' WITH RECONFIGURE;
-      ALTER SYSTEM ALTER CONFIGURATION('global.ini','HOST','{{ ansible_facts['hostname'] }}') SET ('persistence','log_mode') = 'normal' WITH RECONFIGURE;
+      ALTER SYSTEM ALTER CONFIGURATION('global.ini','SYSTEM')
+        SET ('persistence','log_mode')
+        = 'normal' WITH RECONFIGURE;
       EOF
   ignore_errors: true
-  when: __sap_ha_install_hana_hsr_register_log_mode.rc != '0'
+  when: "'normal' not in __sap_ha_install_hana_hsr_register_log_mode.stdout"
   changed_when: true


### PR DESCRIPTION
**NEW: support explicit HSR interface**
Configure `[system_replication_hostname_resolution]` and `[system_replication_communication]` `listeninterface` in `global.ini` to route HSR traffic over a dedicated network interface.

New variables:
- `node_hsr_ip` (per node in cluster_nodes)
- `sap_ha_install_hana_hsr_listeninterface` (.internal/.global)

Solves issue #1219.

**FIX: Refactor `set_log_mode`**
- Use SQL query (M_INIFILE_CONTENTS) instead of grep for idempotency check.
- Fix conditional that always evaluated true due to integer/string comparison (rc != '0'). 
- Drop redundant ALTER HOST layer (silently updates host specific global.ini), set SYSTEM layer (default global.ini) only.

**Pseudo-Idempotency**
All `global.ini` settings run check tasks first, using SQL checks that filter LAYER_NAME = 'SYSTEM' to avoid false positives from DEFAULT or HOST layer values.
The checks are exact matches. If the values change, it overrides the existing parameter with the new value.
If there is already a HANA system replication active between the instances, the setup is skipped. (not a new change)

**Tested**

Preparation: dedicated interface/IP statically configured on each node

| Test | Input | Expected | Result |
| :---- | :---- | :---- | :---- |
| no new vars | baseline | unchanged behavior | PASS |
| node_hsr_ip | both nodes | hostname_resolution set | PASS |
| node_hsr_ip | only on 1 of 2 nodes | validation error | PASS |
| node_hsr_ip | IP not on interface | validation error | PASS |
| listeninterface | `.global`, no node_hsr_ip | listeninterface only | PASS |
| listeninterface | empty | not configured | PASS |
| listeninterface | `foo` | validation error | PASS |
| listeninterface | `.internal`, no IPs | validation error | PASS |
| node_hsr_ip + listeninterface | both nodes + `.global` | both configured | PASS |
| node_hsr_ip + listeninterface | both nodes + `.internal` | both configured | PASS |