### PR TITLE
sap_general_preconfigure, sap_hana_preconfigure: Fixes for Ansible 2.19

### DIFF
--- a/roles/sap_general_preconfigure/meta/argument_specs.yml
+++ b/roles/sap_general_preconfigure/meta/argument_specs.yml
@@ -157,7 +157,8 @@ argument_specs:
         example:
           '@minimal-environment'
         required: false
-        type: str
+        type: list
+        elements: str
 
       sap_general_preconfigure_envgroups:
         default: "{{ __sap_general_preconfigure_envgroups }}"
@@ -167,7 +168,8 @@ argument_specs:
         example:
           '@minimal-environment'
         required: false
-        type: str
+        type: list
+        elements: str
 
       sap_general_preconfigure_patterns:
         default: "{{ __sap_general_preconfigure_patterns }}"

--- a/roles/sap_general_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_7.yml
@@ -145,9 +145,9 @@ __sap_general_preconfigure_required_ppc64le:
   - ppc64-diag
   - IBMinvscout
 
-__sap_general_preconfigure_min_packages_7_2:
+__sap_general_preconfigure_min_packages_7_2: []
 
-__sap_general_preconfigure_min_packages_7_3:
+__sap_general_preconfigure_min_packages_7_3: []
 
 # SAP note 2812427:
 __sap_general_preconfigure_min_packages_7_4:
@@ -161,11 +161,11 @@ __sap_general_preconfigure_min_packages_7_5:
 __sap_general_preconfigure_min_packages_7_6:
   - [ 'kernel', '3.10.0-957.35.1.el7' ]
 
-__sap_general_preconfigure_min_packages_7_7:
+__sap_general_preconfigure_min_packages_7_7: []
 
-__sap_general_preconfigure_min_packages_7_8:
+__sap_general_preconfigure_min_packages_7_8: []
 
-__sap_general_preconfigure_min_packages_7_9:
+__sap_general_preconfigure_min_packages_7_9: []
 
 __sap_general_preconfigure_min_pkgs: "{{ lookup('vars', '__sap_general_preconfigure_min_packages_' + ansible_facts['distribution_version'] | replace(\".\", \"_\")) }}"
 

--- a/roles/sap_general_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_general_preconfigure/vars/RedHat_7.yml
@@ -59,8 +59,6 @@ __sap_general_preconfigure_req_hana_repos:
 __sap_general_preconfigure_req_ha_repos:
   - rhel-ha-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ __sap_general_preconfigure_rhel_7_ha_arch_string }}-{{ __sap_general_preconfigure_max_repo_type_ha_string }}rpms
 
-__sap_general_preconfigure_envgroups: ""
-
 __sap_general_preconfigure_packagegroups_x86_64:
   - "@base"
   - "@compat-libraries"

--- a/roles/sap_general_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_15.yml
@@ -34,8 +34,8 @@ __sap_general_preconfigure_packages_2578899:
   - sysctl-logger
 
 __sap_general_preconfigure_min_pkgs: []
-__sap_general_preconfigure_packagegroups:
-__sap_general_preconfigure_envgroups:
+__sap_general_preconfigure_packagegroups: []
+__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_general_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_15.yml
@@ -34,8 +34,6 @@ __sap_general_preconfigure_packages_2578899:
   - sysctl-logger
 
 __sap_general_preconfigure_min_pkgs: []
-__sap_general_preconfigure_packagegroups: []
-__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
@@ -35,8 +35,6 @@ __sap_general_preconfigure_packages_2578899:
   - sysctl-logger
 
 __sap_general_preconfigure_min_pkgs: []
-__sap_general_preconfigure_packagegroups: []
-__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_15.yml
@@ -35,8 +35,8 @@ __sap_general_preconfigure_packages_2578899:
   - sysctl-logger
 
 __sap_general_preconfigure_min_pkgs: []
-__sap_general_preconfigure_packagegroups:
-__sap_general_preconfigure_envgroups:
+__sap_general_preconfigure_packagegroups: []
+__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
@@ -29,8 +29,6 @@ __sap_general_preconfigure_packages:
   - lsof
 
 __sap_general_preconfigure_min_pkgs: []
-__sap_general_preconfigure_packagegroups: []
-__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_general_preconfigure/vars/SLES_SAP_16.yml
@@ -29,8 +29,8 @@ __sap_general_preconfigure_packages:
   - lsof
 
 __sap_general_preconfigure_min_pkgs: []
-__sap_general_preconfigure_packagegroups:
-__sap_general_preconfigure_envgroups:
+__sap_general_preconfigure_packagegroups: []
+__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_kernel_parameters_default: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.

