### PR TITLE
sap_hana_install: New functionality to add Fast Restart Option config to HANA

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: codespell-project/actions-codespell@v2
         with:
           # lowercase only
-          ignore_words_list: aas,hsa,te,chage,addopt,sybsystem,uptodate
+          ignore_words_list: aas,hsa,te,chage,addopt,sybsystem,uptodate,fro

--- a/roles/sap_hana_install/README.md
+++ b/roles/sap_hana_install/README.md
@@ -228,7 +228,7 @@ Steps:
 2. Gather list of all Instance profiles in `/hana/shared/<SID>/profile/`.
 3. Gather list of all directories in `/usr/sap/<SID>/HDB<Instance Number>/`.
 4. If the existing instance profile or directory was found in hosts list, create separate list without them.
-    - This list of the `new hosts` is used for one-time tasks. 
+    - This list of the `new hosts` is used for one-time tasks.
 
 
 #### Pre-Tasks for Installation
@@ -312,7 +312,8 @@ Steps:
 7. Apply SELinux policies if the variable `sap_hana_install_configure_selinux` is set to `true`.
 8. (Red Hat specific) Configure `fapolicyd` if the variable `sap_hana_install_configure_fapolicyd` is set to `true`.
 Additionally, if `sap_hana_install_enable_fapolicyd` is set to `true`, also enable and start the `fapolicyd` service.
-9. Output final status of installed system.
+9. Perform Fast Restart Option (FRO) configuration if requested (`sap_hana_install_fro_state` is set to `enabled` or `disabled`).
+10. Output final status of installed system.
 
 
 #### Post-Tasks for Addhosts
@@ -328,7 +329,8 @@ Steps:
 7. Apply SELinux policies if the variable `sap_hana_install_configure_selinux` is set to `true`.
 8. (Red Hat specific) Configure `fapolicyd` if the variable `sap_hana_install_configure_fapolicyd` is set to `true`.
 Additionally, if `sap_hana_install_enable_fapolicyd` is set to `true`, also enable and start the `fapolicyd` service.
-9. Output final status of installed system.
+9. Perform Fast Restart Option (FRO) configuration if requested (`sap_hana_install_fro_state` is set to `enabled` or `disabled`).
+10. Output final status of installed system.
 <!-- END Execution Flow -->
 
 ### Example
@@ -407,6 +409,7 @@ With the following tags, the role can be called to perform certain activities on
 - tag `sap_hana_install_create_configfile`: Only generate the hdblcm configfile.
 - tag `sap_hana_install_check_hana_exists`: Only check if there is already HANA installed with the
   desired SID and instance number.
+- tag `sap_hana_install_fro_configure`: Run only the Fast Restart Option configuration steps. This will have only effect if `sap_hana_install_fro_state` is set to `enabled` or `disabled`.
 
 The following tags have been removed in this release:
 