--- a/roles/sap_general_preconfigure/vars/main.yml
+++ b/roles/sap_general_preconfigure/vars/main.yml
@@ -2,8 +2,8 @@
 ---
 
 # dummy entries for passing the arg spec validation:
-__sap_general_preconfigure_packagegroups: ''
-__sap_general_preconfigure_envgroups: ''
+__sap_general_preconfigure_packagegroups: []
+__sap_general_preconfigure_envgroups: []
 __sap_general_preconfigure_patterns: []
 __sap_general_preconfigure_packages: []
 __sap_general_preconfigure_min_pkgs: []

--- a/roles/sap_hana_preconfigure/vars/RedHat_10.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_10.yml
@@ -132,8 +132,6 @@ __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_precon
 
 # In SAP Note XXX, certain minimal required packages for the different RHEL 10 minor releases are listed.
 # The following will assign them properly to __sap_hana_preconfigure_min_pkgs.
-# If variable __sap_hana_preconfigure_min_packages_VERSION_ARCH is not defined,
-# variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
 
 # Minimum required package levels for RHEL 10.0:
 __sap_hana_preconfigure_min_packages_10_0_x86_64:

--- a/roles/sap_hana_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_7.yml
@@ -58,8 +58,6 @@ __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_precon
 
 # In SAP Note 2235581, certain minimal required packages for the different RHEL 7 minor releases are listed.
 # The following will assign them properly to __sap_hana_preconfigure_min_pkgs.
-# If variable __sap_hana_preconfigure_min_packages_VERSION is not defined,
-# variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
 
 __sap_hana_preconfigure_min_packages_7_2_x86_64:
   - [ 'kernel', '3.10.0-327.62.4.el7' ]

--- a/roles/sap_hana_preconfigure/vars/RedHat_7.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_7.yml
@@ -88,9 +88,9 @@ __sap_hana_preconfigure_min_packages_7_4_ppc64le:
   - [ 'kernel', '3.10.0-693.11.6.el7' ]
   - [ 'tuned-profiles-sap-hana', '2.8.0-5.el7_4.2' ]
 
-__sap_hana_preconfigure_min_packages_7_5_x86_64:
+__sap_hana_preconfigure_min_packages_7_5_x86_64: []
 
-__sap_hana_preconfigure_min_packages_7_5_ppc64le:
+__sap_hana_preconfigure_min_packages_7_5_ppc64le: []
 
 # Attention: SAP note 2812427 requires more recent package kernel-3.10.0-957.35.1, covered by role sap_general_preconfigure
 __sap_hana_preconfigure_min_packages_7_6_x86_64:
@@ -106,9 +106,9 @@ __sap_hana_preconfigure_min_packages_7_7_x86_64:
 __sap_hana_preconfigure_min_packages_7_7_ppc64le:
   - [ 'kernel', '3.10.0-1062.26.1.el7' ]
 
-__sap_hana_preconfigure_min_packages_7_8_x86_64:
+__sap_hana_preconfigure_min_packages_7_8_x86_64: []
 
-__sap_hana_preconfigure_min_packages_7_8_ppc64le:
+__sap_hana_preconfigure_min_packages_7_8_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_7_9_x86_64:
   - [ 'kernel', '3.10.0-1160.11.1.el7' ]

--- a/roles/sap_hana_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_8.yml
@@ -138,8 +138,6 @@ __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_precon
 
 # In SAP Note 2777782, certain minimal required packages for the different RHEL 8 minor releases are listed.
 # The following will assign them properly to __sap_hana_preconfigure_min_pkgs.
-# If variable __sap_hana_preconfigure_min_packages_VERSION_ARCH is not defined,
-# variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
 
 # Minimum required package levels for RHEL 8.0:
 # Attention: SAP note 2812427 requires more recent package kernel-4.18.0-80.15.1.el8_0 also for x86_64, covered by role sap_general_preconfigure

--- a/roles/sap_hana_preconfigure/vars/RedHat_8.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_8.yml
@@ -143,7 +143,7 @@ __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_precon
 
 # Minimum required package levels for RHEL 8.0:
 # Attention: SAP note 2812427 requires more recent package kernel-4.18.0-80.15.1.el8_0 also for x86_64, covered by role sap_general_preconfigure
-__sap_hana_preconfigure_min_packages_8_0_x86_64:
+__sap_hana_preconfigure_min_packages_8_0_x86_64: []
 
 __sap_hana_preconfigure_min_packages_8_0_ppc64le:
   - [ 'kernel', '4.18.0-80.15.1.el8_0' ]
@@ -160,9 +160,9 @@ __sap_hana_preconfigure_min_packages_8_2_x86_64:
 __sap_hana_preconfigure_min_packages_8_2_ppc64le:
   - [ 'kernel', '4.18.0-193.40.1.el8_2' ]
 
-__sap_hana_preconfigure_min_packages_8_3_x86_64:
+__sap_hana_preconfigure_min_packages_8_3_x86_64: []
 
-__sap_hana_preconfigure_min_packages_8_3_ppc64le:
+__sap_hana_preconfigure_min_packages_8_3_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_8_4_x86_64:
   - [ 'kernel', '4.18.0-305.3.1.el8_4' ]
@@ -170,18 +170,18 @@ __sap_hana_preconfigure_min_packages_8_4_x86_64:
 __sap_hana_preconfigure_min_packages_8_4_ppc64le:
   - [ 'kernel', '4.18.0-305.17.1.el8_4' ]
 
-__sap_hana_preconfigure_min_packages_8_5_x86_64:
+__sap_hana_preconfigure_min_packages_8_5_x86_64: []
 
-__sap_hana_preconfigure_min_packages_8_5_ppc64le:
+__sap_hana_preconfigure_min_packages_8_5_ppc64le: []
 
-__sap_hana_preconfigure_min_packages_8_6_x86_64:
+__sap_hana_preconfigure_min_packages_8_6_x86_64: []
 
 __sap_hana_preconfigure_min_packages_8_6_ppc64le:
   - [ 'kernel', '4.18.0-372.32.1.el8_6' ]
 
-__sap_hana_preconfigure_min_packages_8_7_x86_64:
+__sap_hana_preconfigure_min_packages_8_7_x86_64: []
 
-__sap_hana_preconfigure_min_packages_8_7_ppc64le:
+__sap_hana_preconfigure_min_packages_8_7_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_8_8_x86_64:
   - [ 'kernel', '4.18.0-477.13.1.el8_8' ]
@@ -189,9 +189,9 @@ __sap_hana_preconfigure_min_packages_8_8_x86_64:
 __sap_hana_preconfigure_min_packages_8_8_ppc64le:
   - [ 'kernel', '4.18.0-477.13.1.el8_8' ]
 
-__sap_hana_preconfigure_min_packages_8_9_x86_64:
+__sap_hana_preconfigure_min_packages_8_9_x86_64: []
 
-__sap_hana_preconfigure_min_packages_8_9_ppc64le:
+__sap_hana_preconfigure_min_packages_8_9_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_8_10_x86_64:
   - [ 'kernel', '4.18.0-553.16.1.el8_10' ]

--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -135,8 +135,6 @@ __sap_hana_preconfigure_sapnotes_versions: "{{ lookup('vars', '__sap_hana_precon
 
 # In SAP Note XXX, certain minimal required packages for the different RHEL 9 minor releases are listed.
 # The following will assign them properly to __sap_hana_preconfigure_min_pkgs.
-# If variable __sap_hana_preconfigure_min_packages_VERSION_ARCH is not defined,
-# variable __sap_hana_preconfigure_min_pkgs will be undefined as well.
 
 # Minimum required package levels for RHEL 9.0:
 __sap_hana_preconfigure_min_packages_9_0_x86_64:

--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -146,9 +146,9 @@ __sap_hana_preconfigure_min_packages_9_0_ppc64le:
   - [ 'kernel', '5.14.0-70.43.1.el9_0' ]
   - [ 'glibc', '2.34-28.el9_0.3' ]
 
-__sap_hana_preconfigure_min_packages_9_1_x86_64:
+__sap_hana_preconfigure_min_packages_9_1_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_1_ppc64le:
+__sap_hana_preconfigure_min_packages_9_1_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_9_2_x86_64:
   - [ 'kernel', '5.14.0-284.25.1.el9_2' ]
@@ -156,9 +156,9 @@ __sap_hana_preconfigure_min_packages_9_2_x86_64:
 __sap_hana_preconfigure_min_packages_9_2_ppc64le:
   - [ 'kernel', '5.14.0-284.25.1.el9_2' ]
 
-__sap_hana_preconfigure_min_packages_9_3_x86_64:
+__sap_hana_preconfigure_min_packages_9_3_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_3_ppc64le:
+__sap_hana_preconfigure_min_packages_9_3_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_9_4_x86_64:
   - [ 'kernel', '5.14.0-427.100.1.el9_4' ]