@@ -456,8 +459,20 @@ ansible-playbook sap-hana-install.yml --tags=sap_hana_install_check_hana_exists
     sap_hana_install_lss_backup_password: ''
     sap_hana_install_secure_store: localsecurestore
     ```
-> **NOTE**: SAP HANA 2.0 SPS08 requires LSS filesystem to be shared across all Scale-Out (cluster) hosts.</br>
-> This role will check if directory defined in `sap_hana_insall_lss_inst_path` is present for SPS08 or higher and if it is mounted as shared file system.
+  > **NOTE**: SAP HANA 2.0 SPS08 requires LSS filesystem to be shared across all Scale-Out (cluster) hosts.</br>
+  > This role will check if directory defined in `sap_hana_insall_lss_inst_path` is present for SPS08 or higher and if it is mounted as shared file system.
+
+- ### Fast Restart Option (FRO)
+  SAP HANA Fast Restart Option is available as of HANA2.0 SPS04. It uses storage in the file system to preserve and reuse MAIN data fragments to speed up SAP HANA restarts. This is effective in cases where the operating system is not restarted.
+
+  For explantation of how this role handles the FRO configuration see the comments in `defaults/main.yml`.
+  For details how FRO works see [HANA online help](https://help.sap.com/docs/SAP_HANA_PLATFORM/6b94445c94ae495c83a19646e7c3fd56/ce158d28135147f099b761f8b1ee43fc.html?locale=en-US&version=LATEST).
+
+  The role parameters that impact FRO configuration are:
+  ```
+  sap_hana_install_fro_state:
+  sap_hana_install_fro_mem_percent:
+  ```
 
 - ### Additional examples
   For more examples on how to use this role in different installation scenarios, refer to the [ansible.playbooks_for_sap](https://github.com/sap-linuxlab/ansible.playbooks_for_sap) playbooks.

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -128,6 +128,31 @@ sap_hana_install_recreate_tenant_database: false
 # If this not desired, set the following variable to `false`.
 sap_hana_install_configure_selinux: true
 
+# Enables/Disables/Keeps the Fast Restart Option (FRO) for SAP HANA.
+# When set to 'enabled', the role will configure tmpfs mounts for all NUMA nodes and set the corresponding HANA parameters.
+# When set to 'disabled', the role will remove any existing tmpfs mounts for FRO and unset the corresponding HANA parameters.
+# When set to 'unchanged', the role will not modify the FRO configuration.
+# NOTE: When enabling FRO the HANA database must be restarted for the changes to take effect. This is not done automatically by the role.
+# NOTE: When disabling FRO, the HANA database must be restarted. This is not handled automatically by the role.
+#   This means that the disabling will fail and will have to be executed twice!
+#   The flow is: 1) run disable (it will fail) 2) restart HANA manually 3) run disable again (it will succeed).
+#   This is a security precaution to avoid data loss and to allow the administrator to follow their own restart procedure.
+sap_hana_install_fro_state: 'unchanged'
+
+# When enabling FRO, this variable defines the percentage of the main memory per NUMA node to use for FRO tmpfs mounts.
+# Make sure you understand the implication of settings this and you have performed the necessary calculations to set this correctly.
+# Default value is 40% which is considered safe and a good starting point for testing (assuming your server was sized according
+#   to SAP HANA hardware sizing guidelines).
+# Setting this to 0 will make the tmpfs unlimited i.e. all available memory will be useable for FRO.
+#   This can lead to out of memory situations if the memory is not restricted using HANA parameters.
+# Setting this to 100 will use all memory at the point of execution of this role i.e. the size will be fixed to 100% as of today.
+#   This can lead to out of memory situations if the memory is not restricted using HANA parameters.
+# Setting this to any other number will set the size of the tmpfs to that percentage of the main memory of the NUMA node at the point of execution of this role.
+#   The calculation is done per each NUMA node and is rounded down (decimals are truncated) to the nearest gigabyte.
+#   For example, if you set this to 50 and you have a NUMA node with 383 GB of main memory, the tmpfs size will be set to 191 GB.
+#   Sensible values are probably somewhere between 40 and 60, but this really depends on your workload and on how much memory you have available.
+sap_hana_install_fro_mem_percent: 40
+
 ################
 # Parameters for hdblcm:
 ################

--- a/roles/sap_hana_install/defaults/main.yml
+++ b/roles/sap_hana_install/defaults/main.yml
@@ -143,7 +143,7 @@ sap_hana_install_fro_state: 'unchanged'
 # Make sure you understand the implication of settings this and you have performed the necessary calculations to set this correctly.
 # Default value is 40% which is considered safe and a good starting point for testing (assuming your server was sized according
 #   to SAP HANA hardware sizing guidelines).
-# Setting this to 0 will make the tmpfs unlimited i.e. all available memory will be useable for FRO.
+# Setting this to 0 will make the tmpfs unlimited i.e. all available memory will be usable for FRO.
 #   This can lead to out of memory situations if the memory is not restricted using HANA parameters.
 # Setting this to 100 will use all memory at the point of execution of this role i.e. the size will be fixed to 100% as of today.
 #   This can lead to out of memory situations if the memory is not restricted using HANA parameters.

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -135,6 +135,14 @@
       ansible.builtin.include_tasks:
         file: post_addhosts.yml
 
+- name: SAP HANA - Main - Post-Tasks - Fast Restart Option (FRO)
+  ansible.builtin.include_tasks:
+    file: post_tasks/fro.yml
+    apply:
+      tags:
+        - sap_hana_install_fro_configure
+  when: sap_hana_install_fro_state in ['enabled', 'disabled']
+  tags: sap_hana_install_fro_configure
 
 # Show final status of SAP HANA System
 # Gather details about installed database for finished message

--- a/roles/sap_hana_install/tasks/main.yml
+++ b/roles/sap_hana_install/tasks/main.yml
@@ -141,8 +141,9 @@
     apply:
       tags:
         - sap_hana_install_fro_configure
-  when: sap_hana_install_fro_state in ['enabled', 'disabled']
-  tags: sap_hana_install_fro_configure
+  when:
+    - sap_hana_install_fro_state in ['enabled', 'disabled']
+    - "'sap_hana_install_fro_configure' in ansible_run_tags or __sap_hana_install_fact_is_installed"
 
 # Show final status of SAP HANA System
 # Gather details about installed database for finished message

--- a/roles/sap_hana_install/tasks/post_tasks/fro.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/fro.yml
@@ -2,7 +2,7 @@
 # As of SPS08 this can be done using
 # hdblcm --configure_fast_restart_option --tmpfs_mountpoints_path=<path>
 #        --restrict_tmpfs_global_allocation_limit --tmpfs_global_allocation_limit=<limit in MB>
-# However, the approach below is universal regardlesss of HANA version and also allows changing or removal of the FRO configuration which
+# However, the approach below is universal regardless of HANA version and also allows changing or removal of the FRO configuration which
 # is not currently possible using hdblcm
 
 - name: SAP HANA - Post-Tasks - FRO - Gather NUMA nodes and their memory sizes

--- a/roles/sap_hana_install/tasks/post_tasks/fro.yml
+++ b/roles/sap_hana_install/tasks/post_tasks/fro.yml
@@ -1,0 +1,145 @@
+---
+# As of SPS08 this can be done using
+# hdblcm --configure_fast_restart_option --tmpfs_mountpoints_path=<path>
+#        --restrict_tmpfs_global_allocation_limit --tmpfs_global_allocation_limit=<limit in MB>
+# However, the approach below is universal regardlesss of HANA version and also allows changing or removal of the FRO configuration which
+# is not currently possible using hdblcm
+
+- name: SAP HANA - Post-Tasks - FRO - Gather NUMA nodes and their memory sizes
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && cat /sys/devices/system/node/node*/meminfo | grep MemTotal | awk '{print $2, $4}'"
+  register: __sap_hana_install_numa_memory_sizes_output
+  failed_when: __sap_hana_install_numa_memory_sizes_output.rc != 0
+  become: true
+  changed_when: false
+
+- name: SAP HANA - Post-Tasks - FRO - Extract NUMA nodes and memory sizes
+  ansible.builtin.set_fact:
+    __sap_hana_install_fact_numa_nodes: "{{ __sap_hana_install_numa_memory_sizes_output.stdout_lines | map('split') | list }}"
+
+- name: SAP HANA - Post-Tasks - FRO - Define fact for tmpfs base paths
+  ansible.builtin.set_fact:
+    __sap_hana_install_fact_fro_base_path: "{{ __sap_hana_install_fact_numa_nodes | map(attribute=0) | map('regex_replace', '^(.*)$', '/hana/tmpfs\\1/' + sap_hana_install_sid | upper) | join(';') }}"
+
+- name: SAP HANA - Post-Tasks - FRO - Get UID of user {{ sap_hana_install_sid | lower }}adm and GID of group sapsys
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && getent passwd {{ sap_hana_install_sid | lower }}adm | cut -d: -f3 && getent group sapsys | cut -d: -f3"
+  register: __sap_hana_install_user_group_ids
+  changed_when: false
+  become: true
+
+- name: SAP HANA - Post-Tasks - FRO - Create TMPFS mount points for each NUMA node
+  ansible.builtin.file:
+    path: "/hana/tmpfs{{ numa_node[0] }}/{{ sap_hana_install_sid | upper }}"
+    state: directory
+    owner: "{{ sap_hana_install_sid | lower }}adm"
+    group: sapsys
+    mode: '1775'
+  loop: "{{ __sap_hana_install_fact_numa_nodes }}"
+  loop_control:
+    loop_var: numa_node
+    label: "Processing NUMA node {{ numa_node[0] }}"
+  when: sap_hana_install_fro_state == 'enabled'
+
+- name: SAP HANA - Post-Tasks - FRO - Disable FRO by unsetting basepath parameters in HANA and reconfiguring the system
+  ansible.builtin.shell: |
+    source ~/.profile && HDBSettings.sh \
+    setParameter.py  -unset="SYSTEM/global.ini/persistence/basepath_persistent_memory_volumes"
+  args:
+    executable: /bin/bash
+  register: __sap_hana_install_hana_setparam_disable
+  become: true
+  become_user: "{{ sap_system_sid | lower }}adm"
+  changed_when: __sap_hana_install_hana_setparam_disable.rc == 0
+  failed_when: __sap_hana_install_hana_setparam_disable.rc != 0
+  when: sap_hana_install_fro_state == 'disabled'
+
+- name: SAP HANA - Post-Tasks - FRO - Unmount TMPFS for all NUMA nodes if FRO is disabled to allow cleanup of mount points
+  become: true
+  ansible.posix.mount:
+    src: "tmpfs{{ sap_hana_install_sid | lower }}{{ numa_node[0] }}"
+    path: "/hana/tmpfs{{ numa_node[0] }}/{{ sap_hana_install_sid | upper }}"
+    fstype: tmpfs
+    opts: "\
+      rw,relatime,mpol=prefer:{{ numa_node[0] }},\
+      {{ ('size=' + ((numa_node[1] | int * sap_hana_install_fro_mem_percent | int // 100) // 1048576) | string + 'G,') if sap_hana_install_fro_mem_percent > 0 else '' }}\
+      uid={{ __sap_hana_install_user_group_ids.stdout_lines[0] }},\
+      gid={{ __sap_hana_install_user_group_ids.stdout_lines[1] }}"
+    state: unmounted
+  loop: "{{ __sap_hana_install_fact_numa_nodes }}"
+  loop_control:
+    loop_var: numa_node
+    label: "Processing NUMA node {{ numa_node[0] }}"
+  when: sap_hana_install_fro_state == 'disabled'
+
+- name: SAP HANA - Post-Tasks - FRO - Mount/Unmount TMPFS for all NUMA nodes
+  become: true
+  ansible.posix.mount:
+    src: "tmpfs{{ sap_hana_install_sid | lower }}{{ numa_node[0] }}"
+    path: "/hana/tmpfs{{ numa_node[0] }}/{{ sap_hana_install_sid | upper }}"
+    fstype: tmpfs
+    opts: "\
+      rw,relatime,mpol=prefer:{{ numa_node[0] }},\
+      {{ ('size=' + ((numa_node[1] | int * sap_hana_install_fro_mem_percent | int // 100) // 1048576) | string + 'G,') if sap_hana_install_fro_mem_percent > 0 else '' }}\
+      uid={{ __sap_hana_install_user_group_ids.stdout_lines[0] }},\
+      gid={{ __sap_hana_install_user_group_ids.stdout_lines[1] }}"
+    state: "{{ 'mounted' if sap_hana_install_fro_state == 'enabled' else 'absent' }}"
+  loop: "{{ __sap_hana_install_fact_numa_nodes }}"
+  loop_control:
+    loop_var: numa_node
+    label: "Processing NUMA node {{ numa_node[0] }}"
+  when: sap_hana_install_fro_state in ['enabled', 'disabled']
+
+- name: SAP HANA - Post-Tasks - FRO - Enable FRO by setting basepath parameters in HANA and reconfiguring the system
+  ansible.builtin.shell: |
+    source ~/.profile && HDBSettings.sh \
+    setParameter.py  -set="SYSTEM/global.ini/persistence/basepath_persistent_memory_volumes={{ __sap_hana_install_fact_fro_base_path }}"
+  args:
+    executable: /bin/bash
+  register: __sap_hana_install_hana_setparam_enable
+  become: true
+  become_user: "{{ sap_system_sid | lower }}adm"
+  changed_when: __sap_hana_install_hana_setparam_enable.rc == 0
+  failed_when: __sap_hana_install_hana_setparam_enable.rc != 0
+  when: sap_hana_install_fro_state == 'enabled'
+
+- name: SAP HANA - Post-Tasks - FRO - Remove TMPFS mount points for each NUMA node
+  ansible.builtin.file:
+    path: "/hana/tmpfs{{ numa_node[0] }}/{{ sap_hana_install_sid | upper }}"
+    state: absent
+    owner: "{{ sap_hana_install_sid | lower }}adm"
+    group: sapsys
+    mode: '1775'
+  loop: "{{ __sap_hana_install_fact_numa_nodes }}"
+  loop_control:
+    loop_var: numa_node
+    label: "Processing NUMA node {{ numa_node[0] }}"
+  when: sap_hana_install_fro_state == 'disabled'
+
+- name: SAP HANA - Post-Tasks - FRO - Check TMPFS directory content
+  ansible.builtin.find:
+    paths: "/hana/tmpfs{{ numa_node[0] }}"
+    file_type: any
+    recurse: false
+  register: __sap_hana_install_fro_tmpfs_dir_content
+  loop: "{{ __sap_hana_install_fact_numa_nodes }}"
+  loop_control:
+    loop_var: numa_node
+    label: "Processing NUMA node {{ numa_node[0] }}"
+  changed_when: false
+  failed_when: false
+  when: sap_hana_install_fro_state == 'disabled'
+
+- name: SAP HANA - Post-Tasks - FRO - Remove TMPFS parent directory only if not used by another system and empty
+  ansible.builtin.file:
+    path: "/hana/tmpfs{{ dir_check.numa_node[0] }}"
+    state: absent
+  loop: "{{ __sap_hana_install_fro_tmpfs_dir_content.results | default([]) }}"
+  loop_control:
+    loop_var: dir_check
+    label: "Processing NUMA node {{ dir_check.numa_node[0] }}"
+  when:
+    - sap_hana_install_fro_state == 'disabled'
+    - not dir_check.skipped | default(false)
+    - not dir_check.failed | default(false)
+    - dir_check.matched | default(0) == 0


### PR DESCRIPTION
This PR adds functionality to sap_hana_install which will enable/disable HANA Fast Restart Option.
The default behaviour of this role not to do anything in relation to FRO so this change doesn't break anything.
This functionality allows to enable FRO as an after-installation step (as this is the correct time to do it).
This functionality also allows to change/disable FRO as is basically the same code. It is slightly illogical that hana_install role can do this, but currently there is no other option. 
Moving this to a separate role will create a dependency of this role to the new role which is undesirable. 