@@ -166,9 +166,9 @@ __sap_hana_preconfigure_min_packages_9_4_x86_64:
 __sap_hana_preconfigure_min_packages_9_4_ppc64le:
   - [ 'kernel', '5.14.0-427.100.1.el9_4' ]
 
-__sap_hana_preconfigure_min_packages_9_5_x86_64:
+__sap_hana_preconfigure_min_packages_9_5_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_5_ppc64le:
+__sap_hana_preconfigure_min_packages_9_5_ppc64le: []
 
 __sap_hana_preconfigure_min_packages_9_6_x86_64:
   - [ 'kernel', '5.14.0-570.17.1.el9_6' ]
@@ -177,21 +177,21 @@ __sap_hana_preconfigure_min_packages_9_6_ppc64le:
   - [ 'kernel', '5.14.0-570.17.1.el9_6' ]
   - [ 'glibc', '2.34-168.el9_6.20' ]
 
-__sap_hana_preconfigure_min_packages_9_7_x86_64:
+__sap_hana_preconfigure_min_packages_9_7_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_7_ppc64le:
+__sap_hana_preconfigure_min_packages_9_7_ppc64le: []
 
-__sap_hana_preconfigure_min_packages_9_8_x86_64:
+__sap_hana_preconfigure_min_packages_9_8_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_8_ppc64le:
+__sap_hana_preconfigure_min_packages_9_8_ppc64le: []
 
-__sap_hana_preconfigure_min_packages_9_9_x86_64:
+__sap_hana_preconfigure_min_packages_9_9_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_9_ppc64le:
+__sap_hana_preconfigure_min_packages_9_9_ppc64le: []
 
-__sap_hana_preconfigure_min_packages_9_10_x86_64:
+__sap_hana_preconfigure_min_packages_9_10_x86_64: []
 
-__sap_hana_preconfigure_min_packages_9_10_ppc64le:
+__sap_hana_preconfigure_min_packages_9_10_ppc64le: []
 
 __sap_hana_preconfigure_min_pkgs: "{{ lookup('vars', '__sap_hana_preconfigure_min_packages_' + ansible_facts['distribution_version'] | string | replace(\".\", \"_\") + '_' + ansible_facts['architecture']) }}"
 

--- a/roles/sap_hana_preconfigure/vars/SLES_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_15.yml
@@ -94,7 +94,7 @@ __sap_hana_preconfigure_packages_2684254:
   - insserv-compat
   - libltdl7
 
-__sap_hana_preconfigure_min_pkgs:
+__sap_hana_preconfigure_min_pkgs: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.
 __sap_hana_preconfigure_use_saptune: false

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_15.yml
@@ -61,7 +61,7 @@ __sap_hana_preconfigure_packages_2684254:
   - libltdl7
 
 
-__sap_hana_preconfigure_min_pkgs:
+__sap_hana_preconfigure_min_pkgs: []
 
 # SLES_SAP is using saptune, but SLES is using sapconf.
 __sap_hana_preconfigure_use_saptune: true

--- a/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
+++ b/roles/sap_hana_preconfigure/vars/SLES_SAP_16.yml
@@ -7,7 +7,7 @@ __sap_hana_preconfigure_sapnotes_versions: []
   # 3577842 - - SAP HANA DB: Recommended OS settings for SLES 16 / SLES for SAP Applications 16
   # - { number: '3577842', version: '1' }
 
-__sap_hana_preconfigure_min_pkgs:
+__sap_hana_preconfigure_min_pkgs: []
 
 __sap_hana_preconfigure_patterns:
   - sles_sap_minimal_sap


### PR DESCRIPTION
These avoid error messages which occur on Ansible 2.19 and later on RHEL 7, 8 and 9 if the length of null defined vars is requested, for example:

`[ERROR]: Task failed: The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()`

Related task is: https://github.com/sap-linuxlab/community.sap_install/blob/931e140bd23bb1ae55ddb960f4b1c8dacb8dd7a2/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml#L143 , and this task is inside a block starting here: https://github.com/sap-linuxlab/community.sap_install/blob/931e140bd23bb1ae55ddb960f4b1c8dacb8dd7a2/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml#L135 .

The other changes in this PR are related:
- ensuring correct variable type definitions for two vars in `sap_general_preconfigure/meta/argument_specs.yml`
- removing superfluous comments in the RHEL vars files of `sap_hana_preconfigure` after the all affected vars have been correctly defined

I have not tested on SLES (I also changed the SLES related vars file of `sap_hana_preconfigure`) and maybe no code is evaluating those vars for SLES, but I modified them just so that all these vars are defined the same way as they are now in RHEL.